### PR TITLE
fix(api): key Slack run dedup by message identity, not envelope event_id

### DIFF
--- a/apps/api/src/lib/__tests__/slack-service.test.ts
+++ b/apps/api/src/lib/__tests__/slack-service.test.ts
@@ -1,4 +1,30 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const reserveNativeChatRun = vi.hoisted(() => vi.fn())
+
+vi.mock('../native-chat-runner.js', () => ({
+  reserveNativeChatRun,
+}))
+
+// The Slack SDK must never reach the network: `start()` calls `auth.test()`,
+// which would hang indefinitely under fake timers.
+const socketStart = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+
+vi.mock('@slack/socket-mode', () => ({
+  SocketModeClient: class {
+    on = vi.fn()
+    start = socketStart
+    disconnect = vi.fn().mockResolvedValue(undefined)
+  },
+}))
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: class {
+    auth = { test: vi.fn().mockResolvedValue({ user_id: 'UBOT', team_id: 'T123' }) }
+    chat = { postMessage: vi.fn().mockResolvedValue(undefined) }
+    filesUploadV2 = vi.fn().mockResolvedValue(undefined)
+  },
+}))
 
 vi.mock('../artifact-links.js', () => ({
   buildArtifactLinkLinesSync: (
@@ -29,6 +55,14 @@ const config = {
 }
 
 describe('Slack service helpers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('always accepts human direct messages', async () => {
     expect(
       shouldTriggerSlackEvent(config, {
@@ -124,6 +158,406 @@ describe('Slack service helpers', () => {
     expect(stripSlackBotMention('<@UBOT> ask <@UOTHER> for help', 'UBOT')).toBe(
       'ask <@UOTHER> for help',
     )
+  })
+
+  it('derives one dedup key per message so a doubly-delivered mention runs once', async () => {
+    reserveNativeChatRun.mockReset()
+    reserveNativeChatRun.mockResolvedValue({ status: 'started', runId: 'run_1' })
+    const manager = new SlackConnectionManager()
+    const connection = {
+      config: {
+        appId: 'A123',
+        appToken: 'xapp-test',
+        botToken: 'xoxb-test',
+        groupTriggerOnAt: true,
+        groupTriggerOnNewMessage: true,
+        groupReplyMode: 'new',
+        p2pReplyMode: 'new',
+        sendArtifactsAsFile: true,
+      },
+      botUserId: 'UBOT',
+      teamId: 'T123',
+    }
+    const handleEnvelope = (
+      manager as unknown as {
+        handleEnvelope: (agentId: string, connection: unknown, envelope: unknown) => Promise<void>
+      }
+    ).handleEnvelope.bind(manager)
+
+    // One user @-mention in a channel that also subscribes message.channels:
+    // Slack delivers an app_mention envelope and a message envelope, each with
+    // its own event_id, but both describe the same message ts.
+    const event = {
+      channel: 'C123',
+      channel_type: 'channel',
+      user: 'U123',
+      text: '<@UBOT> hello',
+      ts: '1710000000.000001',
+    }
+    await handleEnvelope('agt_1', connection, {
+      ack: vi.fn().mockResolvedValue(undefined),
+      body: { event_id: 'Ev_APP_MENTION', team_id: 'T123' },
+      event: { ...event, type: 'app_mention' },
+    })
+    await handleEnvelope('agt_1', connection, {
+      ack: vi.fn().mockResolvedValue(undefined),
+      body: { event_id: 'Ev_MESSAGE', team_id: 'T123' },
+      event: { ...event, type: 'message' },
+    })
+
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    // The message envelope supersedes the deferred mention, so only one
+    // reservation is made — and it is keyed by message identity, not by the
+    // per-envelope event_id, so any redelivery collapses onto it too.
+    expect(reserveNativeChatRun).toHaveBeenCalledTimes(1)
+    const { eventId } = reserveNativeChatRun.mock.calls[0]?.[0] as { eventId: string }
+    expect(eventId).toBe('slack:T123:C123:1710000000.000001')
+  })
+
+  it('prefers the message envelope so a mentioned file upload keeps its attachments', async () => {
+    reserveNativeChatRun.mockReset()
+    reserveNativeChatRun.mockResolvedValue({ status: 'started', runId: 'run_1' })
+    const manager = new SlackConnectionManager()
+    const connection = {
+      config: {
+        appId: 'A123',
+        appToken: 'xapp-test',
+        botToken: 'xoxb-test',
+        groupTriggerOnAt: true,
+        groupTriggerOnNewMessage: true,
+        groupReplyMode: 'new',
+        p2pReplyMode: 'new',
+        sendArtifactsAsFile: true,
+      },
+      botUserId: 'UBOT',
+      teamId: 'T123',
+    }
+    const handleEnvelope = (
+      manager as unknown as {
+        handleEnvelope: (agentId: string, connection: unknown, envelope: unknown) => Promise<void>
+      }
+    ).handleEnvelope.bind(manager)
+
+    // Slack's app_mention payload carries no `files` array, so if that envelope
+    // wins the dedup race the upload is silently dropped.
+    await handleEnvelope('agt_1', connection, {
+      ack: vi.fn().mockResolvedValue(undefined),
+      body: { event_id: 'Ev_APP_MENTION', team_id: 'T123' },
+      event: {
+        type: 'app_mention',
+        channel: 'C123',
+        user: 'U123',
+        text: '<@UBOT> review this',
+        ts: '1710000000.000001',
+      },
+    })
+
+    expect(reserveNativeChatRun).not.toHaveBeenCalled()
+
+    await handleEnvelope('agt_1', connection, {
+      ack: vi.fn().mockResolvedValue(undefined),
+      body: { event_id: 'Ev_MESSAGE', team_id: 'T123' },
+      event: {
+        type: 'message',
+        channel: 'C123',
+        channel_type: 'channel',
+        user: 'U123',
+        text: '<@UBOT> review this',
+        ts: '1710000000.000001',
+        subtype: 'file_share',
+        files: [{ id: 'F123', name: 'report.pdf', mimetype: 'application/pdf', size: 42 }],
+      },
+    })
+
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(reserveNativeChatRun).toHaveBeenCalledTimes(1)
+    const reserved = reserveNativeChatRun.mock.calls[0]?.[0] as {
+      nativeAttachments: unknown[]
+    }
+    expect(reserved.nativeAttachments).toHaveLength(1)
+  })
+
+  it('still triggers on app_mention when message.channels is not subscribed', async () => {
+    reserveNativeChatRun.mockReset()
+    reserveNativeChatRun.mockResolvedValue({ status: 'started', runId: 'run_1' })
+    const manager = new SlackConnectionManager()
+    const connection = {
+      config: {
+        appId: 'A123',
+        appToken: 'xapp-test',
+        botToken: 'xoxb-test',
+        groupTriggerOnAt: true,
+        groupTriggerOnNewMessage: false,
+        groupReplyMode: 'new',
+        p2pReplyMode: 'new',
+        sendArtifactsAsFile: true,
+      },
+      botUserId: 'UBOT',
+      teamId: 'T123',
+    }
+    const handleEnvelope = (
+      manager as unknown as {
+        handleEnvelope: (agentId: string, connection: unknown, envelope: unknown) => Promise<void>
+      }
+    ).handleEnvelope.bind(manager)
+
+    // The documented default workspace setup subscribes app_mention only, so no
+    // message envelope ever follows. Dropping it outright would break every
+    // existing channel deployment.
+    await handleEnvelope('agt_1', connection, {
+      ack: vi.fn().mockResolvedValue(undefined),
+      body: { event_id: 'Ev_APP_MENTION', team_id: 'T123' },
+      event: {
+        type: 'app_mention',
+        channel: 'C123',
+        user: 'U123',
+        text: '<@UBOT> hello',
+        ts: '1710000000.000001',
+      },
+    })
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(reserveNativeChatRun).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops deferred mentions when the Agent connection stops', async () => {
+    reserveNativeChatRun.mockReset()
+    reserveNativeChatRun.mockResolvedValue({ status: 'started', runId: 'run_1' })
+    const manager = new SlackConnectionManager()
+    const config = {
+      appId: 'A123',
+      appToken: 'xapp-test',
+      botToken: 'xoxb-test',
+      groupTriggerOnAt: true,
+      groupTriggerOnNewMessage: false,
+      groupReplyMode: 'new',
+      p2pReplyMode: 'new',
+      sendArtifactsAsFile: true,
+    }
+    const connection = { config, botUserId: 'UBOT', teamId: 'T123' }
+    ;(manager as unknown as { connections: Map<string, unknown> }).connections.set('agt_1', {
+      ...connection,
+      socket: { disconnect: vi.fn().mockResolvedValue(undefined) },
+    })
+    const handleEnvelope = (
+      manager as unknown as {
+        handleEnvelope: (agentId: string, connection: unknown, envelope: unknown) => Promise<void>
+      }
+    ).handleEnvelope.bind(manager)
+
+    await handleEnvelope('agt_1', connection, {
+      ack: vi.fn().mockResolvedValue(undefined),
+      body: { event_id: 'Ev_APP_MENTION', team_id: 'T123' },
+      event: {
+        type: 'app_mention',
+        channel: 'C123',
+        user: 'U123',
+        text: '<@UBOT> hello',
+        ts: '1710000000.000001',
+      },
+    })
+    const pending = manager as unknown as {
+      pendingMentions: Map<string, unknown>
+      connections: Map<string, unknown>
+    }
+    expect([...pending.pendingMentions.keys()]).toEqual(['agt_1 slack:T123:C123:1710000000.000001'])
+    expect(pending.connections.has('agt_1')).toBe(true)
+
+    await manager.stop('agt_1')
+    expect([...pending.pendingMentions.keys()]).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(reserveNativeChatRun).not.toHaveBeenCalled()
+  })
+
+  it('leaves a failed deferred mention un-acked so Slack redelivers it', async () => {
+    reserveNativeChatRun.mockReset()
+    reserveNativeChatRun.mockRejectedValue(new Error('database unavailable'))
+    const manager = new SlackConnectionManager()
+    const connection = {
+      config: {
+        appId: 'A123',
+        appToken: 'xapp-test',
+        botToken: 'xoxb-test',
+        groupTriggerOnAt: true,
+        groupTriggerOnNewMessage: false,
+        groupReplyMode: 'new',
+        p2pReplyMode: 'new',
+        sendArtifactsAsFile: true,
+      },
+      botUserId: 'UBOT',
+      teamId: 'T123',
+    }
+    const handleEnvelope = (
+      manager as unknown as {
+        handleEnvelope: (agentId: string, connection: unknown, envelope: unknown) => Promise<void>
+      }
+    ).handleEnvelope.bind(manager)
+
+    const ack = vi.fn().mockResolvedValue(undefined)
+    await handleEnvelope('agt_1', connection, {
+      ack,
+      body: { event_id: 'Ev_APP_MENTION', team_id: 'T123' },
+      event: {
+        type: 'app_mention',
+        channel: 'C123',
+        user: 'U123',
+        text: '<@UBOT> hello',
+        ts: '1710000000.000001',
+      },
+    })
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(reserveNativeChatRun).toHaveBeenCalledTimes(1)
+    // Acking here would tell Slack the mention was handled and lose it forever.
+    expect(ack).not.toHaveBeenCalled()
+  })
+
+  it('acks a superseded mention and drops timers when the connection is replaced', async () => {
+    reserveNativeChatRun.mockReset()
+    reserveNativeChatRun.mockResolvedValue({ status: 'started', runId: 'run_1' })
+    const manager = new SlackConnectionManager()
+    const connection = {
+      config: {
+        appId: 'A123',
+        appToken: 'xapp-test',
+        botToken: 'xoxb-test',
+        groupTriggerOnAt: true,
+        groupTriggerOnNewMessage: true,
+        groupReplyMode: 'new',
+        p2pReplyMode: 'new',
+        sendArtifactsAsFile: true,
+      },
+      botUserId: 'UBOT',
+      teamId: 'T123',
+    }
+    const handleEnvelope = (
+      manager as unknown as {
+        handleEnvelope: (agentId: string, connection: unknown, envelope: unknown) => Promise<void>
+      }
+    ).handleEnvelope.bind(manager)
+
+    const mentionAck = vi.fn().mockResolvedValue(undefined)
+    const event = {
+      channel: 'C123',
+      channel_type: 'channel',
+      user: 'U123',
+      text: '<@UBOT> hello',
+      ts: '1710000000.000001',
+    }
+    await handleEnvelope('agt_1', connection, {
+      ack: mentionAck,
+      body: { event_id: 'Ev_APP_MENTION', team_id: 'T123' },
+      event: { ...event, type: 'app_mention' },
+    })
+    await handleEnvelope('agt_1', connection, {
+      ack: vi.fn().mockResolvedValue(undefined),
+      body: { event_id: 'Ev_MESSAGE', team_id: 'T123' },
+      event: { ...event, type: 'message' },
+    })
+
+    // The message envelope took over, so the mention must be acknowledged
+    // rather than left for Slack to redeliver.
+    expect(mentionAck).toHaveBeenCalledTimes(1)
+
+    const pending = manager as unknown as { pendingMentions: Map<string, unknown> }
+    expect([...pending.pendingMentions.keys()]).toEqual([])
+  })
+
+  it('drops deferred mentions belonging to a replaced connection', async () => {
+    reserveNativeChatRun.mockReset()
+    reserveNativeChatRun.mockResolvedValue({ status: 'started', runId: 'run_1' })
+    const manager = new SlackConnectionManager()
+    const config = {
+      appId: 'A123',
+      appToken: 'xapp-test',
+      botToken: 'xoxb-test',
+      groupTriggerOnAt: true,
+      groupTriggerOnNewMessage: false,
+      groupReplyMode: 'new',
+      p2pReplyMode: 'new',
+      sendArtifactsAsFile: true,
+    }
+    const connection = { config, botUserId: 'UBOT', teamId: 'T123' }
+    const internals = manager as unknown as {
+      connections: Map<string, unknown>
+      pendingMentions: Map<string, unknown>
+      handleEnvelope: (agentId: string, connection: unknown, envelope: unknown) => Promise<void>
+    }
+    internals.connections.set('agt_1', {
+      ...connection,
+      socket: { disconnect: vi.fn().mockResolvedValue(undefined) },
+    })
+
+    await internals.handleEnvelope.call(manager, 'agt_1', connection, {
+      ack: vi.fn().mockResolvedValue(undefined),
+      body: { event_id: 'Ev_APP_MENTION', team_id: 'T123' },
+      event: {
+        type: 'app_mention',
+        channel: 'C123',
+        user: 'U123',
+        text: '<@UBOT> hello',
+        ts: '1710000000.000001',
+      },
+    })
+    expect([...internals.pendingMentions.keys()]).toHaveLength(1)
+
+    // Restarting the Agent replaces the connection; the old timer closes over a
+    // disconnected socket and must not fire against it.
+    await manager.start('agt_1', config).catch(() => undefined)
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(reserveNativeChatRun).not.toHaveBeenCalled()
+    expect([...internals.pendingMentions.keys()]).toEqual([])
+  })
+
+  it('drops deferred mentions when startup fails', async () => {
+    reserveNativeChatRun.mockReset()
+    reserveNativeChatRun.mockResolvedValue({ status: 'started', runId: 'run_1' })
+    const manager = new SlackConnectionManager()
+    const config = {
+      appId: 'A123',
+      appToken: 'xapp-test',
+      botToken: 'xoxb-test',
+      groupTriggerOnAt: true,
+      groupTriggerOnNewMessage: false,
+      groupReplyMode: 'new',
+      p2pReplyMode: 'new',
+      sendArtifactsAsFile: true,
+    }
+    const internals = manager as unknown as {
+      pendingMentions: Map<string, unknown>
+      handleEnvelope: (agentId: string, connection: unknown, envelope: unknown) => Promise<void>
+    }
+
+    // Socket listeners are attached before start() resolves, so an event can be
+    // deferred against a connection whose startup then fails.
+    await internals.handleEnvelope.call(
+      manager,
+      'agt_1',
+      { config, botUserId: 'UBOT', teamId: 'T123' },
+      {
+        ack: vi.fn().mockResolvedValue(undefined),
+        body: { event_id: 'Ev_APP_MENTION', team_id: 'T123' },
+        event: {
+          type: 'app_mention',
+          channel: 'C123',
+          user: 'U123',
+          text: '<@UBOT> hello',
+          ts: '1710000000.000001',
+        },
+      },
+    )
+    expect([...internals.pendingMentions.keys()]).toHaveLength(1)
+
+    socketStart.mockRejectedValueOnce(new Error('socket refused'))
+    await expect(manager.start('agt_1', config)).rejects.toThrow('socket refused')
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(reserveNativeChatRun).not.toHaveBeenCalled()
+    expect([...internals.pendingMentions.keys()]).toEqual([])
   })
 
   it('neutralizes outbound Slack mentions without changing ordinary links', async () => {

--- a/apps/api/src/lib/slack-service.ts
+++ b/apps/api/src/lib/slack-service.ts
@@ -73,6 +73,24 @@ export function shouldTriggerSlackEvent(
   return (config.groupTriggerOnAt && isMentioned) || config.groupTriggerOnNewMessage
 }
 
+/**
+ * Key the run reservation by message identity, never by `event_id`.
+ *
+ * A single @-mention in a channel that subscribes both `app_mention` and
+ * `message.channels` is delivered as two envelopes carrying two *different*
+ * `event_id`s. Keying on the envelope therefore reserved two runs for one
+ * message, and the agent answered twice at twice the token cost. Team + channel
+ * + `ts` names the message itself, so every duplicate delivery collapses onto
+ * the `runs_native_chat_event_unique` index.
+ *
+ * Slack redeliveries of the *same* envelope already collapse here too, so this
+ * key strictly widens the existing dedup guarantee rather than trading one
+ * class of duplicate for another.
+ */
+export function buildSlackDedupKey(teamId: string, channel: string, ts?: string): string {
+  return `slack:${teamId}:${channel}:${ts ?? 'unknown'}`
+}
+
 export function extractSlackNativeAttachments(
   event: Pick<SlackMessageEvent, 'files'>,
 ): NativeChatAttachment[] {
@@ -147,9 +165,24 @@ export function neutralizeSlackMentions(text: string): string {
   return text.replace(/<(?=[!@])/g, '<\u200b')
 }
 
+/**
+ * How long an `app_mention` waits for the richer `message` twin to arrive.
+ *
+ * Both envelopes describe the same message, but only `message` carries
+ * `files` and `channel_type`. Slack emits them together, so a short wait lets
+ * the better payload win the dedup race deterministically instead of by
+ * arrival order. Workspaces that subscribe `app_mention` alone simply see the
+ * timer elapse and proceed unchanged.
+ */
+const SLACK_APP_MENTION_GRACE_MS = 1_500
+
 export class SlackConnectionManager {
   private readonly connections = new Map<string, SlackConnection>()
   private readonly appHolders = new Map<string, string>()
+  private readonly pendingMentions = new Map<
+    string,
+    { timer: ReturnType<typeof setTimeout>; ack: () => Promise<void> }
+  >()
 
   async start(agentId: string, rawConfig: SlackConfig | Record<string, unknown>): Promise<void> {
     const config = slackConfigSchema.parse(rawConfig)
@@ -165,6 +198,9 @@ export class SlackConnectionManager {
         this.appHolders.delete(previous.config.appId)
       }
       previous.socketOpen = false
+      // The replaced connection's deferred mentions close over its stale socket
+      // and config, so they must not survive it.
+      this.clearPendingMentions(agentId)
     }
     // Reserve synchronously before the first await so concurrent starters cannot both pass.
     this.appHolders.set(config.appId, agentId)
@@ -220,6 +256,9 @@ export class SlackConnectionManager {
     } catch (error) {
       this.connections.delete(agentId)
       if (this.appHolders.get(config.appId) === agentId) this.appHolders.delete(config.appId)
+      // Listeners are attached before `socket.start()`, so a failed startup can
+      // still have deferred a mention against the connection being discarded.
+      this.clearPendingMentions(agentId)
       throw error
     }
   }
@@ -253,33 +292,97 @@ export class SlackConnectionManager {
       senderUserId: event.user ?? '',
       chatType: isDirectMessage ? 'p2p' : 'channel',
     })
-    const eventId =
-      envelope.body?.event_id ??
-      `slack:${connection.teamId}:${event.channel}:${event.ts ?? 'unknown'}`
+    const eventId = buildSlackDedupKey(
+      envelope.body?.team_id ?? connection.teamId,
+      event.channel,
+      event.ts,
+    )
+
+    // A `message` envelope supersedes any deferred `app_mention` for the same
+    // message: it carries the attachments the mention payload lacks. Scope the
+    // key by Agent so two Agents in one workspace never cancel each other.
+    const pendingKey = `${agentId} ${eventId}`
+    const deferred = this.pendingMentions.get(pendingKey)
+    if (deferred) {
+      clearTimeout(deferred.timer)
+      this.pendingMentions.delete(pendingKey)
+      // The superseding envelope owns this message now, so acknowledge the
+      // mention we are dropping instead of leaving it for redelivery.
+      await deferred
+        .ack()
+        .catch((error) =>
+          logger.warn({ error, agentId, eventId }, 'Failed to ack a superseded Slack mention'),
+        )
+    }
+    if (event.type === 'app_mention') {
+      // Register before the first await: `stop()` sweeps this map, and a timer
+      // armed after that sweep would outlive the connection it belongs to.
+      const timer = setTimeout(() => {
+        this.pendingMentions.delete(pendingKey)
+        void this.reserve(agentId, eventId, {
+          connection,
+          event,
+          intent,
+          ctx: ctx as RunChannelContextSlack,
+          displayName,
+          nativeAttachments,
+        })
+          // Acknowledge only once the reservation has committed, exactly as the
+          // immediate path does: a transient failure must leave the envelope
+          // un-acked so Slack redelivers rather than dropping the mention.
+          .then(() => envelope.ack())
+          .catch((error) =>
+            logger.error({ error, agentId, eventId }, 'Failed to reserve deferred Slack mention'),
+          )
+      }, SLACK_APP_MENTION_GRACE_MS)
+      // Never hold the process open for a pending mention.
+      timer.unref?.()
+      this.pendingMentions.set(pendingKey, { timer, ack: envelope.ack })
+      return
+    }
 
     try {
-      const result = await reserveNativeChatRun({
-        agentId,
-        source: 'slack',
-        eventId,
-        conversationId: buildSlackConversationId(connection.teamId, event),
+      await this.reserve(agentId, eventId, {
+        connection,
+        event,
         intent,
-        channel: ctx as RunChannelContextSlack,
+        ctx: ctx as RunChannelContextSlack,
         displayName,
         nativeAttachments,
       })
       // Acknowledge only after the unique event reservation has committed.
       await envelope.ack()
-      if (result.status === 'queue_full') {
-        await this.sendMessageByContext(
-          agentId,
-          ctx as RunChannelContextSlack,
-          'Agent queue is full.',
-        )
-      }
     } catch (error) {
       // No acknowledgement on persistence failure: Slack will redeliver the event.
       logger.error({ error, agentId, eventId }, 'Failed to reserve Slack event')
+    }
+  }
+
+  private async reserve(
+    agentId: string,
+    eventId: string,
+    input: {
+      connection: SlackConnection
+      event: SlackMessageEvent
+      intent: string
+      ctx: RunChannelContextSlack
+      displayName?: string | null
+      nativeAttachments: NativeChatAttachment[]
+    },
+  ): Promise<void> {
+    const { connection, event, intent, ctx, displayName, nativeAttachments } = input
+    const result = await reserveNativeChatRun({
+      agentId,
+      source: 'slack',
+      eventId,
+      conversationId: buildSlackConversationId(connection.teamId, event),
+      intent,
+      channel: ctx,
+      displayName,
+      nativeAttachments,
+    })
+    if (result.status === 'queue_full') {
+      await this.sendMessageByContext(agentId, ctx, 'Agent queue is full.')
     }
   }
 
@@ -385,11 +488,24 @@ export class SlackConnectionManager {
       this.appHolders.delete(connection.config.appId)
     }
     connection.socketOpen = false
+    // Drop deferred mentions: a stopped Agent must not start a run afterwards.
+    this.clearPendingMentions(agentId)
     await connection.socket
       .disconnect()
       .catch((error) =>
         logger.warn({ error, agentId }, 'Failed to disconnect Slack Socket Mode cleanly'),
       )
+  }
+
+  private clearPendingMentions(agentId: string): void {
+    for (const [key, pending] of this.pendingMentions) {
+      if (key.startsWith(`${agentId} `)) {
+        clearTimeout(pending.timer)
+        this.pendingMentions.delete(key)
+        // Leave the envelope un-acked: the Agent is going away, so let Slack
+        // redeliver to whatever connection takes over.
+      }
+    }
   }
 
   stopAll(): void {


### PR DESCRIPTION
## Problem

A single Slack @-mention triggered **two Agent runs** — two replies to the user, double the tokens.

When a workspace subscribes both `app_mention` and `message.channels`, Slack delivers one channel mention as **two envelopes**. `SocketModeClient` dispatches on `payload.event.type` ([`SocketModeClient.js:342`](https://github.com/slackapi/node-slack-sdk/blob/main/packages/socket-mode/src/SocketModeClient.ts)), so the `app_mention` envelope hit one listener and the `message` envelope hit the other — and both were routed into the same handler:

```ts
socket.on('message', handleEvent)
socket.on('app_mention', handleEvent)
```

`shouldTriggerSlackEvent` never inspects `event.type`, so both passed the trigger gate. The reservation key was then taken from `envelope.body.event_id`, and **Slack assigns the two envelopes different `event_id`s** — so the unique index on `trigger_event_id` saw two distinct keys and could not collapse them. The `slack:team:channel:ts` fallback that would have caught this was effectively dead code: `event_id` is always present on a real envelope.

**One correction to how this was originally reported:** it is not limited to workspaces with `groupTriggerOnNewMessage` enabled. The trigger condition is subscribing `message.channels` *at all*. On the default `groupTriggerOnAt` path the `message` envelope still carries `<@BOT>` in its text, so `isMentioned` is true and it double-fires too. The toggle decides whether *non-mention* messages run, not whether a mention runs twice.

## Fix

Key the reservation by **message identity** (`team:channel:ts`) instead of envelope identity. This *strictly widens* the existing guarantee — same-envelope redeliveries already collapsed onto the index, and now cross-envelope duplicates do as well. This mirrors #19, which fixed the same class of bug (dedup keyed at the wrong granularity) on the Feishu side.

Two further defects surfaced while fixing this, both of which the dedup key alone does **not** solve:

**1. `app_mention` payloads carry no `files` array.** With only the dedup key in place, whichever envelope won the race decided whether an @-mention *with an upload* kept its attachments — if `app_mention` won, the file was silently dropped. A mention now waits briefly (1.5s) for the richer `message` twin and is superseded by it when it arrives.

Workspaces subscribing `app_mention` **only** — the setup [the manual documents](apps/web/src/content/manual/zh/12-triggers.md) — simply see the timer elapse and behave exactly as before. This is covered by a dedicated test, because dropping the `app_mention` envelope outright (the other obvious fix) would break every existing channel deployment.

**2. Deferred mentions outlived their connection.** They are now swept on `stop()`, on connection replacement in `start()`, and on the `start()` **failure** path — listeners attach before `socket.start()`, so a mention can already be pending when startup throws.

### Ack semantics

Slack's redelivery contract is preserved throughout:

| Path | Behaviour | Why |
|---|---|---|
| Deferred mention fires | ack **after** the reservation commits | A transient DB failure must leave the envelope un-acked so Slack redelivers, rather than losing the message |
| Mention superseded by `message` | acked by the superseding envelope | Otherwise Slack would redeliver a mention we deliberately dropped |
| Mention swept (stop / replace / failed start) | deliberately **not** acked | Redelivery should reach whatever connection takes over — safe now that the dedup key is message-scoped |

## Testing

TDD throughout: every regression test was confirmed **red before** its fix and green after. I verified this individually by reverting each fix in isolation and re-running.

- `pnpm test` (api) — **5445/5445 passing, 348/348 files**
- `pnpm typecheck` — fully green
- `biome check` on both touched files — **0 diagnostics**
- All four gate scripts (`arch-rules` / `forbidden-tokens` / `file-lines` / `docker-context`) exit 0

Six new tests cover: cross-envelope dedup, attachment preservation, `app_mention`-only workspaces, failed-reservation ack semantics, superseded-mention ack, and timer cleanup on stop / replacement / failed startup.

### Reviewed with `codex exec review`

Two rounds against the working tree. Codex confirmed the dedup and ordering logic correct, and found **three real defects that I fixed in response**:

1. **[P1]** The deferred path acked *before* the reservation committed — a regression I introduced, which would lose the message permanently on a transient DB failure. This is what motivated the ack table above.
2. **[P2]** Pending timers survived connection replacement in `start()` (I had only swept in `stop()`).
3. **[P2]** Pending timers survived a *failed* `start()`.

It also caught a **flaky test** that passed 3/3 locally for me: my connection-replacement test called the real `manager.start()`, which reaches `WebClient.auth.test()` over the network and hangs under fake timers. `@slack/socket-mode` and `@slack/web-api` are now mocked — the test file went from 3.2s to 0.6s and is deterministic.

## Notes

Manual update not needed — no user-visible surface changed; this restores intended behaviour. The Slack setup steps in the manual (including `message.channels`) were already correct.
