### PR TITLE
docs: drop the broken contrib.rocks contributors image

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,8 @@ By participating you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Contributors
 
-Thanks to everyone who has contributed to a2wave!
-
-<a href="https://github.com/LilithGames/a2wave/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=LilithGames/a2wave" alt="a2wave contributors" />
-</a>
+Thanks to everyone who has contributed to a2wave — see the
+[contributors graph](https://github.com/LilithGames/a2wave/graphs/contributors).
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -187,11 +187,8 @@ typecheck 门禁，以及人工评审。AI 辅助的贡献以同样的标准欢�
 
 ## 贡献者
 
-感谢每一位为 a2wave 做出贡献的伙伴！
-
-<a href="https://github.com/LilithGames/a2wave/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=LilithGames/a2wave" alt="a2wave contributors" />
-</a>
+感谢每一位为 a2wave 做出贡献的伙伴——完整名单见
+[贡献者图谱](https://github.com/LilithGames/a2wave/graphs/contributors)。
 
 ## 开源协议
 


### PR DESCRIPTION
Follow-up to #10 — the contributors image was still rendering broken.

## Cause

`contrib.rocks` returns **404** with the body `Repository not found: LilithGames/a2wave`, so both READMEs showed a broken-image icon in the Contributors section.

The repo is public and has one contributor, so this is not a permissions problem — the service simply has not indexed a repository created on 2026-08-06. Its response carries `cache-control: max-age=43200`, so the 404 sticks for up to 12 hours regardless.

## Fix

Replace the image with a plain link to GitHub's own contributors graph, in both `README.md` and `README.zh-CN.md`. That removes a third-party dependency from the README rather than waiting on a cache we do not control.

## Verification

- `curl` on the contrib.rocks URL: 404, `text/plain`, `Repository not found`
- No `contrib.rocks` reference remains in any markdown file
- Both language versions keep matching structure

Manual update not needed — no user-facing functionality changed.