### PR TITLE
docs: streamline README and extract configuration reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="apps/web/public/brand-icons/default.svg" alt="a2wave" width="72" height="72" />
+<img src="https://raw.githubusercontent.com/LilithGames/a2wave/main/apps/web/public/brand-icons/default.svg" alt="a2wave" width="72" height="72" />
 
 # a2wave
 
@@ -23,19 +23,17 @@ Slack, Discord, an HTTP API, or a schedule. No flowcharts, no glue code.
 ## What is a2wave?
 
 a2wave turns the agent CLIs you already use — **Claude Code, Cursor Agent, OpenAI
-Codex, and more** — into shared, governed services your whole team can reach from
-Feishu, Slack, Discord, an HTTP API, or a scheduled trigger.
+Codex, and more** — into shared, governed services, reachable from Feishu, Slack,
+Discord, an HTTP API, or a schedule.
 
-You describe an Agent in natural language, bind it to a model provider, extend it
-with Skills and MCP servers, and publish it. a2wave handles the rest: credential
-injection, run queueing, audit trails, permissions, and delivery to whichever
-channel your colleagues actually live in.
+Describe an Agent in natural language, bind a model provider, extend it with Skills
+and MCP servers, publish. a2wave handles credential injection, run queueing, audit
+trails, permissions, and delivery.
 
-**a2wave orchestrates; it does not execute.** There is no bundled LLM inference,
-no sandbox runtime, and no drag-and-drop DAG editor — execution capability comes
-from the underlying CLIs, and orchestration is written in natural language rather
-than wired together in a flowchart. These boundaries are deliberate and enforced;
-see the [Iron Rules](./AGENTS.md#product-identity--iron-rules).
+**a2wave orchestrates; it does not execute.** No bundled LLM inference, no sandbox
+runtime, no drag-and-drop DAG editor — execution comes from the underlying CLIs, and
+orchestration is written in natural language. These boundaries are enforced; see the
+[Iron Rules](./AGENTS.md#product-identity--iron-rules).
 
 ### How it compares
 
@@ -46,74 +44,64 @@ see the [Iron Rules](./AGENTS.md#product-identity--iron-rules).
 | **Model execution** | Your existing CLI + your credentials | Vendor-managed runtimes | Local only |
 | **Governance** | Per-Agent permissions, audit trail, run queue | Varies | None |
 
-a2wave is the right fit when your team already trusts a coding agent CLI and needs
-to *share* it — with access control, an audit trail, and delivery into Feishu or
-Slack — rather than rebuild its reasoning as a graph.
+Pick a2wave when your team already trusts an agent CLI and needs to *share* it — with
+access control, an audit trail, and delivery into Feishu or Slack — rather than
+rebuild its reasoning as a graph.
 
 ## Features
 
 - 🤖 **Bring your own agent CLI** — Claude Code, Cursor Agent, OpenAI Codex,
-  OpenCode, Qoder, Trae, Kimi, and Pi run as interchangeable execution engines.
-  CLIs install on demand from a pinned, checksum-verified lockfile, so the base
-  image stays small.
+  OpenCode, Qoder, Trae, Kimi and Pi are interchangeable execution engines,
+  installed on demand from a pinned, checksum-verified lockfile.
 - 🌊 **Publish to multiple channels** — one Agent, reachable via HTTP API, Feishu,
-  Slack, Discord, the A2A protocol, scheduled triggers, GitLab / GitHub repository
-  triggers, and a first-party chat page.
+  Slack, Discord, A2A, schedules, GitLab / GitHub repository triggers, and a
+  first-party chat page.
 - 🧩 **Extend by composition** — add capabilities through Skills and MCP servers
   (stdio / SSE / HTTP / proxy groups) instead of forking the platform.
-- 🔗 **Agent-to-agent calls** — Agents reach other Agents over the A2A protocol,
-  including agents hosted outside your deployment.
-- 📚 **Persistent memory** — per-Agent memory with progressive disclosure, plus
-  keyword, vector, and hybrid search.
+- 🔗 **Agent-to-agent calls** — Agents reach other Agents over A2A, including ones
+  hosted outside your deployment.
+- 📚 **Persistent memory** — per-Agent, with progressive disclosure and keyword,
+  vector and hybrid search.
 - 🧪 **Built-in evaluation** — replay curated case sets against an Agent's current
   config, with a frozen provider/model/prompt snapshot for honest comparison.
-- 📦 **Git & Perforce workspaces** — Agents operate on real checkouts, with
-  isolated worktrees per evaluation run.
+- 📦 **Git & Perforce workspaces** — Agents work on real checkouts, with isolated
+  worktrees per evaluation run.
 - 🔐 **Enterprise auth** — OIDC and SAML SSO, per-Agent owner/editor/viewer
   permissions, rate limiting, and an audit entry behind every write.
 
 ## Trust Model
 
-a2wave is designed for **internal enterprise teams**, assuming that the people who
-create Agents and the people who use them are **trusted colleagues acting in good
-faith**.
+a2wave is built for **internal enterprise teams**: Agent authors and Agent users are
+assumed to be **trusted colleagues acting in good faith**.
 
-This shapes the product's boundaries. Agents run CLIs with real capabilities
-(filesystem access, shell execution, injected credentials) *by design*. The platform
-deliberately does **not** sandbox authors from each other, nor defend against a
-malicious insider crafting a hostile Agent. Its security controls — authentication,
-per-Agent permissions, audit logging, rate limiting — enforce **accountability and
-least privilege among cooperating teammates**, not containment of an adversary
-already inside the trust boundary.
+That shapes the boundaries. Agents run CLIs with real capabilities — filesystem,
+shell, injected credentials — *by design*. The platform does not sandbox authors from
+each other, nor defend against an insider crafting a hostile Agent. Its controls
+(authentication, per-Agent permissions, audit logging, rate limiting) enforce
+**accountability and least privilege among teammates**, not containment of an
+adversary already inside.
 
 > [!IMPORTANT]
-> If you plan to expose a2wave to untrusted users or run untrusted Agent
-> configurations, that is out of scope for the current design — add your own
-> isolation layer. Full statement: [SECURITY.md](./SECURITY.md).
+> Exposing a2wave to untrusted users or running untrusted Agent configurations is out
+> of scope — add your own isolation layer. Full statement: [SECURITY.md](./SECURITY.md).
 
 ## Quick Start (Docker)
 
 ```bash
-# 1. Copy the environment template (no edits needed to get started)
-cp .env.example .env
-
-# 2. Build and start
+cp .env.example .env       # no edits needed
 docker compose up -d --build
 ```
 
-After the service starts, visit **http://localhost:3502** — or the port you set as
-`A2WAVE_HOST_PORT` in `.env`, which remaps the host side only (the container always
-listens on 3502, because the image's `EXPOSE`, `PORT` default and `HEALTHCHECK` all
-hardcode it).
+Visit **http://localhost:3502**. Then create an Agent, bind a model provider, and
+publish it — the in-app manual at `/wiki` walks through the first one end to end.
 
 > If `ADMIN_PASSWORD` is left empty, the first person to reach the setup page claims
-> the admin account — no token required. Set `ADMIN_PASSWORD` in `.env` to initialize
-> the admin during boot and close that window entirely.
+> the admin account. Set it in `.env` to close that window.
 
 > [!IMPORTANT]
-> **On macOS**, add these to `.env` before starting. Docker Desktop does not share
-> `/data`, and it reports bind mounts as root-owned — which the entrypoint refuses to
-> adopt, so the container crash-loops without them.
+> **On macOS**, add this to `.env` first — Docker Desktop reports bind mounts as
+> root-owned, which the entrypoint refuses to adopt, so the container crash-loops
+> without it.
 >
 > ```bash
 > A2WAVE_WORKSPACE_DIR=$HOME/a2wave-workspace
@@ -121,173 +109,69 @@ hardcode it).
 > A2WAVE_RUN_AS_GID=10001
 > ```
 
-Next: create an Agent, bind a model provider, and publish it to a channel. The
-in-app user manual at `/wiki` walks through the first Agent end to end.
+Every setting has a working default; see [`.env.example`](./.env.example) for the
+full list, and [Configuration](./docs/agent/configuration.md) for what each one does.
 
-### Database Backend
+## Local Development
 
-The backend is selected by `DATABASE_URL` alone: a `postgres://` scheme means
-PostgreSQL, anything else is a SQLite file path.
-
-**SQLite (default, supported)** — nothing to configure. The commands above give
-you one container with the database on a named volume.
-
-**PostgreSQL ≥ 9.6 (experimental)** — set the URL in `.env` and start with the
-`postgres` profile, which adds the bundled database container:
+Requires **Node.js ≥ 22** (matching the image's `node:22-slim` runtime) and **pnpm ≥ 9**.
 
 ```bash
-# PostgreSQL requires an explicit AUTH_SECRET — see the note below. Generate one
-# and append it, rather than pasting the command itself as the value:
+pnpm install
+cp .env.example .env       # leave AUTH_SECRET empty; pnpm dev generates one
+pnpm dev                   # API :3502 + Web :3501
+pnpm stop                  # free the ports if a previous run left orphans
+```
+
+Development guides, API reference and database operations: [AGENTS.md](./AGENTS.md).
+CLI install / upgrade / publish: [CLI Installation & Publishing](./docs/agent/cli-install-publish.md).
+
+## Database Backend
+
+`DATABASE_URL` alone picks the backend: a `postgres://` scheme means PostgreSQL,
+anything else is a SQLite file path.
+
+**SQLite (default, supported)** — nothing to configure; the Quick Start above gives
+you one container with the database on a named volume.
+
+**PostgreSQL ≥ 9.6 (experimental)** — start with the `postgres` profile, which adds
+the bundled database container:
+
+```bash
+# PostgreSQL requires an explicit AUTH_SECRET. Append a generated value —
+# do not paste the command itself as the value.
 echo "AUTH_SECRET=$(openssl rand -hex 32)" >> .env
 echo "DATABASE_URL=postgres://a2wave:a2wave@postgres:5432/a2wave" >> .env
 
 docker compose --profile postgres up -d
 ```
 
-Migrations run automatically on boot and pick the matching lineage; the API
-waits for the database healthcheck first, so a cold start is safe. The database
-port is not published to the host — change `POSTGRES_PASSWORD` before using this
-outside a local trial.
+Migrations run on boot and pick the matching lineage; the API waits for the database
+healthcheck, so a cold start is safe. The database port is not published to the host
+— change `POSTGRES_PASSWORD` before using this outside a local trial.
 
 > [!IMPORTANT]
-> `postgres` in that URL is the **compose service name**, which resolves only on
-> the compose network. The same `.env` is read by host-run commands (`pnpm run
-> dev`, `pnpm db:migrate`), so leaving the line uncommented points them at a
-> hostname the host cannot resolve. To run a containerised PostgreSQL instance
-> *and* a local SQLite one side by side, keep `DATABASE_URL` out of `.env` and
-> pass it per command instead — see
+> `postgres` in that URL is the **compose service name**, resolvable only on the
+> compose network. Host-run commands (`pnpm dev`, `pnpm db:migrate`) read the same
+> `.env` and will fail on it. To run containerised PostgreSQL and local SQLite side
+> by side, keep `DATABASE_URL` out of `.env` and pass it per command — see
 > [docs/agent/postgresql.md](./docs/agent/postgresql.md#running-docker-postgresql-alongside-a-local-sqlite-instance).
 
-Verify it came up on the right backend — the API prints an experimental-backend
-warning at startup, and the tables land in PostgreSQL rather than a `.db` file:
-
-```bash
-docker compose logs a2wave | grep -i postgres
-docker compose exec postgres psql -U a2wave -d a2wave -c '\dt'
-```
-
 > [!WARNING]
-> PostgreSQL is **experimental** and not yet recommended for production: it
-> passes the full suite and an end-to-end smoke test, but has no production soak
-> time. There is **no SQLite → PostgreSQL data migration path** — switching
-> starts from an empty database. It exists for multi-instance deployments, where
-> a single SQLite file cannot be shared safely. Details, including the
-> per-process cache caveats that matter when running replicas:
+> PostgreSQL is **experimental** and not recommended for production: it passes the
+> full suite and a smoke test, but has no production soak time, and there is **no
+> SQLite → PostgreSQL migration path** — switching starts from an empty database. It
+> exists for multi-instance deployments, where one SQLite file cannot be shared
+> safely. Details, including per-process cache caveats for replicas:
 > [docs/agent/postgresql.md](./docs/agent/postgresql.md).
-
-### Environment Variables
-
-**Nothing is required for the default SQLite setup.** `cp .env.example .env` and go —
-every variable below has a working default. Running more than one replica is the one
-exception; see the note under `AUTH_SECRET`.
-
-| Variable | Default | Description |
-|------|------|------|
-| `AUTH_SECRET` | auto-generated | Signing secret for sessions and tokens. Left empty, `pnpm dev` writes one into `.env` and the container persists one in its data volume, so restarts keep you logged in. Set it explicitly (`openssl rand -hex 32`) to control the value — an explicit secret is never overwritten. **Required when running more than one replica** (see below). |
-
-> [!IMPORTANT]
-> **Multi-replica deployments must set `AUTH_SECRET` explicitly, to the same value on every
-> replica.** A generated secret is private to the instance that made it, so replicas would
-> sign tokens the others reject and encrypt SSO settings the others cannot read. Because
-> PostgreSQL is the multi-instance backend, the container refuses to start rather than
-> generate one when `DATABASE_URL` points at PostgreSQL.
-
-> **Provider API Keys** (`CURSOR_API_KEY` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) are **not**
-> configured here — set them per Agent, on the Agent detail page → Environment Variables.
-
-<details>
-<summary><b>Optional variables</b> — auth, networking, and trusted-host allowlists</summary>
-
-
-
-| Variable | Default | Description |
-|------|--------|------|
-| `A2WAVE_HOST_PORT` | `3502` | Host port the Docker deployment publishes on. Remaps the **host** side only — the container always listens on 3502 |
-| `ADMIN_PASSWORD` | empty | Optional initial admin password, applied on first boot only and never overwritten. **Left empty, the first person to reach the setup page claims the admin account — no token guards it.** Set it if you cannot accept that window |
-| `AUTH_SESSION_TTL_DAYS` | `1` | Login session lifetime (days) for browser cookies and API/CLI bearer tokens, range `1~365`; leaving it unset keeps the original 24-hour behavior |
-| `CORS_ORIGIN` | `http://localhost:3501` | Frontend origin, when it is served from a **different** origin than the API (the dev two-port setup). It grants both cross-origin reads and cookie-authenticated writes. The single-container deployment serves the frontend from the API itself, so same-origin requests are always allowed and this needs no change |
-| `TRUSTED_PROXY` | `false` | Trust `X-Forwarded-For` only when the direct TCP peer is allowlisted below |
-| `TRUSTED_PROXY_ADDRESSES` | empty | Comma-separated exact proxy IPv4/IPv6 addresses or CIDRs; proxies must overwrite XFF or append each hop |
-| `TRUSTED_IMPORT_HOSTS` | empty | Exact Agent-export DNS hostnames allowed to resolve to controlled enterprise-private addresses during URL import |
-| `TRUSTED_MCP_HOSTS` | empty | Exact remote MCP DNS hostnames allowed to resolve to controlled enterprise-private addresses |
-| `TRUSTED_A2A_ROUTE_HOSTS` | empty | Exact remote A2A DNS hostnames allowed as private-address exceptions when public-only mode is enabled |
-| `SCM_WORKSPACES_ALLOWED_ROOTS` | empty | Comma-separated absolute roots approved for non-admin custom Git workspaces; the built-in `~/.a2wave/workspaces` root is always allowed |
-| `ALLOW_PRIVATE_ROUTE_TARGETS` | `true` | Allow ordinary private/CGNAT/ULA remote A2A targets with per-hop validation and DNS pinning; set `false` for public-only mode (exact hostname exceptions remain available) |
-
-> Adjusting `AUTH_SESSION_TTL_DAYS` only affects new logins / newly issued tokens; to immediately tighten already-issued tokens, combine it with logout, password change, or `tokenVersion` revocation.
-
-</details>
-
-<details>
-<summary><b>SCM sources & settings overrides</b> — bootstrap Git/Perforce checkouts from env</summary>
-
-#### P4 SCM Source (created automatically once all fields are filled in)
-
-| Variable | Description |
-|------|------|
-| `SCM_P4_PORT` | P4 server address (Perforce native protocol, not HTTP). Plaintext: `host:1666`, SSL: `ssl:host:1666` |
-| `SCM_P4_USER` | P4 username |
-| `SCM_P4_PASSWD` | P4 password |
-| `SCM_P4_CLIENT` | P4 Workspace name |
-| `SCM_P4_DEPOT_PATH` | Depot path, e.g. `//depot/main/...` |
-| `SCM_P4_LOCAL_PATH` | Local sync directory, defaults to `/app/data/p4-workspace` |
-| `SCM_P4_AUTO_SYNC` | Whether to auto-sync, defaults to `true` |
-
-#### Git SCM Source (created automatically once the URL is set)
-
-| Variable | Description |
-|------|------|
-| `SCM_GIT_REPO_URL` | Repository address |
-| `SCM_GIT_BRANCH` | Branch, defaults to `main` |
-| `SCM_GIT_USERNAME` | Username (HTTPS authentication) |
-| `SCM_GIT_PAT` | Personal Access Token |
-| `SCM_GIT_LOCAL_PATH` | Local clone directory, defaults to `/app/data/git-workspace` |
-| `SCM_GIT_AUTO_SYNC` | Whether to auto-sync, defaults to `true` |
-
-#### Settings Override (optional)
-
-| Variable | Description |
-|------|------|
-| `SETTINGS_GENERAL_WORKSPACE_PATH` | Workspace path |
-| `SETTINGS_GENERAL_TIMEOUT_MINUTES` | Global timeout (minutes) |
-| `SETTINGS_BRANDING_SUBTITLE` | Branding subtitle |
-| `SETTINGS_BRANDING_FAVICON_URL` | Favicon address |
-
-</details>
-
-## Local Development
-
-### Prerequisites
-
-- Node.js >= 22 (matches the `node:22-slim` runtime in the Docker image)
-- pnpm >= 9
-
-```bash
-pnpm install
-
-# Create a local .env. Leave AUTH_SECRET empty — `pnpm dev` generates one
-# into .env on first start.
-cp .env.example .env
-
-# Start frontend and backend together (API :3502 + Web :3501 by default;
-# override with PORT / WEB_PORT in .env)
-pnpm dev
-
-# Free the ports if a previous run left orphaned servers behind
-pnpm stop
-```
-
-For more development guides, API documentation, and database operations, see [AGENTS.md](./AGENTS.md).
-
-For CLI installation, upgrade, and publishing workflows, see [CLI Installation & Publishing](./docs/agent/cli-install-publish.md).
 
 ## Channels
 
-A published Agent can be reached through multiple channels: HTTP API, Feishu, Slack,
-Discord, the A2A protocol, scheduled triggers, GitLab / GitHub repository triggers,
-and the first-party chat page.
+A published Agent is reachable through HTTP API, Feishu, Slack, Discord, the A2A
+protocol, scheduled triggers, GitLab / GitHub repository triggers, and the
+first-party chat page.
 
-> The Feishu channel currently supports Feishu (feishu.cn) apps; Lark international
+> The Feishu channel supports Feishu (feishu.cn) apps; Lark international
 > (larksuite.com) is not configurable yet.
 
 ## Documentation
@@ -295,34 +179,34 @@ and the first-party chat page.
 | Document | Contents |
 |------|------|
 | [Core Concepts](./docs/core-concepts.md) | Agent, Provider, Skill, MCP Server, SCM Source, Run, Evaluation |
+| [Configuration](./docs/agent/configuration.md) | Every environment variable and settings override |
 | [Project Guide](./AGENTS.md) | Architecture, full API reference, testing strategy, conventions |
 | [CLI Installation & Publishing](./docs/agent/cli-install-publish.md) | Installing, upgrading, and publishing the `a2wave` CLI |
 | [Contributing](./CONTRIBUTING.md) | Dev setup, commit convention, quality gates, AI policy |
 | [Security Policy](./SECURITY.md) | Trust model and vulnerability disclosure |
 
-The running instance also serves an interactive API reference at `/api/docs`
-(Swagger UI) and an in-app user manual at `/wiki`.
+A running instance also serves an interactive API reference at `/api/docs` (Swagger
+UI) and the user manual at `/wiki`.
 
 ## Built with AI
 
-a2wave is built extensively with AI coding agents — a fitting way to build a
-platform that orchestrates them. Every change lands through a full test
-pyramid (unit / integration / E2E), hard lint and typecheck gates, and human
-review. AI-assisted contributions are held to the same bar; see the
+a2wave is built extensively with AI coding agents — a fitting way to build a platform
+that orchestrates them. Every change lands through a full test pyramid (unit /
+integration / E2E), hard lint and typecheck gates, and human review. AI-assisted
+contributions are held to the same bar; see the
 [AI Contribution Policy](./CONTRIBUTING.md#ai-contribution-policy).
 
 ## Contributing
 
 Issues, discussions and pull requests are welcome. Start with
-[CONTRIBUTING.md](./CONTRIBUTING.md) — it covers the development setup, the commit convention, the
-quality gates a change must pass, and the AI contribution policy. Note that a2wave has explicit
-product boundaries (the Iron Rules in [AGENTS.md](./AGENTS.md)); features that cross them need
-maintainer discussion first. By participating you agree to the
-[Code of Conduct](./CODE_OF_CONDUCT.md).
+[CONTRIBUTING.md](./CONTRIBUTING.md) — dev setup, commit convention, quality gates and
+the AI contribution policy. a2wave has explicit product boundaries (the Iron Rules in
+[AGENTS.md](./AGENTS.md)); features that cross them need maintainer discussion first.
+By participating you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 > [!WARNING]
-> Please do **not** report security vulnerabilities through public issues or pull requests — follow
-> [SECURITY.md](./SECURITY.md) to disclose privately.
+> Do **not** report security vulnerabilities through public issues or pull requests —
+> follow [SECURITY.md](./SECURITY.md) to disclose privately.
 
 ## Contributors
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="apps/web/public/brand-icons/default.svg" alt="a2wave" width="72" height="72" />
+<img src="https://raw.githubusercontent.com/LilithGames/a2wave/main/apps/web/public/brand-icons/default.svg" alt="a2wave" width="72" height="72" />
 
 # a2wave
 
@@ -22,11 +22,15 @@
 
 ## a2wave 是什么
 
-a2wave 把你已经在用的 Agent CLI——**Claude Code、Cursor Agent、OpenAI Codex 等**——变成整个团队都能用的、受治理的服务，可以从飞书、Slack、Discord、HTTP API 或定时任务直接触达。
+a2wave 把你已经在用的 Agent CLI——**Claude Code、Cursor Agent、OpenAI Codex 等**——变成
+受治理的共享服务，可从飞书、Slack、Discord、HTTP API 或定时任务直接触达。
 
-你用自然语言描述一个 Agent，绑定模型 Provider，用 Skills 和 MCP Server 扩展它的能力，然后发布。剩下的交给 a2wave：凭证注入、运行排队、审计留痕、权限控制，以及投递到同事真正在用的那个渠道。
+用自然语言描述一个 Agent，绑定模型 Provider，用 Skills 和 MCP Server 扩展能力，然后发布。
+凭证注入、运行排队、审计留痕、权限控制和消息投递，都交给 a2wave。
 
-**a2wave 只做编排，不做执行。** 平台不内置 LLM 推理、不内置沙箱运行时、也没有拖拽式 DAG 编辑器——执行能力来自底层 CLI，编排用自然语言表达，而不是在流程图里连线。这些边界是刻意设计并强制约束的，详见[产品铁律](./AGENTS.md#product-identity--iron-rules)。
+**a2wave 只做编排，不做执行。** 不内置 LLM 推理、不内置沙箱运行时、也没有拖拽式 DAG
+编辑器——执行能力来自底层 CLI，编排用自然语言表达。这些边界是强制约束的，详见
+[产品铁律](./AGENTS.md#product-identity--iron-rules)。
 
 ### 和其他方案的区别
 
@@ -37,45 +41,55 @@ a2wave 把你已经在用的 Agent CLI——**Claude Code、Cursor Agent、OpenA
 | **模型执行** | 你现有的 CLI + 你自己的凭证 | 厂商托管的运行时 | 仅本地 |
 | **治理能力** | 按 Agent 的权限、审计留痕、运行排队 | 视产品而定 | 无 |
 
-如果你的团队已经在用某个 Agent CLI，需要的是把它**共享出去**——带上权限控制、审计留痕，并投递到飞书或 Slack——而不是把它的推理过程重新画成一张图，那 a2wave 就是合适的选择。
+如果你的团队已经在用某个 Agent CLI，需要的是把它**共享出去**——带上权限控制、审计留痕，
+并投递到飞书或 Slack——而不是把它的推理过程重画成一张图，那 a2wave 就是合适的选择。
 
 ## 核心能力
 
-- 🤖 **自带 Agent CLI** —— Claude Code、Cursor Agent、OpenAI Codex、OpenCode、Qoder、Trae、Kimi、Pi 都可作为可互换的执行引擎。CLI 按需从锁定并校验哈希的 lockfile 安装，基础镜像因此保持精简。
-- 🌊 **一次发布，多渠道触达** —— 同一个 Agent 可通过 HTTP API、飞书、Slack、Discord、A2A 协议、定时任务、GitLab / GitHub 仓库触发和平台自建聊天页触达。
-- 🧩 **以组合方式扩展** —— 通过 Skills 与 MCP Server（stdio / SSE / HTTP / 代理分组）增加能力，而不是 fork 平台本身。
-- 🔗 **Agent 之间互相调用** —— 基于 A2A 协议，Agent 可以调用其他 Agent，包括部署在你的实例之外的 Agent。
-- 📚 **持久化记忆** —— 按 Agent 隔离的记忆，支持渐进式披露，以及关键词、向量与混合检索。
-- 🧪 **内置评测** —— 用整理好的用例集回放当前 Agent 配置，并冻结 provider / 模型 / 提示词快照，保证对比公平。
-- 📦 **Git 与 Perforce 工作区** —— Agent 在真实检出上工作，评测运行还会获得隔离的 worktree。
-- 🔐 **企业级认证** —— OIDC 与 SAML 单点登录、按 Agent 的 owner/editor/viewer 权限、限流，以及每一次写操作背后的审计记录。
+- 🤖 **自带 Agent CLI** —— Claude Code、Cursor Agent、OpenAI Codex、OpenCode、Qoder、
+  Trae、Kimi、Pi 均可作为可互换的执行引擎，按需从锁定并校验哈希的 lockfile 安装。
+- 🌊 **一次发布，多渠道触达** —— 同一个 Agent 可通过 HTTP API、飞书、Slack、Discord、
+  A2A 协议、定时任务、GitLab / GitHub 仓库触发和平台自建聊天页触达。
+- 🧩 **以组合方式扩展** —— 通过 Skills 与 MCP Server（stdio / SSE / HTTP / 代理分组）
+  增加能力，而不是 fork 平台本身。
+- 🔗 **Agent 之间互相调用** —— 基于 A2A 协议调用其他 Agent，包括部署在你的实例之外的。
+- 📚 **持久化记忆** —— 按 Agent 隔离，支持渐进式披露与关键词、向量、混合检索。
+- 🧪 **内置评测** —— 用整理好的用例集回放当前 Agent 配置，并冻结 provider / 模型 /
+  提示词快照，保证对比公平。
+- 📦 **Git 与 Perforce 工作区** —— Agent 在真实检出上工作，评测运行获得隔离的 worktree。
+- 🔐 **企业级认证** —— OIDC 与 SAML 单点登录、按 Agent 的 owner/editor/viewer 权限、
+  限流，以及每一次写操作背后的审计记录。
 
 ## 信任模型
 
-a2wave 面向**企业内部团队**设计，其核心假设是：创建 Agent 的人与使用 Agent 的人，都是**善意行事、值得信任的同事**。
+a2wave 面向**企业内部团队**设计，假设创建 Agent 的人与使用 Agent 的人，都是**善意行事、
+值得信任的同事**。
 
-这一假设塑造了产品边界。Agent 运行的底层 CLI *在设计上*就拥有真实能力（文件系统访问、Shell 执行、注入的凭证）。平台刻意**不**在作者之间做沙箱隔离，也不防御精心构造恶意 Agent 的内部攻击者。平台的安全控制——认证、按 Agent 划分的权限、审计日志、限流——是为了在协作的同事之间落实**问责与最小权限**，而不是围堵已在信任边界内部的对手。
+这一假设塑造了产品边界。Agent 运行的底层 CLI *在设计上*就拥有真实能力：文件系统访问、
+Shell 执行、注入的凭证。平台刻意**不**在作者之间做沙箱隔离，也不防御精心构造恶意 Agent
+的内部攻击者。认证、按 Agent 划分的权限、审计日志、限流这些控制，是为了在协作的同事之间
+落实**问责与最小权限**，而不是围堵已在信任边界内部的对手。
 
 > [!IMPORTANT]
-> 如果你计划把 a2wave 暴露给不可信用户，或运行不可信的 Agent 配置，这超出当前设计范围——请自行添加隔离层。完整说明见 [SECURITY.md](./SECURITY.md)。
+> 把 a2wave 暴露给不可信用户，或运行不可信的 Agent 配置，超出当前设计范围——请自行添加
+> 隔离层。完整说明见 [SECURITY.md](./SECURITY.md)。
 
 ## 快速开始（Docker）
 
 ```bash
-# 1. 复制环境变量模板（开箱即用，无需修改）
-cp .env.example .env
-
-# 2. 构建并启动
+cp .env.example .env       # 开箱即用，无需修改
 docker compose up -d --build
 ```
 
-服务启动后访问 **http://localhost:3502**——如果在 `.env` 里设置了 `A2WAVE_HOST_PORT`，则访问对应端口。该变量只改宿主机侧端口，容器内始终监听 3502（镜像的 `EXPOSE`、`PORT` 默认值和 `HEALTHCHECK` 都硬编码了它）。
+访问 **http://localhost:3502**，然后创建 Agent、绑定模型 Provider 并发布。应用内手册
+`/wiki` 有完整的第一个 Agent 上手流程。
 
-> 如果 `ADMIN_PASSWORD` 留空，谁先打开 setup 页面谁就拿到 admin 账号——不需要任何 token。在 `.env` 中设置 `ADMIN_PASSWORD` 可在启动时初始化 admin，彻底关闭这个窗口。
+> 如果 `ADMIN_PASSWORD` 留空，谁先打开 setup 页面谁就拿到 admin 账号。在 `.env` 中设置
+> 它可以关闭这个窗口。
 
 > [!IMPORTANT]
-> **macOS 用户**请在启动前把以下配置加入 `.env`。Docker Desktop 不共享 `/data`，且会把
-> bind mount 报告为 root 所有——entrypoint 拒绝接管这种情况，不加这些配置容器会反复重启。
+> **macOS 用户**请先把以下配置加入 `.env`。Docker Desktop 会把 bind mount 报告为 root
+> 所有，entrypoint 拒绝接管，不加这些配置容器会反复重启。
 >
 > ```bash
 > A2WAVE_WORKSPACE_DIR=$HOME/a2wave-workspace
@@ -83,141 +97,60 @@ docker compose up -d --build
 > A2WAVE_RUN_AS_GID=10001
 > ```
 
-下一步：创建一个 Agent，绑定模型 Provider，然后发布到某个渠道。应用内的用户手册 `/wiki` 有完整的第一个 Agent 上手流程。
+所有配置项都有可用默认值，完整列表见 [`.env.example`](./.env.example)，逐项说明见
+[配置说明](./docs/agent/configuration.md)。
 
-### 数据库后端
+## 本地开发
 
-后端仅由 `DATABASE_URL` 决定：`postgres://` 协议表示 PostgreSQL，其他一律当作 SQLite 文件路径。
-
-**SQLite（默认，官方支持）** —— 无需任何配置。上面的命令即可启动单容器部署，数据库位于命名卷上。
-
-**PostgreSQL ≥ 9.6（实验性）** —— 在 `.env` 中设置连接串，并用 `postgres` profile 启动，它会带上内置的数据库容器：
+需要 **Node.js ≥ 22**（与镜像的 `node:22-slim` 运行时一致）和 **pnpm ≥ 9**。
 
 ```bash
-# PostgreSQL 下 AUTH_SECRET 必填（见下方说明）。请生成后追加，
-# 不要把命令本身当作值粘贴进去：
+pnpm install
+cp .env.example .env       # AUTH_SECRET 留空，pnpm dev 会自动生成
+pnpm dev                   # API :3502 + Web :3501
+pnpm stop                  # 上次运行留下孤儿进程占用端口时用它释放
+```
+
+更多开发指南、API 文档与数据库操作见 [AGENTS.md](./AGENTS.md)。
+CLI 的安装、升级与发布见 [CLI 安装与发布](./docs/agent/cli-install-publish.md)。
+
+## 数据库后端
+
+后端仅由 `DATABASE_URL` 决定：`postgres://` 协议表示 PostgreSQL，其他一律当作 SQLite
+文件路径。
+
+**SQLite（默认，官方支持）** —— 无需任何配置，上面的快速开始即是单容器部署，数据库位于
+命名卷上。
+
+**PostgreSQL ≥ 9.6（实验性）** —— 用 `postgres` profile 启动，它会带上内置的数据库容器：
+
+```bash
+# PostgreSQL 下 AUTH_SECRET 必填。请生成后追加，不要把命令本身当作值粘贴进去：
 echo "AUTH_SECRET=$(openssl rand -hex 32)" >> .env
 echo "DATABASE_URL=postgres://a2wave:a2wave@postgres:5432/a2wave" >> .env
 
 docker compose --profile postgres up -d
 ```
 
-迁移在启动时自动执行并选择对应的迁移谱系；API 会先等待数据库健康检查通过，因此冷启动是安全的。数据库端口不会发布到宿主机——在本地试用之外的场景请先修改 `POSTGRES_PASSWORD`。
-
-确认确实跑在 PostgreSQL 上：API 启动时会打印实验性后端的警告，且表建在 PostgreSQL 里而非 `.db` 文件中：
-
-```bash
-docker compose logs a2wave | grep -i postgres
-docker compose exec postgres psql -U a2wave -d a2wave -c '\dt'
-```
-
-> [!WARNING]
-> PostgreSQL 目前是**实验性**的，尚不推荐用于生产：它能通过完整测试套件与端到端冒烟测试，但没有生产环境的长期运行验证。**不存在 SQLite → PostgreSQL 的数据迁移路径**——切换意味着从空数据库开始。它面向多实例部署，因为单个 SQLite 文件无法被安全共享。详细说明（含多副本时需要注意的进程内缓存问题）见 [docs/agent/postgresql.md](./docs/agent/postgresql.md)。
-
-### 环境变量
-
-**默认的 SQLite 部署无需填写任何变量。** `cp .env.example .env` 之后即可启动，下面每一项都有可用的默认值。唯一的例外是多副本部署，见 `AUTH_SECRET` 下方的说明。
-
-| 变量 | 默认值 | 说明 |
-|------|--------|------|
-| `AUTH_SECRET` | 自动生成 | 登录态与 token 的签名密钥。留空时，`pnpm dev` 会写入 `.env`，容器则持久化在数据卷中，因此重启不会把大家踢下线。想自己指定就显式设置（`openssl rand -hex 32`）——显式配置的密钥永远优先，且不会被覆盖。**多副本部署必填**（见下）。 |
+迁移在启动时自动执行并选择对应的迁移谱系；API 会先等待数据库健康检查通过，冷启动是安全
+的。数据库端口不会发布到宿主机——本地试用之外的场景请先修改 `POSTGRES_PASSWORD`。
 
 > [!IMPORTANT]
-> **多副本部署必须显式设置 `AUTH_SECRET`，且所有副本用同一个值。** 自动生成的密钥只属于生成它
-> 的那个实例，副本之间会互相拒绝对方签发的 token，一方加密的 SSO 配置另一方也解不开。由于
-> PostgreSQL 正是面向多实例的后端，当 `DATABASE_URL` 指向 PostgreSQL 时容器会直接拒绝启动，
-> 而不是生成一个实例私有的密钥。
+> URL 里的 `postgres` 是 **compose 服务名**，只在 compose 网络内可解析。宿主机上运行的
+> 命令（`pnpm dev`、`pnpm db:migrate`）读的是同一份 `.env`，会解析失败。若要让容器内的
+> PostgreSQL 与本地 SQLite 并存，请把 `DATABASE_URL` 移出 `.env`，改为按命令传入——见
+> [docs/agent/postgresql.md](./docs/agent/postgresql.md#running-docker-postgresql-alongside-a-local-sqlite-instance)。
 
-> **Provider API Key**（`CURSOR_API_KEY` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`）**不**在这里配置——请在每个 Agent 的详情页 → 环境变量中单独设置。
-
-<details>
-<summary><b>可选变量</b> —— 认证、网络与可信主机允许列表</summary>
-
-
-
-| 变量 | 默认值 | 说明 |
-|------|--------|------|
-| `A2WAVE_HOST_PORT` | `3502` | Docker 部署对外发布的宿主机端口。只改**宿主机**侧，容器内始终监听 3502 |
-| `ADMIN_PASSWORD` | 空 | 可选的管理员初始密码，仅在首次启动时生效且不会覆盖已有密码。**留空时，谁先打开 setup 页面谁就拿到 admin 账号——没有任何 token 保护。** 无法接受这个窗口就必须预先设置 |
-| `AUTH_SESSION_TTL_DAYS` | `1` | 浏览器 cookie 与 API/CLI bearer token 的登录态有效期（天），范围 `1~365`；不配置则保持原有 24 小时行为 |
-| `CORS_ORIGIN` | `http://localhost:3501` | 前端访问地址 |
-| `TRUSTED_PROXY` | `false` | 仅当直连 TCP 对端在下面的允许列表中时，才信任 `X-Forwarded-For` |
-| `TRUSTED_PROXY_ADDRESSES` | 空 | 逗号分隔的精确代理 IPv4/IPv6 地址或 CIDR；代理必须覆写 XFF 或逐跳追加 |
-| `TRUSTED_IMPORT_HOSTS` | 空 | URL 导入 Agent 配置时，允许解析到受控企业内网地址的精确 DNS 主机名 |
-| `TRUSTED_MCP_HOSTS` | 空 | 允许解析到受控企业内网地址的远程 MCP 精确 DNS 主机名 |
-| `TRUSTED_A2A_ROUTE_HOSTS` | 空 | 启用仅公网模式后，仍允许解析到受控企业内网地址的远程 A2A 精确 DNS 主机名例外 |
-| `SCM_WORKSPACES_ALLOWED_ROOTS` | 空 | 逗号分隔的绝对路径根目录，供非管理员自定义 Git 工作区使用；内置的 `~/.a2wave/workspaces` 始终允许 |
-| `ALLOW_PRIVATE_ROUTE_TARGETS` | `true` | 默认允许普通私网/CGNAT/ULA A2A 目标，同时保留逐跳校验和 DNS 固定；设为 `false` 后仅允许公网目标（仍可配置精确域名例外） |
-
-> 调整 `AUTH_SESSION_TTL_DAYS` 只影响新登录 / 新签发的 token；如需立即收紧已签发的 token，请配合登出、改密或 `tokenVersion` 撤销。
-
-</details>
-
-<details>
-<summary><b>代码源与 Settings 覆盖</b> —— 通过环境变量初始化 Git / Perforce 检出</summary>
-
-#### P4 代码源（全部填写后自动创建）
-
-| 变量 | 说明 |
-|------|------|
-| `SCM_P4_PORT` | P4 服务器地址（Perforce 原生协议，非 HTTP）。明文：`host:1666`，SSL：`ssl:host:1666` |
-| `SCM_P4_USER` | P4 用户名 |
-| `SCM_P4_PASSWD` | P4 密码 |
-| `SCM_P4_CLIENT` | P4 Workspace 名称 |
-| `SCM_P4_DEPOT_PATH` | Depot 路径，如 `//depot/main/...` |
-| `SCM_P4_LOCAL_PATH` | 本地同步目录，默认 `/app/data/p4-workspace` |
-| `SCM_P4_AUTO_SYNC` | 是否自动同步，默认 `true` |
-
-#### Git 代码源（填写 URL 后自动创建）
-
-| 变量 | 说明 |
-|------|------|
-| `SCM_GIT_REPO_URL` | 仓库地址 |
-| `SCM_GIT_BRANCH` | 分支，默认 `main` |
-| `SCM_GIT_USERNAME` | 用户名（HTTPS 认证） |
-| `SCM_GIT_PAT` | Personal Access Token |
-| `SCM_GIT_LOCAL_PATH` | 本地克隆目录，默认 `/app/data/git-workspace` |
-| `SCM_GIT_AUTO_SYNC` | 是否自动同步，默认 `true` |
-
-#### Settings 覆盖（可选）
-
-| 变量 | 说明 |
-|------|------|
-| `SETTINGS_GENERAL_WORKSPACE_PATH` | 工作区路径 |
-| `SETTINGS_GENERAL_TIMEOUT_MINUTES` | 全局超时（分钟） |
-| `SETTINGS_BRANDING_SUBTITLE` | 品牌副标题 |
-| `SETTINGS_BRANDING_FAVICON_URL` | Favicon 地址 |
-
-</details>
-
-## 本地开发
-
-### 环境要求
-
-- Node.js >= 22（与 Docker 镜像的 `node:22-slim` 运行时保持一致）
-- pnpm >= 9
-
-```bash
-pnpm install
-
-# 创建本地 .env（AUTH_SECRET 留空即可，pnpm dev 首次启动会自动生成并写入）
-cp .env.example .env
-
-# 同时启动前端与后端（默认 API :3502 + Web :3501；
-# 可在 .env 中用 PORT / WEB_PORT 覆盖）
-pnpm dev
-
-# 如果上一次运行留下了孤儿进程占用端口，用它释放
-pnpm stop
-```
-
-更多开发指南、API 文档与数据库操作见 [AGENTS.md](./AGENTS.md)。
-
-CLI 的安装、升级与发布流程见 [CLI 安装与发布](./docs/agent/cli-install-publish.md)。
+> [!WARNING]
+> PostgreSQL 目前是**实验性**的，尚不推荐用于生产：它能通过完整测试套件与端到端冒烟测试，
+> 但没有生产环境的长期验证。**不存在 SQLite → PostgreSQL 的数据迁移路径**——切换意味着从
+> 空数据库开始。它面向多实例部署，因为单个 SQLite 文件无法被安全共享。详细说明（含多副本
+> 时的进程内缓存注意事项）见 [docs/agent/postgresql.md](./docs/agent/postgresql.md)。
 
 ## 发布渠道
 
-一个已发布的 Agent 可以通过多个渠道触达：HTTP API、飞书、Slack、Discord、A2A 协议、定时任务、GitLab / GitHub 仓库触发，以及平台自建的聊天页。
+已发布的 Agent 可通过 HTTP API、飞书、Slack、Discord、A2A 协议、定时任务、
+GitLab / GitHub 仓库触发，以及平台自建的聊天页触达。
 
 > 飞书渠道目前支持飞书（feishu.cn）应用；Lark 国际版（larksuite.com）暂不可配置。
 
@@ -226,23 +159,31 @@ CLI 的安装、升级与发布流程见 [CLI 安装与发布](./docs/agent/cli-
 | 文档 | 内容 |
 |------|------|
 | [核心概念](./docs/core-concepts.md) | Agent、Provider、Skill、MCP Server、代码源、Run、评测 |
+| [配置说明](./docs/agent/configuration.md) | 全部环境变量与 Settings 覆盖项 |
 | [项目指南](./AGENTS.md) | 架构、完整 API 参考、测试策略、开发约定 |
 | [CLI 安装与发布](./docs/agent/cli-install-publish.md) | `a2wave` CLI 的安装、升级与发布流程 |
 | [贡献指南](./CONTRIBUTING.md) | 开发环境、提交约定、质量门禁、AI 贡献政策 |
 | [安全策略](./SECURITY.md) | 信任模型与漏洞披露流程 |
 
-服务运行后还会提供交互式 API 参考（`/api/docs`，Swagger UI）与应用内用户手册（`/wiki`）。
+服务运行后还提供交互式 API 参考（`/api/docs`，Swagger UI）与应用内用户手册（`/wiki`）。
 
 ## 用 AI 构建
 
-a2wave 自身就是大量使用 AI 编码 Agent 构建的——对于一个 Agent 编排平台来说，这是最贴切的建设方式。每一个变更都要经过完整的测试金字塔（单元 / 集成 / E2E）、强制的 lint 与 typecheck 门禁，以及人工评审。AI 辅助的贡献也以同样的标准欢迎，详见 [AI 贡献政策](./CONTRIBUTING.md#ai-contribution-policy)。
+a2wave 自身就是大量使用 AI 编码 Agent 构建的——对于一个 Agent 编排平台来说，这是最贴切的
+建设方式。每一个变更都要经过完整的测试金字塔（单元 / 集成 / E2E）、强制的 lint 与
+typecheck 门禁，以及人工评审。AI 辅助的贡献以同样的标准欢迎，详见
+[AI 贡献政策](./CONTRIBUTING.md#ai-contribution-policy)。
 
 ## 参与贡献
 
-欢迎提 issue、参与讨论与提交 PR。请先阅读 [CONTRIBUTING.md](./CONTRIBUTING.md)——其中包含开发环境搭建、提交信息约定、变更必须通过的质量门禁，以及 AI 贡献政策。注意 a2wave 有明确的产品边界（[AGENTS.md](./AGENTS.md) 中的产品铁律），越界的特性需要先与维护者讨论。参与本项目即表示你同意遵守[行为准则](./CODE_OF_CONDUCT.md)。
+欢迎提 issue、参与讨论与提交 PR。请先阅读 [CONTRIBUTING.md](./CONTRIBUTING.md)——其中包含
+开发环境搭建、提交信息约定、质量门禁与 AI 贡献政策。注意 a2wave 有明确的产品边界
+（[AGENTS.md](./AGENTS.md) 中的产品铁律），越界的特性需要先与维护者讨论。参与本项目即表示
+你同意遵守[行为准则](./CODE_OF_CONDUCT.md)。
 
 > [!WARNING]
-> 请**不要**通过公开 issue 或 PR 报告安全漏洞——按 [SECURITY.md](./SECURITY.md) 的流程私下披露。
+> 请**不要**通过公开 issue 或 PR 报告安全漏洞——按 [SECURITY.md](./SECURITY.md) 的流程
+> 私下披露。
 
 ## 贡献者
 
@@ -254,4 +195,5 @@ a2wave 自身就是大量使用 AI 编码 Agent 构建的——对于一个 Agen
 
 ## 开源协议
 
-基于 [Apache License 2.0](./LICENSE) 授权。Copyright 2026 Lilith Games——署名与随附的第三方材料见 [NOTICE](./NOTICE)。
+基于 [Apache License 2.0](./LICENSE) 授权。Copyright 2026 Lilith Games——署名与随附的
+第三方材料见 [NOTICE](./NOTICE)。

--- a/docs/agent/configuration.md
+++ b/docs/agent/configuration.md
@@ -1,0 +1,92 @@
+# Configuration
+
+All configuration is read from `.env` (see [`.env.example`](../../.env.example)).
+
+**Nothing is required for the default SQLite setup.** `cp .env.example .env` and go —
+every variable below has a working default. Running more than one replica is the one
+exception; see `AUTH_SECRET`.
+
+## Core
+
+| Variable | Default | Description |
+|------|------|------|
+| `AUTH_SECRET` | auto-generated | Signing secret for sessions and tokens. Left empty, `pnpm dev` writes one into `.env` and the container persists one in its data volume, so restarts keep you logged in. Set it explicitly (`openssl rand -hex 32`) to control the value — an explicit secret is never overwritten. **Required when running more than one replica** (see below) |
+| `DATABASE_URL` | `./data/a2wave.db` | A `postgres://` scheme selects PostgreSQL; anything else is a SQLite file path. See [PostgreSQL](./postgresql.md) |
+
+> [!IMPORTANT]
+> **Multi-replica deployments must set `AUTH_SECRET` explicitly, to the same value on
+> every replica.** A generated secret is private to the instance that made it, so
+> replicas would sign tokens the others reject and encrypt SSO settings the others
+> cannot read. Because PostgreSQL is the multi-instance backend, the container refuses
+> to start rather than generate one when `DATABASE_URL` points at PostgreSQL.
+
+> **Provider API keys** (`CURSOR_API_KEY` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) are
+> **not** configured here — set them per Agent, on the Agent detail page → Environment
+> Variables.
+
+## Auth, networking and trusted hosts
+
+| Variable | Default | Description |
+|------|--------|------|
+| `A2WAVE_HOST_PORT` | `3502` | Host port the Docker deployment publishes on. Remaps the **host** side only — the container always listens on 3502, because the image's `EXPOSE`, `PORT` default and `HEALTHCHECK` all hardcode it |
+| `ADMIN_PASSWORD` | empty | Optional initial admin password, applied on first boot only and never overwritten. **Left empty, the first person to reach the setup page claims the admin account — no token guards it.** Set it if you cannot accept that window |
+| `AUTH_SESSION_TTL_DAYS` | `1` | Login session lifetime (days) for browser cookies and API/CLI bearer tokens, range `1~365`; leaving it unset keeps the original 24-hour behavior |
+| `CORS_ORIGIN` | `http://localhost:3501` | Frontend origin, when it is served from a **different** origin than the API (the dev two-port setup). It grants both cross-origin reads and cookie-authenticated writes. The single-container deployment serves the frontend from the API itself, so same-origin requests are always allowed and this needs no change |
+| `TRUSTED_PROXY` | `false` | Trust `X-Forwarded-For` only when the direct TCP peer is allowlisted below |
+| `TRUSTED_PROXY_ADDRESSES` | empty | Comma-separated exact proxy IPv4/IPv6 addresses or CIDRs; proxies must overwrite XFF or append each hop |
+| `TRUSTED_IMPORT_HOSTS` | empty | Exact Agent-export DNS hostnames allowed to resolve to controlled enterprise-private addresses during URL import |
+| `TRUSTED_MCP_HOSTS` | empty | Exact remote MCP DNS hostnames allowed to resolve to controlled enterprise-private addresses |
+| `TRUSTED_A2A_ROUTE_HOSTS` | empty | Exact remote A2A DNS hostnames allowed as private-address exceptions when public-only mode is enabled |
+| `SCM_WORKSPACES_ALLOWED_ROOTS` | empty | Comma-separated absolute roots approved for non-admin custom Git workspaces; the built-in `~/.a2wave/workspaces` root is always allowed |
+| `ALLOW_PRIVATE_ROUTE_TARGETS` | `true` | Allow ordinary private/CGNAT/ULA remote A2A targets with per-hop validation and DNS pinning; set `false` for public-only mode (exact hostname exceptions remain available) |
+
+> Adjusting `AUTH_SESSION_TTL_DAYS` only affects new logins / newly issued tokens; to
+> immediately tighten already-issued tokens, combine it with logout, password change,
+> or `tokenVersion` revocation.
+
+## macOS Docker Desktop
+
+Docker Desktop does not share `/data`, and it reports bind mounts as root-owned —
+which the entrypoint refuses to adopt, so the container crash-loops without these.
+
+| Variable | Description |
+|------|------|
+| `A2WAVE_WORKSPACE_DIR` | Host directory for the workspace, e.g. `$HOME/a2wave-workspace` |
+| `A2WAVE_RUN_AS_UID` | UID the container process runs as, e.g. `10001` |
+| `A2WAVE_RUN_AS_GID` | GID the container process runs as, e.g. `10001` |
+
+## SCM sources
+
+Bootstrap a Git or Perforce checkout from the environment on first boot.
+
+### P4 SCM source (created automatically once all fields are filled in)
+
+| Variable | Description |
+|------|------|
+| `SCM_P4_PORT` | P4 server address (Perforce native protocol, not HTTP). Plaintext: `host:1666`, SSL: `ssl:host:1666` |
+| `SCM_P4_USER` | P4 username |
+| `SCM_P4_PASSWD` | P4 password |
+| `SCM_P4_CLIENT` | P4 Workspace name |
+| `SCM_P4_DEPOT_PATH` | Depot path, e.g. `//depot/main/...` |
+| `SCM_P4_LOCAL_PATH` | Local sync directory, defaults to `/app/data/p4-workspace` |
+| `SCM_P4_AUTO_SYNC` | Whether to auto-sync, defaults to `true` |
+
+### Git SCM source (created automatically once the URL is set)
+
+| Variable | Description |
+|------|------|
+| `SCM_GIT_REPO_URL` | Repository address |
+| `SCM_GIT_BRANCH` | Branch, defaults to `main` |
+| `SCM_GIT_USERNAME` | Username (HTTPS authentication) |
+| `SCM_GIT_PAT` | Personal Access Token |
+| `SCM_GIT_LOCAL_PATH` | Local clone directory, defaults to `/app/data/git-workspace` |
+| `SCM_GIT_AUTO_SYNC` | Whether to auto-sync, defaults to `true` |
+
+## Settings overrides (optional)
+
+| Variable | Description |
+|------|------|
+| `SETTINGS_GENERAL_WORKSPACE_PATH` | Workspace path |
+| `SETTINGS_GENERAL_TIMEOUT_MINUTES` | Global timeout (minutes) |
+| `SETTINGS_BRANDING_SUBTITLE` | Branding subtitle |
+| `SETTINGS_BRANDING_FAVICON_URL` | Favicon address |


### PR DESCRIPTION
## Why

Both READMEs had grown into reference manuals. Roughly 60 rows of environment-variable tables sat between a newcomer and their first Agent, and **Local Development** was buried below the PostgreSQL section — so the fastest path from clone to running was the hardest one to find.

## What changed

**Removed the Environment Variables sections** from both READMEs, along with the two `<details>` blocks (optional variables, SCM sources & settings overrides).

**Extracted rather than deleted.** The tables moved to a new `docs/agent/configuration.md`, linked from the Quick Start and the Documentation table. The trusted-host allowlists, proxy settings and SCM bootstrap variables are documented nowhere else, so dropping them outright would have lost real information.

**Reordered** to Quick Start → Local Development → Database Backend. Deployment concerns now come after getting started.

**Fixed the broken brand icon.** It used a repo-relative path (`apps/web/public/brand-icons/default.svg`), which breaks wherever the README renders detached from the repo tree. Both files now use an absolute `raw.githubusercontent.com` URL, verified returning 200.

**Trimmed prose** — EN 339 → 222 lines, ZH 258 → 199. Cuts were verbosity, not facts. Every warning survives: the `AUTH_SECRET` multi-replica requirement, the compose service-name trap, the absent SQLite → PostgreSQL migration path, and the open `ADMIN_PASSWORD` setup window.

## Verification

- Heading structure is 1:1 across both languages
- Every relative link target resolves on disk
- `check-forbidden-tokens`, `check-file-lines`, `check-docker-context` pass
- Pre-push typecheck green across all four projects

## Note for reviewers

Per `AGENTS.md`, changes touching the README's Local Development section should run `pnpm test:e2e:onboarding` — the only test that sees what a fresh clone sees. **I have not run it**; it clones, installs and boots from scratch, taking several minutes. Worth running before merge, since the Quick Start commands were restructured.

The image URL pins to `main`, so the icon tracks the branch rather than a fixed commit.

Manual update not needed — no user-facing functionality changed.