### PR TITLE
fix(ci): make license inventory host-independent and drop gitleaks-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,16 +104,36 @@ jobs:
   # Full-history secret scan. Must stay at zero findings: the allowlists in .gitleaks.toml are
   # scoped to specific placeholder strings, so anything reported here is genuinely new.
   # fetch-depth: 0 because a shallow clone would scan only the tip commit.
+  #
+  # Runs the gitleaks binary directly rather than gitleaks/gitleaks-action. The action requires a
+  # GITLEAKS_LICENSE for organization-owned repos (free, but a manual request) and fails hard
+  # without one; the scanner itself is MIT-licensed and needs no key. Invoking it directly also
+  # keeps this job off the deprecated Node 20 action runtime.
+  #
+  # The release is pinned and checksum-verified, matching how scripts/provider-clis/install.mjs
+  # fetches third-party binaries — an unpinned download would let a moved tag change what runs.
+  # Bump VERSION and SHA256 together; the checksum comes from the release's tarball.
   secret-scan:
     runs-on: ubuntu-latest
+    env:
+      GITLEAKS_VERSION: 8.30.1
+      GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
-          GITLEAKS_ENABLE_SUMMARY: "true"
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL -o "$archive" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
+          echo "${GITLEAKS_SHA256}  ${archive}" | sha256sum --check --strict -
+          tar -xzf "$archive" gitleaks
+      # --redact so a genuine finding does not print the secret into public CI logs.
+      # Exit code is the gate: 0 clean, 1 leaks found, 2 an error such as a malformed config.
+      - name: Scan full history
+        run: ./gitleaks detect --source . --config .gitleaks.toml --redact --no-banner
 
   # Compliance gate: docs/dependency-license-inventory.md must still match the installed tree,
   # and no GPL/AGPL/LGPL/SSPL or unknown-licensed dependency may enter it. Kept out of `lint`

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,7 +18,8 @@
 # (`useDefault = true` loads them; redefining an id overrides that entry wholesale, so the
 # pattern must be restated to attach a rule-scoped allowlist).
 #
-# Verify with:  gitleaks detect --source . --redact --no-banner
+# Verify with:  gitleaks detect --source . --config .gitleaks.toml --redact --no-banner
+# (the same command CI runs; see the secret-scan job in .github/workflows/ci.yml)
 # Regression-tested by: scripts/gates/__tests__/gitleaks-config.test.mjs
 
 [extend]

--- a/docs/dependency-license-inventory.md
+++ b/docs/dependency-license-inventory.md
@@ -1,29 +1,34 @@
 # Dependency License Inventory
 
-Generated: 2026-08-07 · `node scripts/gates/check-license-inventory.mjs --write` · 834 packages
+Generated: 2026-08-07 · `node scripts/gates/check-license-inventory.mjs --write` · 825 packages
 
 Regenerate with `pnpm licenses:write`; `pnpm licenses:check` verifies this file still matches
 the installed dependency tree and is enforced in CI.
+
+Platform-specific native binaries (`@esbuild/linux-x64`, `lightningcss-darwin-arm64`,
+`fsevents`, …) are omitted: pnpm installs only the ones matching the host, so listing them
+would make this file differ between a macOS laptop and a Linux CI runner. They are still
+checked for forbidden licenses, and each carries the same license as its parent package.
 
 ## Summary
 
 | License | Packages |
 |---|---|
-| MIT | 710 |
+| MIT | 703 |
 | ISC | 41 |
 | Apache-2.0 | 38 |
 | BSD-3-Clause | 23 |
 | BSD-2-Clause | 7 |
 | BlueOak-1.0.0 | 3 |
-| MIT OR Apache-2.0 | 2 |
-| MPL-2.0 | 2 |
 | (BSD-2-Clause OR MIT OR Apache-2.0) | 1 |
 | (MIT OR CC0-1.0) | 1 |
 | (MIT OR WTFPL) | 1 |
 | 0BSD | 1 |
 | CC-BY-4.0 | 1 |
 | MIT AND ISC | 1 |
+| MIT OR Apache-2.0 | 1 |
 | MIT-0 | 1 |
+| MPL-2.0 | 1 |
 | OFL-1.1 | 1 |
 
 Result: **no GPL/AGPL/LGPL/SSPL dependencies and no unknown licenses.** The inventory includes notice, attribution, font, and file-level copyleft licenses such as MPL-2.0; release artifacts must retain all applicable notices.
@@ -79,7 +84,6 @@ Result: **no GPL/AGPL/LGPL/SSPL dependencies and no unknown licenses.** The inve
 | @babel/types | 7.29.0 | MIT |
 | @bcoe/v8-coverage | 1.0.2 | MIT |
 | @biomejs/biome | 1.9.4 | MIT OR Apache-2.0 |
-| @biomejs/cli-darwin-arm64 | 1.9.4 | MIT OR Apache-2.0 |
 | @codemirror/autocomplete | 6.20.0 | MIT |
 | @codemirror/commands | 6.10.2 | MIT |
 | @codemirror/language | 6.12.2 | MIT |
@@ -101,7 +105,6 @@ Result: **no GPL/AGPL/LGPL/SSPL dependencies and no unknown licenses.** The inve
 | @emotion/unitless | 0.7.5 | MIT |
 | @esbuild-kit/core-utils | 3.3.2 | MIT |
 | @esbuild-kit/esm-loader | 2.6.5 | MIT |
-| @esbuild/darwin-arm64 | 0.25.12, 0.27.3 | MIT |
 | @fastify/deepmerge | 3.2.1 | MIT |
 | @floating-ui/core | 1.7.5 | MIT |
 | @floating-ui/dom | 1.7.6 | MIT |
@@ -142,11 +145,8 @@ Result: **no GPL/AGPL/LGPL/SSPL dependencies and no unknown licenses.** The inve
 | @marijn/find-cluster-break | 1.0.2 | MIT |
 | @modelcontextprotocol/sdk | 1.27.1 | MIT |
 | @node-rs/argon2 | 2.0.2 | MIT |
-| @node-rs/argon2-darwin-arm64 | 2.0.2 | MIT |
 | @node-saml/node-saml | 5.1.0 | MIT |
-| @oxc-parser/binding-darwin-arm64 | 0.142.0 | MIT |
 | @oxc-project/types | 0.142.0 | MIT |
-| @oxc-resolver/binding-darwin-arm64 | 11.24.2 | MIT |
 | @petamoriken/float16 | 3.9.3 | MIT |
 | @pinojs/redact | 0.4.0 | MIT |
 | @playwright/test | 1.58.2 | Apache-2.0 |
@@ -204,7 +204,6 @@ Result: **no GPL/AGPL/LGPL/SSPL dependencies and no unknown licenses.** The inve
 | @rc-component/virtual-list | 1.0.2 | MIT |
 | @reduxjs/toolkit | 2.12.0 | MIT |
 | @rolldown/pluginutils | 1.0.0-beta.27 | MIT |
-| @rollup/rollup-darwin-arm64 | 4.61.0 | MIT |
 | @sapphire/async-queue | 1.5.5 | MIT |
 | @sapphire/shapeshift | 4.0.0 | MIT |
 | @sapphire/snowflake | 3.5.5 | MIT |
@@ -223,7 +222,6 @@ Result: **no GPL/AGPL/LGPL/SSPL dependencies and no unknown licenses.** The inve
 | @stryker-mutator/vitest-runner | 9.6.1 | Apache-2.0 |
 | @tailwindcss/node | 4.1.18 | MIT |
 | @tailwindcss/oxide | 4.1.18 | MIT |
-| @tailwindcss/oxide-darwin-arm64 | 4.1.18 | MIT |
 | @tailwindcss/vite | 4.1.18 | MIT |
 | @tanstack/query-core | 5.90.20 | MIT |
 | @tanstack/react-query | 5.90.20 | MIT |
@@ -446,7 +444,6 @@ Result: **no GPL/AGPL/LGPL/SSPL dependencies and no unknown licenses.** The inve
 | forwarded | 0.2.0 | MIT |
 | fresh | 2.0.0 | MIT |
 | fs-constants | 1.0.0 | MIT |
-| fsevents | 2.3.2, 2.3.3 | MIT |
 | function-bind | 1.1.2 | MIT |
 | gel | 2.2.0 | Apache-2.0 |
 | gensync | 1.0.0-beta.2 | MIT |
@@ -525,7 +522,6 @@ Result: **no GPL/AGPL/LGPL/SSPL dependencies and no unknown licenses.** The inve
 | knip | 6.32.0 | ISC |
 | launder | 1.7.1 | MIT |
 | lightningcss | 1.30.2 | MPL-2.0 |
-| lightningcss-darwin-arm64 | 1.30.2 | MPL-2.0 |
 | lilconfig | 3.1.3 | MIT |
 | lines-and-columns | 1.2.4 | MIT |
 | lint-staged | 15.5.2 | MIT |

--- a/scripts/gates/__tests__/check-license-inventory.test.mjs
+++ b/scripts/gates/__tests__/check-license-inventory.test.mjs
@@ -95,6 +95,60 @@ test('renderInventory records the total and every package row', () => {
   assert.ok(rendered.endsWith('\n'), 'file must end with a trailing newline')
 })
 
+// The inventory is committed once but regenerated on whatever machine runs the gate. Native
+// toolchains (esbuild, rollup, biome, lightningcss, @node-rs/argon2, oxc, tailwind oxide) ship
+// one prebuilt binary package per platform, and pnpm installs only the ones matching the host.
+// A macOS developer therefore resolves 8 darwin-arm64 packages where a linux-x64 CI runner
+// resolves 14 linux/musl ones — drift that no regeneration can reconcile, because fixing one
+// host breaks the other. These packages carry the same license as their parent and add nothing
+// to a compliance claim, so the inventory excludes them and becomes host-independent.
+test('summarise drops platform-specific native binary packages', () => {
+  const { packages, total } = summarise({
+    MIT: [
+      { name: 'zod', versions: ['3.25.76'] },
+      { name: '@esbuild/darwin-arm64', versions: ['0.25.12'] },
+      { name: '@esbuild/linux-x64', versions: ['0.25.12'] },
+      { name: '@rollup/rollup-win32-x64-msvc', versions: ['4.61.0'] },
+      { name: 'lightningcss-linux-x64-musl', versions: ['1.30.2'] },
+      { name: '@node-rs/argon2-android-arm64', versions: ['2.0.2'] },
+      { name: 'fsevents', versions: ['2.3.3'] },
+    ],
+  })
+
+  assert.deepEqual(
+    packages.map((p) => p.name),
+    ['zod'],
+  )
+  assert.equal(total, 1)
+})
+
+// The exclusion keys off a platform suffix, not a substring: a package whose name merely
+// contains a platform word is a normal dependency and must stay in the inventory.
+test('summarise keeps packages that only mention a platform in passing', () => {
+  const { packages } = summarise({
+    MIT: [
+      { name: 'darwin-notify', versions: ['1.0.0'] },
+      { name: 'is-wsl', versions: ['2.2.0'] },
+      { name: 'linuxify', versions: ['1.0.0'] },
+    ],
+  })
+
+  assert.deepEqual(
+    packages.map((p) => p.name),
+    ['darwin-notify', 'is-wsl', 'linuxify'],
+  )
+})
+
+// A forbidden license must still fail even on a platform package: dropping it from the rendered
+// inventory is a noise decision, not a licensing exemption.
+test('findForbidden still inspects platform-specific packages', () => {
+  const violations = findForbidden(
+    summarise({ 'GPL-3.0': [{ name: '@esbuild/linux-x64', versions: ['0.25.12'] }] }),
+  )
+  assert.equal(violations.length, 1)
+  assert.equal(violations[0].name, '@esbuild/linux-x64')
+})
+
 test('existingGeneratedOn recovers the committed stamp, or null when absent', () => {
   assert.equal(existingGeneratedOn(renderInventory(summarise(REPORT), '2026-01-02')), '2026-01-02')
   assert.equal(existingGeneratedOn('# No stamp here\n'), null)

--- a/scripts/gates/check-license-inventory.mjs
+++ b/scripts/gates/check-license-inventory.mjs
@@ -32,6 +32,74 @@ const FORBIDDEN_PATTERNS = [/\bA?GPL\b/i, /\bLGPL\b/i, /\bSSPL\b/i]
 
 const UNKNOWN_LICENSES = new Set(['', 'Unknown', 'UNKNOWN', 'unknown', 'UNLICENSED'])
 
+/**
+ * Operating systems that native toolchains publish per-platform binary packages for. Sourced
+ * from the `os:` fields pnpm records in the lockfile, so it covers the long tail (openharmony,
+ * loong64 hosts) rather than just the three platforms developers run.
+ */
+const PLATFORMS = [
+  'aix',
+  'android',
+  'darwin',
+  'freebsd',
+  'linux',
+  'netbsd',
+  'openbsd',
+  'openharmony',
+  'sunos',
+  'win32',
+]
+
+/**
+ * CPU architectures and libc/ABI tails that follow the platform token in these package names.
+ * Matching against a closed list rather than "any trailing word" is what separates
+ * `@esbuild/darwin-arm64` from `darwin-notify`: only the former's tail is an architecture.
+ */
+const ARCH_TAILS = [
+  'arm',
+  'arm64',
+  'ia32',
+  'x64',
+  'x86',
+  'loong64',
+  'mips64el',
+  'ppc64',
+  'riscv64',
+  's390x',
+  'gnu',
+  'musl',
+  'gnueabihf',
+  'musleabihf',
+  'msvc',
+]
+
+/**
+ * Matches a package whose name ends in `<platform>` followed by one or more architecture/libc
+ * segments: `@esbuild/darwin-arm64`, `lightningcss-linux-x64-musl`, `@rollup/rollup-win32-x64-msvc`,
+ * `@node-rs/argon2-linux-arm-gnueabihf`. The platform must sit on a `-` or `/` boundary and every
+ * trailing segment must be a known arch/libc token, so ordinary packages that merely contain a
+ * platform word — `linuxify`, `darwin-notify`, `is-wsl` — are not swept up.
+ */
+const PLATFORM_PACKAGE = new RegExp(
+  `(?:^|[-/])(?:${PLATFORMS.join('|')})(?:-(?:${ARCH_TAILS.join('|')}))+$`,
+)
+
+/**
+ * `fsevents` is a macOS-only dependency with no name-encoded platform, so the suffix rule cannot
+ * see it. It is the only such package in the tree; a new one shows up as inventory drift on the
+ * first CI run after it lands, which is exactly when it should be reviewed.
+ */
+const PLATFORM_ONLY_PACKAGES = new Set(['fsevents'])
+
+/**
+ * True when a package ships only on some platforms, so pnpm resolves a different set of them on
+ * a macOS laptop than on a linux CI runner. Excluded from the rendered inventory to keep the
+ * committed file host-independent — never from the forbidden-license check.
+ */
+export function isPlatformSpecific(name) {
+  return PLATFORM_ONLY_PACKAGES.has(name) || PLATFORM_PACKAGE.test(name)
+}
+
 /** Run `pnpm licenses list --json` and parse it. Throws with a tagged cause on a cold store. */
 export function readLicenseReport(runner = defaultRunner) {
   let raw
@@ -62,19 +130,30 @@ function defaultRunner() {
  * counts. pnpm reports one entry per (name, license) pair with all resolved versions attached,
  * so a package appearing under two licenses is deliberately counted once per license — that is
  * the compliance-relevant unit.
+ *
+ * Platform-specific native binaries are dropped (see `isPlatformSpecific`): pnpm resolves a
+ * different subset of them per host, which would make the committed file unreproducible off the
+ * machine that generated it. `platformPackages` keeps them for `findForbidden`, so the exclusion
+ * is cosmetic and never a licensing blind spot.
  */
 export function summarise(report) {
   const packages = []
+  const platformPackages = []
   const counts = new Map()
 
   for (const [license, entries] of Object.entries(report)) {
-    counts.set(license, (counts.get(license) ?? 0) + entries.length)
     for (const entry of entries) {
-      packages.push({
+      const pkg = {
         name: entry.name,
         versions: [...new Set(entry.versions ?? [])].join(', '),
         license,
-      })
+      }
+      if (isPlatformSpecific(entry.name)) {
+        platformPackages.push(pkg)
+        continue
+      }
+      counts.set(license, (counts.get(license) ?? 0) + 1)
+      packages.push(pkg)
     }
   }
 
@@ -82,13 +161,18 @@ export function summarise(report) {
   const summary = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
   const total = packages.length
 
-  return { packages, summary, total }
+  return { packages, platformPackages, summary, total }
 }
 
-/** Licenses that must never appear. Returns the offending `license → packages` pairs. */
-export function findForbidden({ packages }) {
+/**
+ * Licenses that must never appear. Returns the offending `license → packages` pairs.
+ *
+ * Scans the platform-specific packages too, even though they are absent from the rendered
+ * inventory — they are still shipped code, and only their *listing* is host-dependent noise.
+ */
+export function findForbidden({ packages, platformPackages = [] }) {
   const violations = []
-  for (const pkg of packages) {
+  for (const pkg of [...packages, ...platformPackages]) {
     if (UNKNOWN_LICENSES.has(pkg.license)) {
       violations.push({ ...pkg, reason: 'unknown license' })
       continue
@@ -113,6 +197,11 @@ export function renderInventory({ packages, summary, total }, generatedOn) {
     '',
     'Regenerate with `pnpm licenses:write`; `pnpm licenses:check` verifies this file still matches',
     'the installed dependency tree and is enforced in CI.',
+    '',
+    'Platform-specific native binaries (`@esbuild/linux-x64`, `lightningcss-darwin-arm64`,',
+    '`fsevents`, …) are omitted: pnpm installs only the ones matching the host, so listing them',
+    'would make this file differ between a macOS laptop and a Linux CI runner. They are still',
+    'checked for forbidden licenses, and each carries the same license as its parent package.',
     '',
     '## Summary',
     '',


### PR DESCRIPTION
Fixes both red jobs on `main`. Neither was stale data — both failed for reasons no amount of regeneration could fix.

## `license-inventory`

The committed inventory listed the **9 darwin-arm64** native binaries pnpm resolves on a Mac, while the linux-x64 runner resolves **15 linux/musl** ones instead — hence 834 vs 840 packages.

These per-platform binaries are chosen by the host, so the file could only ever match the machine that generated it. Regenerating on macOS kept CI red; regenerating on Linux would have broken every Mac developer.

**Fix:** exclude platform-specific packages from the rendered inventory, keyed on a `<platform>-<arch>` name suffix matched against closed platform and arch/libc lists — so `linuxify` and `darwin-notify` are *not* swept up with `@esbuild/darwin-arm64`. `fsevents` encodes no platform in its name and is listed explicitly. Both hosts now converge on **825 packages**.

The exclusion is presentational only: `findForbidden` still scans the dropped packages, so a copyleft license in a native binary fails the gate exactly as before. Each also carries the same license as its parent, so the compliance claim is unweakened.

Verified the rule against every `os:`-constrained package in `pnpm-lock.yaml` — zero misses.

## `secret-scan`

`gitleaks-action` requires `GITLEAKS_LICENSE` for **organization-owned** repos and hard-fails without it (`🛑 missing gitleaks license`). The key is free but needs a manual request.

**Fix:** run the MIT-licensed `gitleaks` binary directly — no key required, and it sidesteps the Node 20 action deprecation warning too. The release is version-pinned and SHA-256 verified, mirroring how `scripts/provider-clis/install.mjs` fetches third-party binaries.

`.gitleaks.toml` and its guard tests are untouched and still enforced.

## Verification

- `pnpm licenses:check` → 825 packages, matches
- `gitleaks detect` on full history with the same pinned 8.30.1 → **no leaks found**, exit 0
- `pnpm typecheck` → green
- `pnpm lint` → 0 errors, no new warnings on changed files
- gate tests → 25/25 pass (3 new tests covering the exclusion rule, added red-first)

Manual update not needed — no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)