### PR TITLE
chore: release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## v0.7.2
+
+- **`a2wave setup` now works with no flags**: `--image` is optional and defaults to the published image matching the CLI's own version (`ghcr.io/lilithgames/a2wave:<cli-version>`), so `npm i -g a2wave && a2wave setup` installs a running platform without cloning or building anything. Pass the flag only for a locally built or mirrored image.
+- **`a2wave setup --upgrade` picks up the same default**: `a2wave update` followed by `a2wave setup --upgrade` moves an existing install to the matching release without retyping the image ref.
+- **The container image is now public**: `ghcr.io/lilithgames/a2wave` can be pulled anonymously (tags `<version>` and `latest`); the READMEs document the CLI quick start and the direct `docker pull` path.
+
 ## v0.7.1
 
 First public release, shipping the `a2wave` CLI to npm and multi-arch container images to GHCR.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2wave",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Command-line client for the a2wave agent orchestration platform",
   "license": "Apache-2.0",
   "homepage": "https://github.com/LilithGames/a2wave#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2wave",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Bumps both manifests to 0.7.2 and adds the CHANGELOG section.

Headline change in this release: `a2wave setup` no longer requires `--image` — it defaults to the published GHCR image matching the CLI's own version, so `npm i -g a2wave && a2wave setup` installs a working platform with no clone and no build.

Release gates already run locally on this range:
- `pnpm test`: 7152 tests green across shared/cli/web/api/scripts
- `pnpm test:e2e`: 179 passed, 16 skipped (one flake retried green in isolation and in a full rerun)
- `check-forbidden-tokens --all`: clean
- End-to-end verified: a bare `a2wave setup` pulls `ghcr.io/lilithgames/a2wave:0.7.1` and reaches a healthy container

After merge: tag `v0.7.2` on main triggers Release + Docker + CLI Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)