### PR TITLE
fix(api): never persist the masked placeholder as a real secret

### DIFF
--- a/apps/api/src/lib/__tests__/agent-import-native-chat.test.ts
+++ b/apps/api/src/lib/__tests__/agent-import-native-chat.test.ts
@@ -180,4 +180,173 @@ describe('agent import native chat credentials', () => {
     })
     expect(insertedAgent.a2aRouteTargets[0]).not.toHaveProperty('apiKey')
   })
+
+  /**
+   * Export masks sensitive env values to '********', so importing one verbatim
+   * would hand the new Agent a literal placeholder as its credential — the run
+   * fails to authenticate while the UI shows a configured-looking masked field.
+   * Clear it instead, exactly as the masked A2A key is dropped above.
+   */
+  it('clears masked sensitive env values instead of importing the placeholder', async () => {
+    const result = await importAgentFromZip(
+      buildNativeChatExportZip(null, {
+        env: {
+          API_TOKEN: { value: '********', sensitive: true },
+          LOG_LEVEL: { value: 'debug', sensitive: false },
+        },
+      }),
+      'usr_test',
+    )
+    const insertedAgent = insertValues.mock.calls[0]?.[0] as {
+      env: Record<string, { value: string; sensitive: boolean }>
+    }
+
+    expect(insertedAgent.env).toEqual({
+      API_TOKEN: { value: '', sensitive: true },
+      LOG_LEVEL: { value: 'debug', sensitive: false },
+    })
+    expect(result.warnings).toContain(
+      'Sensitive environment variable values are not imported; re-enter them before use',
+    )
+  })
+
+  /**
+   * Export masks on `v.sensitive || isSensitiveKey(k)`, so a key-name-detected secret
+   * is exported as dots while keeping `sensitive: false`. Clearing only on the flag
+   * would import that placeholder as the credential itself — and because the entry is
+   * not sensitive the UI renders it in plaintext as '********', which reads as a
+   * deliberate mask rather than the broken credential it is.
+   */
+  it('clears a key-name-detected masked value that carries sensitive:false', async () => {
+    const result = await importAgentFromZip(
+      buildNativeChatExportZip(null, {
+        env: {
+          API_KEY: { value: '********', sensitive: false },
+          LOG_LEVEL: { value: 'debug', sensitive: false },
+        },
+      }),
+      'usr_test',
+    )
+    const insertedAgent = insertValues.mock.calls[0]?.[0] as {
+      env: Record<string, { value: string; sensitive: boolean }>
+    }
+
+    // Promoted to sensitive: the export classified it as a secret by name, and dropping
+    // that classification means the value the user retypes is stored unmasked and served
+    // in plaintext by GET /agents/:id — a worse leak than the placeholder it replaced.
+    expect(insertedAgent.env).toEqual({
+      API_KEY: { value: '', sensitive: true },
+      LOG_LEVEL: { value: 'debug', sensitive: false },
+    })
+    expect(result.warnings).toContain(
+      'Sensitive environment variable values are not imported; re-enter them before use',
+    )
+  })
+
+  /**
+   * A non-sensitive variable whose name looks harmless may legitimately hold the
+   * literal text — export never masked it, so import must not erase it.
+   */
+  it('keeps a literal placeholder typed into a non-secret-looking variable', async () => {
+    await importAgentFromZip(
+      buildNativeChatExportZip(null, {
+        env: { MASK_STYLE: { value: '********', sensitive: false } },
+      }),
+      'usr_test',
+    )
+    const insertedAgent = insertValues.mock.calls[0]?.[0] as {
+      env: Record<string, { value: string; sensitive: boolean }>
+    }
+
+    expect(insertedAgent.env).toEqual({ MASK_STYLE: { value: '********', sensitive: false } })
+  })
+
+  /**
+   * `sanitizeMcpServer` runs `maskAllStringRecord` over env and headers, replacing every
+   * value unconditionally — so a masked value on import is never restorable. Writing it
+   * back verbatim gives the new server '********' as its Authorization header: it renders
+   * fully configured, and the only symptom is a 401 from the remote on every run.
+   */
+  it('clears masked MCP env and headers instead of importing the placeholders', async () => {
+    const zip = new AdmZip()
+    zip.addFile(
+      'manifest.json',
+      Buffer.from(JSON.stringify({ version: '1.0', exportedAt: '2026-01-01' })),
+    )
+    zip.addFile(
+      'mcp-servers/remote.json',
+      Buffer.from(
+        JSON.stringify({
+          name: 'Remote MCP',
+          description: null,
+          type: 'http',
+          url: 'https://mcp.example.com/sse',
+          headers: { Authorization: '********' },
+          env: { API_TOKEN: '********' },
+          isEnabled: true,
+          groupConfig: null,
+        }),
+      ),
+    )
+    zip.addFile(
+      'agent.json',
+      Buffer.from(
+        JSON.stringify({
+          name: 'Agent with MCP',
+          description: null,
+          type: 'cursor',
+          icon: 'bot',
+          systemPrompt: null,
+          config: {},
+          workspaceType: 'temp',
+          maxConcurrency: 1,
+          env: null,
+          feishuConfig: null,
+          slackConfig: null,
+          discordConfig: null,
+          scheduleConfig: null,
+          publishChannels: ['api'],
+          oauthAccessMode: 'all_idaas_users',
+          a2aSkills: null,
+          a2aRouteTargets: null,
+          showLocalChildOutput: null,
+          showRemoteChildOutput: null,
+          mcpServerRefs: ['remote.json'],
+          skillRefs: [],
+          kbDocumentRefs: [],
+          providerRef: null,
+          scmSourceRef: null,
+        }),
+      ),
+    )
+
+    const result = await importAgentFromZip(zip.toBuffer(), 'usr_test')
+    const insertedMcp = insertValues.mock.calls[0]?.[0] as {
+      headers: Record<string, string> | null
+      env: Record<string, string> | null
+    }
+
+    expect(insertedMcp.headers).toEqual({ Authorization: '' })
+    expect(insertedMcp.env).toEqual({ API_TOKEN: '' })
+    expect(result.warnings).toContain(
+      'MCP Server credentials are not imported; re-enter them before use',
+    )
+  })
+
+  it('imports a plain env untouched and warns nothing about it', async () => {
+    const result = await importAgentFromZip(
+      buildNativeChatExportZip(null, {
+        env: { LOG_LEVEL: { value: 'debug', sensitive: false } },
+      }),
+      'usr_test',
+    )
+    const insertedAgent = insertValues.mock.calls[0]?.[0] as {
+      env: Record<string, { value: string; sensitive: boolean }>
+    }
+
+    expect(insertedAgent.env).toEqual({ LOG_LEVEL: { value: 'debug', sensitive: false } })
+    expect(result.warnings).not.toContain(
+      'Sensitive environment variable values are not imported; re-enter them before use',
+    )
+  })
 })

--- a/apps/api/src/lib/agent-import.ts
+++ b/apps/api/src/lib/agent-import.ts
@@ -26,6 +26,7 @@ import {
   REBINDABLE_SYSTEM_SKILL_NAMES,
   computeExportedSkillPackageDigest,
   isRetiredOauthAccessMode,
+  isSensitiveKey,
 } from './agent-export.js'
 import { createId } from './id.js'
 import { resolveUsageScope } from './mcp-stdio.js'
@@ -305,6 +306,35 @@ export function preflightAgentImportArchive(
 }
 
 /**
+ * Blank out placeholder values in an imported MCP `env` / `headers` record.
+ *
+ * `sanitizeMcpServer` masks these with `maskAllStringRecord`, which replaces *every*
+ * value unconditionally — so a placeholder arriving here can never be restored, and
+ * writing it through would make '********' the credential itself. The field then reads
+ * as configured while the remote answers 401 on every run. Blanking leaves the key
+ * visible (the operator still sees which headers the server expects) with an obviously
+ * empty value, which is the honest state.
+ */
+function clearMaskedRecord<T extends Record<string, string> | null | undefined>(record: T): T {
+  if (!record) return record
+  let cleared = false
+  const next = Object.fromEntries(
+    Object.entries(record).map(([key, value]) => {
+      if (value !== MASKED_CREDENTIAL) return [key, value]
+      cleared = true
+      return [key, '']
+    }),
+  )
+  return (cleared ? next : record) as T
+}
+
+/** True when any imported MCP `env` / `headers` value is a masked placeholder. */
+function hasMaskedMcpCredential(mcp: ExportedMcpServer): boolean {
+  const values = [...Object.values(mcp.headers ?? {}), ...Object.values(mcp.env ?? {})]
+  return values.some((value) => value === MASKED_CREDENTIAL)
+}
+
+/**
  * True when an imported MCP server would introduce stdio command execution
  * (host RCE) — a top-level stdio server, or a group with an inline stdio
  * backend. Import must reject these for non-admins, mirroring the create gate,
@@ -408,6 +438,9 @@ export async function importAgentFromZip(
     // 3. Import MCP Servers
     const mcpIdMap = new Map<string, string>() // ref filename -> new ID
     const importedMcps: Array<{ id: string; name: string }> = []
+    // One warning covers the whole import: a bundle with ten servers should not stack
+    // ten identical toasts.
+    let warnedMaskedMcpCredential = false
 
     for (const ref of exportedAgent.mcpServerRefs) {
       if (!ref || ref.includes('/') || ref.includes('\\') || ref === '.' || ref === '..') {
@@ -428,6 +461,11 @@ export async function importAgentFromZip(
       }
       assertImportedMcpUrlsSafe(mcpData)
 
+      if (hasMaskedMcpCredential(mcpData) && !warnedMaskedMcpCredential) {
+        warnedMaskedMcpCredential = true
+        warnings.push('MCP Server credentials are not imported; re-enter them before use')
+      }
+
       // Always create new - add suffix if name exists
       const existingMcp = (
         await tx.select().from(mcpServers).where(eq(mcpServers.name, mcpData.name)).limit(1)
@@ -444,8 +482,8 @@ export async function importAgentFromZip(
         args: mcpData.args,
         cwd: mcpData.cwd,
         url: mcpData.url,
-        headers: mcpData.headers,
-        env: mcpData.env,
+        headers: clearMaskedRecord(mcpData.headers),
+        env: clearMaskedRecord(mcpData.env),
         isEnabled: mcpData.isEnabled,
         // Imported groupConfig is opaque JSON shaped by sanitizeMcpServer;
         // cast to the schema's typed variant without revalidating backends.
@@ -870,6 +908,40 @@ export async function importAgentFromZip(
       )
     }
 
+    // Export masks sensitive values to the placeholder, so importing one verbatim would
+    // make '********' the credential itself: every run authenticates with the literal
+    // dots while the UI, which renders any sensitive value as dots, looks correctly
+    // configured. Clear it so the field reads as empty and asks to be filled in.
+    //
+    // The condition mirrors `sanitizeAgent`'s `v.sensitive || isSensitiveKey(k)` exactly.
+    // Matching on the flag alone would miss a key-name-detected secret, which exports as
+    // dots while keeping `sensitive: false`.
+    //
+    // Such an entry is also promoted to `sensitive: true`. Export judged it a secret by
+    // name, and importing that judgement is the whole point: leaving the flag false means
+    // the value the user retypes is stored unmasked and returned verbatim by every
+    // `GET /agents/:id` — `maskSensitiveEnv` masks on the flag alone — so every viewer of
+    // the Agent reads a live credential that the source instance at least masked.
+    let omittedSensitiveEnv = false
+    const importedEnv = exportedAgent.env
+      ? Object.fromEntries(
+          Object.entries(
+            exportedAgent.env as Record<string, { value: string; sensitive: boolean }>,
+          ).map(([key, entry]) => {
+            if (entry?.value === MASKED_CREDENTIAL && (entry.sensitive || isSensitiveKey(key))) {
+              omittedSensitiveEnv = true
+              return [key, { ...entry, value: '', sensitive: true }]
+            }
+            return [key, entry]
+          }),
+        )
+      : exportedAgent.env
+    if (omittedSensitiveEnv) {
+      warnings.push(
+        'Sensitive environment variable values are not imported; re-enter them before use',
+      )
+    }
+
     await tx.insert(agents).values({
       id: agentId,
       name: agentName,
@@ -929,7 +1001,7 @@ export async function importAgentFromZip(
       publishedAt: null,
       providerId,
       authMode: providerAuthMode,
-      env: exportedAgent.env as (typeof agents.$inferInsert)['env'],
+      env: importedEnv as (typeof agents.$inferInsert)['env'],
       workspaceType: exportedAgent.workspaceType as 'scm' | 'temp',
       scmSourceId,
       maxConcurrency: exportedAgent.maxConcurrency,

--- a/apps/api/src/routes/__tests__/agent-route-secrets.test.ts
+++ b/apps/api/src/routes/__tests__/agent-route-secrets.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { preserveA2ARouteTargetSecrets } from '../agent-route-secrets.js'
+import {
+  preserveA2ARouteTargetSecrets,
+  preserveSensitiveEnvSecrets,
+} from '../agent-route-secrets.js'
 
 describe('A2A route target credential preservation', () => {
   it('restores a masked legacy direct-route key after the UI adds explicit 0.3 defaults', () => {
@@ -159,5 +162,229 @@ describe('A2A route target credential preservation', () => {
     )
 
     expect(result).toEqual({ ok: false, targetName: 'renamed-two' })
+  })
+})
+
+describe('sensitive env credential preservation', () => {
+  it('restores a masked value under an unchanged key', () => {
+    const result = preserveSensitiveEnvSecrets(
+      { API_TOKEN: { value: '********', sensitive: true } },
+      { API_TOKEN: { value: 'stored-secret', sensitive: true } },
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: { API_TOKEN: { value: 'stored-secret', sensitive: true } },
+    })
+  })
+
+  /**
+   * The regression this whole helper exists for: the UI round-trips the masked
+   * placeholder verbatim, so renaming only the key used to look up the old value
+   * by the *new* name, find nothing, and persist the literal '********' — silently
+   * destroying a credential the user never intended to touch.
+   */
+  it('rejects a masked value whose key was renamed, instead of storing the placeholder', () => {
+    const result = preserveSensitiveEnvSecrets(
+      { API_TOKNE: { value: '********', sensitive: true } },
+      { API_TOKEN: { value: 'stored-secret', sensitive: true } },
+    )
+
+    expect(result).toEqual({ ok: false, key: 'API_TOKNE' })
+  })
+
+  /**
+   * With nothing stored at all there is no secret to strand, so the placeholder is
+   * blanked rather than rejected — the user is typing into a fresh row and a 400 telling
+   * them to "re-enter" a value that never existed would be pure obstruction.
+   */
+  it('blanks a masked value for a brand-new key with nothing stored', () => {
+    const result = preserveSensitiveEnvSecrets(
+      { NEW_TOKEN: { value: '********', sensitive: true } },
+      null,
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: { NEW_TOKEN: { value: '', sensitive: true } },
+    })
+  })
+
+  /**
+   * The rename must still be rejected when a real secret is on the line: that is the
+   * data-loss case the whole helper exists to prevent.
+   */
+  it('still rejects a rename while another key holds a real secret', () => {
+    const result = preserveSensitiveEnvSecrets(
+      {
+        API_TOKNE: { value: '********', sensitive: true },
+        OTHER: { value: '********', sensitive: true },
+      },
+      {
+        API_TOKEN: { value: 'stored-secret', sensitive: true },
+        OTHER: { value: 'other-secret', sensitive: true },
+      },
+    )
+
+    expect(result).toEqual({ ok: false, key: 'API_TOKNE' })
+  })
+
+  /**
+   * The eye toggle flips `sensitive` on an existing row in place, keeping the value.
+   * Once the round-trip has replaced that value with dots, the stored plaintext is
+   * still the only copy of it — restoring is what the user means by "mark this secret",
+   * and rejecting would demand they retype a value the UI no longer shows them.
+   */
+  it('restores the stored value when a plaintext entry is newly marked sensitive', () => {
+    const result = preserveSensitiveEnvSecrets(
+      { DB_URL: { value: '********', sensitive: true } },
+      { DB_URL: { value: 'postgres://u:p@h/db', sensitive: false } },
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: { DB_URL: { value: 'postgres://u:p@h/db', sensitive: true } },
+    })
+  })
+
+  /**
+   * Clone and import both persist `{value: '', sensitive: true}` deliberately — the
+   * row is kept so the user knows to refill it. `maskSensitiveEnv` masks it anyway,
+   * so the form round-trips dots over an empty value. Rejecting would make every
+   * cloned Agent unsavable until each blank secret was typed in, including when the
+   * edit was to an unrelated field.
+   */
+  it('restores an empty stored value rather than blocking the save', () => {
+    const result = preserveSensitiveEnvSecrets(
+      { API_TOKEN: { value: '********', sensitive: true } },
+      { API_TOKEN: { value: '', sensitive: true } },
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: { API_TOKEN: { value: '', sensitive: true } },
+    })
+  })
+
+  /**
+   * A stored placeholder is a row already corrupted by the pre-fix bug. Rejecting would
+   * make those Agents — precisely the ones this fix exists for — unsavable in every
+   * field until the credential is retyped, with the UI showing dots and giving no hint
+   * that env is the blocker. Blanking heals the row in place instead: the bad value
+   * stops being injected at runtime, the field reads as empty and asks to be filled,
+   * and the unrelated edit the user actually came to make goes through.
+   */
+  it('blanks a stored placeholder rather than blocking the save', () => {
+    const result = preserveSensitiveEnvSecrets(
+      { API_TOKEN: { value: '********', sensitive: true } },
+      { API_TOKEN: { value: '********', sensitive: true } },
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: { API_TOKEN: { value: '', sensitive: true } },
+    })
+  })
+
+  /**
+   * Renaming a key whose stored value is blank has nothing to lose — there is no secret
+   * to strand — so it must not be rejected with a message demanding the user "re-enter"
+   * a value that never existed.
+   */
+  it('allows renaming a key whose stored value was empty', () => {
+    const result = preserveSensitiveEnvSecrets(
+      { API_TOKEN: { value: '********', sensitive: true } },
+      { API_TOKNE: { value: '', sensitive: true } },
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: { API_TOKEN: { value: '', sensitive: true } },
+    })
+  })
+
+  it('passes through a freshly typed value that replaces the masked one', () => {
+    const result = preserveSensitiveEnvSecrets(
+      { API_TOKEN: { value: 'rotated-secret', sensitive: true } },
+      { API_TOKEN: { value: 'stored-secret', sensitive: true } },
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: { API_TOKEN: { value: 'rotated-secret', sensitive: true } },
+    })
+  })
+
+  /**
+   * A non-sensitive entry is returned in plaintext, so a literal '********' there
+   * is the user's own text and must be stored as typed, not treated as a sentinel.
+   */
+  it('treats the placeholder as literal text on a non-sensitive entry', () => {
+    const result = preserveSensitiveEnvSecrets(
+      { MASK_STYLE: { value: '********', sensitive: false } },
+      { MASK_STYLE: { value: '####', sensitive: false } },
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: { MASK_STYLE: { value: '********', sensitive: false } },
+    })
+  })
+
+  it('drops a removed key without disturbing the entries that remain', () => {
+    const result = preserveSensitiveEnvSecrets(
+      { KEPT: { value: '********', sensitive: true } },
+      {
+        KEPT: { value: 'kept-secret', sensitive: true },
+        REMOVED: { value: 'removed-secret', sensitive: true },
+      },
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: { KEPT: { value: 'kept-secret', sensitive: true } },
+    })
+  })
+
+  it('passes through null/undefined env without touching stored values', () => {
+    expect(preserveSensitiveEnvSecrets(undefined, { A: { value: 's', sensitive: true } })).toEqual({
+      ok: true,
+      value: undefined,
+    })
+    expect(preserveSensitiveEnvSecrets(null, { A: { value: 's', sensitive: true } })).toEqual({
+      ok: true,
+      value: null,
+    })
+  })
+})
+
+describe('sensitive env key swaps', () => {
+  /**
+   * Renaming two sensitive keys past each other cannot strand or cross a credential.
+   * The submitted env is a key→value map, not an ordered list, so a "swap" is indis-
+   * tinguishable from no change at all: each name still resolves to the secret stored
+   * under that same name. This is the structural reason the env path needs no identity
+   * matching, unlike `preserveA2ARouteTargetSecrets`, whose targets are an array where
+   * position and display name can drift independently of the endpoint.
+   */
+  it('keeps each secret bound to its own key when two names are exchanged', () => {
+    const result = preserveSensitiveEnvSecrets(
+      {
+        B_TOKEN: { value: '********', sensitive: true },
+        A_TOKEN: { value: '********', sensitive: true },
+      },
+      {
+        A_TOKEN: { value: 'secret-a', sensitive: true },
+        B_TOKEN: { value: 'secret-b', sensitive: true },
+      },
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        B_TOKEN: { value: 'secret-b', sensitive: true },
+        A_TOKEN: { value: 'secret-a', sensitive: true },
+      },
+    })
   })
 })

--- a/apps/api/src/routes/__tests__/agents-env-masking-cases.ts
+++ b/apps/api/src/routes/__tests__/agents-env-masking-cases.ts
@@ -1,0 +1,202 @@
+import type { Hono } from 'hono'
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
+import { asyncQuery } from '../../test/async-query.js'
+
+interface EnvMaskingTestContext {
+  SAMPLE_AGENT: Record<string, unknown>
+  makeAgentsApp(route: unknown): Hono
+  makeSelectChain(result: unknown): unknown
+  mockDb: {
+    select: { mockReturnValue(value: unknown): void }
+    insert: { mockReturnValue(value: unknown): void }
+    update: { mockReturnValue(value: unknown): void } & Mock
+  }
+}
+
+/**
+ * Sensitive-env masking cases for the agents routes.
+ *
+ * Split out of `agents.test.ts` rather than appended to it, matching
+ * `agents-secret-redaction-cases.ts`: these additions pushed that file past the
+ * repository's 3000-line ceiling. The describes are self-contained (they need only
+ * the shared app factory and the Drizzle mock), so they move as one group.
+ */
+export function registerAgentEnvMaskingTests({
+  SAMPLE_AGENT,
+  makeAgentsApp,
+  makeSelectChain,
+  mockDb,
+}: EnvMaskingTestContext): void {
+  describe('PATCH /agents/:id - sensitive env masking', () => {
+    let app: Hono
+
+    beforeEach(async () => {
+      vi.clearAllMocks()
+      const mod = await import('../agents.js')
+      app = makeAgentsApp(mod.default)
+    })
+
+    const AGENT_WITH_SECRET = {
+      ...SAMPLE_AGENT,
+      env: { API_TOKEN: { value: 'real-secret', sensitive: true } },
+    }
+
+    function captureUpdate() {
+      const setCalls: Record<string, unknown>[] = []
+      mockDb.update.mockReturnValue({
+        set: vi.fn((payload: Record<string, unknown>) => {
+          setCalls.push(payload)
+          return {
+            where: vi.fn().mockReturnValue(
+              asyncQuery({
+                returning: vi
+                  .fn()
+                  .mockReturnValue(asyncQuery({ get: vi.fn().mockReturnValue(AGENT_WITH_SECRET) })),
+                run: vi.fn(),
+              }),
+            ),
+          }
+        }),
+      })
+      return setCalls
+    }
+
+    const patchEnv = (env: Record<string, { value: string; sensitive: boolean }>) =>
+      app.request('/agents/agt_original', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ env }),
+      })
+
+    it('restores the stored secret when the masked value comes back under the same key', async () => {
+      mockDb.select.mockReturnValue(makeSelectChain(AGENT_WITH_SECRET))
+      const setCalls = captureUpdate()
+
+      const res = await patchEnv({ API_TOKEN: { value: '********', sensitive: true } })
+
+      expect(res.status).toBe(200)
+      expect(setCalls.at(-1)?.env).toEqual({
+        API_TOKEN: { value: 'real-secret', sensitive: true },
+      })
+    })
+
+    /**
+     * The destructive path this guard exists for. The UI shows dots, not the secret,
+     * so a user fixing a typo in the key has every reason to believe the value rides
+     * along. Writing the placeholder through would overwrite the real secret with
+     * '********' — unrecoverable, and invisible because the field still renders as dots.
+     */
+    it('rejects a renamed key carrying the masked placeholder, without writing', async () => {
+      mockDb.select.mockReturnValue(makeSelectChain(AGENT_WITH_SECRET))
+      captureUpdate()
+
+      const res = await patchEnv({ API_TOKNE: { value: '********', sensitive: true } })
+
+      expect(res.status).toBe(400)
+      expect((await res.json()) as { code: string }).toMatchObject({
+        code: 'MASKED_SECRET_WITHOUT_STORED_VALUE',
+      })
+      expect(mockDb.update).not.toHaveBeenCalled()
+    })
+
+    it('stores a rotated value typed over the mask', async () => {
+      mockDb.select.mockReturnValue(makeSelectChain(AGENT_WITH_SECRET))
+      const setCalls = captureUpdate()
+
+      const res = await patchEnv({ API_TOKEN: { value: 'rotated', sensitive: true } })
+
+      expect(res.status).toBe(200)
+      expect(setCalls.at(-1)?.env).toEqual({ API_TOKEN: { value: 'rotated', sensitive: true } })
+    })
+
+    it('lets a renamed key through once its value is re-entered', async () => {
+      mockDb.select.mockReturnValue(makeSelectChain(AGENT_WITH_SECRET))
+      const setCalls = captureUpdate()
+
+      const res = await patchEnv({ API_TOKNE: { value: 're-entered', sensitive: true } })
+
+      expect(res.status).toBe(200)
+      expect(setCalls.at(-1)?.env).toEqual({ API_TOKNE: { value: 're-entered', sensitive: true } })
+    })
+
+    /**
+     * The same write-through the env guard exists to prevent, three fields away in this
+     * handler: each channel secret restores only when a stored value exists, so a config
+     * row present but with an empty secret persists the literal placeholder. The channel
+     * then fails to authenticate while the edit page renders dots and reads as configured.
+     */
+    it('never persists the placeholder as a channel secret when nothing is stored', async () => {
+      mockDb.select.mockReturnValue(
+        makeSelectChain({
+          ...SAMPLE_AGENT,
+          feishuConfig: { appId: 'cli_x', appSecret: '' },
+          slackConfig: { appId: 'A1', appToken: '', botToken: '' },
+          discordConfig: { applicationId: 'D1', botToken: '' },
+        }),
+      )
+      const setCalls = captureUpdate()
+
+      const res = await app.request('/agents/agt_original', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          feishuConfig: { appId: 'cli_x', appSecret: '********' },
+          slackConfig: { appId: 'A1', appToken: '********', botToken: '********' },
+          discordConfig: { applicationId: 'D1', botToken: '********' },
+        }),
+      })
+
+      expect(res.status).toBe(200)
+      const saved = setCalls.at(-1) as Record<string, Record<string, string>>
+      expect(saved.feishuConfig.appSecret).not.toBe('********')
+      expect(saved.slackConfig.appToken).not.toBe('********')
+      expect(saved.slackConfig.botToken).not.toBe('********')
+      expect(saved.discordConfig.botToken).not.toBe('********')
+    })
+  })
+
+  describe('POST /agents - sensitive env masking', () => {
+    let app: Hono
+
+    beforeEach(async () => {
+      vi.clearAllMocks()
+      const mod = await import('../agents.js')
+      app = makeAgentsApp(mod.default)
+    })
+
+    /**
+     * Nothing is stored on create, so no secret can be stranded — the placeholder is
+     * blanked rather than rejected. A 400 here would only block a caller round-tripping
+     * an exported config, telling them to "re-enter" a value that never existed on this
+     * instance, while the literal placeholder must still never reach the database.
+     */
+    it('blanks a masked sensitive value on create instead of storing the placeholder', async () => {
+      let inserted: Record<string, unknown> = {}
+      mockDb.insert.mockReturnValue({
+        values: vi.fn().mockImplementation((v: Record<string, unknown>) => {
+          inserted = v
+          return { returning: vi.fn().mockReturnValue(asyncQuery({ get: () => SAMPLE_AGENT })) }
+        }),
+      })
+      // The suite-wide mock drops the body; echo it back so the guard sees the env.
+      const { createAgentInput } = await import('@a2wave/shared')
+      ;(createAgentInput.safeParse as Mock).mockImplementationOnce((input: unknown) => ({
+        success: true,
+        data: input,
+      }))
+
+      const res = await app.request('/agents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'New Agent',
+          type: 'cursor',
+          env: { API_TOKEN: { value: '********', sensitive: true } },
+        }),
+      })
+
+      expect(res.status).toBe(201)
+      expect(inserted.env).toEqual({ API_TOKEN: { value: '', sensitive: true } })
+    })
+  })
+}

--- a/apps/api/src/routes/__tests__/agents.test.ts
+++ b/apps/api/src/routes/__tests__/agents.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { Hono } from 'hono'
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
+import { registerAgentEnvMaskingTests } from './agents-env-masking-cases.js'
 import { registerOauthPublishTests } from './agents-oauth-publish-cases.js'
 import { registerAgentSecretRedactionTests } from './agents-secret-redaction-cases.js'
 import { registerSkillVisibilityCloneTests } from './agents-skill-visibility-clone-cases.js'
@@ -2349,6 +2350,12 @@ describe('feishuConfig legacy normalization in HTTP handlers', () => {
 })
 
 registerAgentSecretRedactionTests({
+  SAMPLE_AGENT,
+  makeAgentsApp,
+  makeSelectChain,
+  mockDb,
+})
+registerAgentEnvMaskingTests({
   SAMPLE_AGENT,
   makeAgentsApp,
   makeSelectChain,

--- a/apps/api/src/routes/agent-route-secrets.ts
+++ b/apps/api/src/routes/agent-route-secrets.ts
@@ -22,6 +22,75 @@ export function maskSensitiveEnv<T extends { env: Record<string, AgentEnvEntry> 
   return { ...agent, env: maskedEnv }
 }
 
+/**
+ * Restore masked sensitive env values, and refuse the write when there is nothing
+ * to restore — rather than persisting the placeholder as if it were the secret.
+ *
+ * The UI never receives a sensitive value in plaintext: it renders the masked
+ * placeholder and submits the whole record back verbatim. A key is the only handle
+ * on the stored value, so renaming one (fixing a typo, say) while leaving the dots
+ * untouched used to look up the *new* name, find nothing, and store '********' as
+ * the value. The Agent then injects that literal at every run, the Provider fails
+ * to authenticate, and the original secret is gone — with the UI still showing dots,
+ * so it reads as configured. Every subsequent save "preserves" the placeholder again,
+ * leaving no way to notice, let alone recover.
+ *
+ * Rejecting mirrors `preserveA2ARouteTargetSecrets`: the user re-enters the value
+ * once, which is the only way the server can learn a secret it was never sent.
+ *
+ * Rejection is deliberately narrow — only a key with no stored entry at all, or one
+ * whose stored value is already the placeholder. Anything else that exists is restored,
+ * because the alternative is blocking saves on Agents whose env is in a perfectly
+ * ordinary state (a blank secret from clone/import, a variable just marked sensitive).
+ */
+/**
+ * True when the stored env holds at least one sensitive value a rename could strand.
+ *
+ * A blank value and the placeholder itself are both "nothing to lose", so renaming a key
+ * that only ever held one of those is harmless and must not be rejected.
+ */
+function hasRestorableSecret(
+  existingEnv: Record<string, AgentEnvEntry> | null | undefined,
+): boolean {
+  return Object.values(existingEnv ?? {}).some(
+    (entry) => entry.sensitive && entry.value && entry.value !== MASKED_SECRET,
+  )
+}
+
+export function preserveSensitiveEnvSecrets(
+  nextEnv: Record<string, AgentEnvEntry> | null | undefined,
+  existingEnv: Record<string, AgentEnvEntry> | null | undefined,
+): { ok: true; value: typeof nextEnv } | { ok: false; key: string } {
+  if (!nextEnv) return { ok: true, value: nextEnv }
+
+  const restored: Record<string, AgentEnvEntry> = {}
+  for (const [key, entry] of Object.entries(nextEnv)) {
+    // A non-sensitive value round-trips in plaintext, so '********' there is
+    // the user's own text and is stored as typed.
+    if (!entry.sensitive || entry.value !== MASKED_SECRET) {
+      restored[key] = entry
+      continue
+    }
+    const stored = existingEnv?.[key]
+    // No entry under this key: the key is the only handle on the stored value, so the
+    // placeholder can never be resolved. That is the rename case — reject, but only when
+    // a real secret would actually be stranded. If nothing stored holds one, the rename
+    // costs nothing, and refusing it would demand the user "re-enter" a value that never
+    // existed (renaming a blank row from clone or import is exactly that).
+    if (!stored) {
+      if (hasRestorableSecret(existingEnv)) return { ok: false, key }
+      restored[key] = { ...entry, value: '' }
+      continue
+    }
+    // A stored placeholder is a row already corrupted by the pre-fix bug. Blank it rather
+    // than reject: rejecting locks those Agents out of every unrelated edit — and they are
+    // the ones this guard exists for — while blanking heals the row, stops the bad value
+    // reaching the runtime, and lets the save through.
+    restored[key] = { ...entry, value: stored.value === MASKED_SECRET ? '' : stored.value }
+  }
+  return { ok: true, value: restored }
+}
+
 export function maskProviderChainConfig<T>(
   config: T,
   replacement: string | null = MASKED_SECRET,

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -148,6 +148,7 @@ import {
   maskA2ARouteTargetSecrets,
   maskSensitiveEnv,
   preserveA2ARouteTargetSecrets,
+  preserveSensitiveEnvSecrets,
 } from './agent-route-secrets.js'
 import { feishuConfigBodySchema } from './publish-feishu-config.js'
 
@@ -158,6 +159,34 @@ const MEMORY_SKILL_NAME = 'a2wave-memory'
 // trips a false "connection lost".
 const SSE_HEARTBEAT_INTERVAL_MS = 30_000
 const MASKED_SECRET = '********'
+
+/**
+ * Resolve a masked channel secret against the stored one.
+ *
+ * The placeholder means "unchanged", so it restores the stored value — but when there is
+ * none (a config row that exists with an empty secret), writing it through would make
+ * '********' the credential itself: the channel fails to authenticate on every callback
+ * while the edit page renders dots and reads as configured. Blanking keeps that state
+ * honest, and the publish preflight already refuses to take a channel live on an empty
+ * secret, so the failure surfaces where the user can act on it.
+ */
+const resolveMaskedChannelSecret = <T extends string | null | undefined>(
+  submitted: T,
+  stored: string | null | undefined,
+): T | string => (submitted === MASKED_SECRET ? (stored ?? '') : submitted)
+
+/**
+ * Shared 400 body for a masked env value with no stored counterpart to restore.
+ *
+ * `code` is for direct API consumers only: `api.ts` builds its thrown Error from `error`
+ * alone, so the web UI shows the prose and never reads the code. That matches the sibling
+ * A2A masked-secret rejection below, which carries the same code for the same reason.
+ */
+const maskedEnvWithoutStoredValue = (key: string) =>
+  ({
+    error: `Environment variable '${key}' was sent masked but no stored value exists to restore. Re-enter its value.`,
+    code: 'MASKED_SECRET_WITHOUT_STORED_VALUE',
+  }) as const
 
 type AgentRow = typeof agents.$inferSelect
 
@@ -1159,6 +1188,15 @@ app.post('/', async (c) => {
   )
   if (groupAccessError) return c.json({ error: groupAccessError }, 403)
 
+  // Nothing is stored yet, so a masked sensitive value is an echoed placeholder (a
+  // cloned draft, say) with no counterpart — and no secret it could strand. It is
+  // blanked rather than rejected, which is why this never fails on create; the point
+  // is only that the literal placeholder must not reach the database.
+  const envRestore = preserveSensitiveEnvSecrets(parsed.data.env, null)
+  if (!envRestore.ok) {
+    return c.json(maskedEnvWithoutStoredValue(envRestore.key), 400)
+  }
+
   const id = createId('agt')
   const authMode = await effectiveProviderAuthMode(parsed.data.providerId, parsed.data.authMode)
   const newAgent = (
@@ -1170,6 +1208,7 @@ app.post('/', async (c) => {
         // default into the INSERT — re-seeding rows on the value 0100 exists to remove.
         oauthAccessMode: 'all_idaas_users',
         ...parsed.data,
+        env: envRestore.value,
         authMode,
         userId,
       })
@@ -1250,19 +1289,14 @@ app.patch('/:id', async (c) => {
   )
   if (groupAccessError) return c.json({ error: groupAccessError }, 403)
 
-  // Preserve existing sensitive env values when frontend sends '********' (masked placeholder)
-  let envToSave = parsed.data.env
-  if (envToSave && existing.env) {
-    const existingEnv = existing.env as Record<string, { value: string; sensitive: boolean }>
-    envToSave = Object.fromEntries(
-      Object.entries(envToSave).map(([key, entry]) => {
-        if (entry.sensitive && entry.value === '********' && existingEnv[key]) {
-          return [key, { ...entry, value: existingEnv[key].value }]
-        }
-        return [key, entry]
-      }),
-    )
+  // Preserve existing sensitive env values when frontend sends '********' (masked placeholder).
+  // A masked value with no stored counterpart — a renamed key, most often — is rejected rather
+  // than written through, which would replace the real secret with the literal placeholder.
+  const envRestore = preserveSensitiveEnvSecrets(parsed.data.env, existing.env)
+  if (!envRestore.ok) {
+    return c.json(maskedEnvWithoutStoredValue(envRestore.key), 400)
   }
+  const envToSave = envRestore.value
 
   // Provider credential placeholders: client may echo '********' from masked chain rows.
   // Treat them as "keep existing" for top-level legacy columns too.
@@ -1307,29 +1341,32 @@ app.patch('/:id', async (c) => {
   let feishuConfigToSave = parsed.data.feishuConfig
     ? normalizeFeishuConfig(parsed.data.feishuConfig as Record<string, unknown>)
     : parsed.data.feishuConfig
-  if (feishuConfigToSave && feishuConfigToSave.appSecret === '********' && existing.feishuConfig) {
-    const existingFeishu = existing.feishuConfig as { appSecret: string }
-    feishuConfigToSave = { ...feishuConfigToSave, appSecret: existingFeishu.appSecret }
+  if (feishuConfigToSave?.appSecret === MASKED_SECRET) {
+    const storedFeishuSecret = (existing.feishuConfig as { appSecret?: string } | null)?.appSecret
+    feishuConfigToSave = { ...feishuConfigToSave, appSecret: storedFeishuSecret ?? '' }
   }
   let slackConfigToSave = parsed.data.slackConfig
-  if (slackConfigToSave && existing.slackConfig) {
+  if (slackConfigToSave) {
     slackConfigToSave = {
       ...slackConfigToSave,
-      appToken:
-        slackConfigToSave.appToken === '********'
-          ? existing.slackConfig.appToken
-          : slackConfigToSave.appToken,
-      botToken:
-        slackConfigToSave.botToken === '********'
-          ? existing.slackConfig.botToken
-          : slackConfigToSave.botToken,
+      appToken: resolveMaskedChannelSecret(
+        slackConfigToSave.appToken,
+        existing.slackConfig?.appToken,
+      ),
+      botToken: resolveMaskedChannelSecret(
+        slackConfigToSave.botToken,
+        existing.slackConfig?.botToken,
+      ),
     }
   }
   let discordConfigToSave = parsed.data.discordConfig
-  if (discordConfigToSave?.botToken === '********' && existing.discordConfig?.botToken) {
+  if (discordConfigToSave) {
     discordConfigToSave = {
       ...discordConfigToSave,
-      botToken: existing.discordConfig.botToken,
+      botToken: resolveMaskedChannelSecret(
+        discordConfigToSave.botToken,
+        existing.discordConfig?.botToken,
+      ),
     }
   }
 

--- a/apps/web/src/components/__tests__/import-agent-dialog.test.tsx
+++ b/apps/web/src/components/__tests__/import-agent-dialog.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/api', () => ({ api: { upload: vi.fn(), post: vi.fn() } }))
+vi.mock('@/lib/antd-static', () => ({
+  message: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}))
+
+import { message } from '@/lib/antd-static'
+import { handleImportSuccess, reportImportWarnings } from '../import-agent-dialog'
+
+const SENSITIVE_ENV_WARNING =
+  'Sensitive environment variable values are not imported; re-enter them before use'
+
+describe('reportImportWarnings', () => {
+  /**
+   * The import route clears masked credentials it cannot restore and reports that
+   * through `warnings`. The dialog closes on success, so a warning that is never
+   * surfaced is one the user never sees — they would discover the cleared secret
+   * only when a run fails to authenticate against an empty credential.
+   */
+  it('raises one toast per server warning', () => {
+    vi.mocked(message.warning).mockClear()
+
+    reportImportWarnings([SENSITIVE_ENV_WARNING, 'Slack credentials are not imported'])
+
+    expect(message.warning).toHaveBeenCalledTimes(2)
+    expect(message.warning).toHaveBeenCalledWith(SENSITIVE_ENV_WARNING)
+    expect(message.warning).toHaveBeenCalledWith('Slack credentials are not imported')
+  })
+
+  it('stays silent when the import reports nothing', () => {
+    vi.mocked(message.warning).mockClear()
+
+    reportImportWarnings([])
+    reportImportWarnings(undefined)
+
+    expect(message.warning).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleImportSuccess', () => {
+  const result = {
+    agent: { id: 'agt_1', name: 'Imported' },
+    mcpServers: [],
+    skills: [],
+    warnings: [SENSITIVE_ENV_WARNING],
+  }
+
+  function run({ withOnSuccess = true } = {}) {
+    const invalidate = vi.fn<(key: string) => void>()
+    const onSuccess = vi.fn()
+    const onClose = vi.fn()
+    handleImportSuccess(result, {
+      t: (key: string) => key,
+      invalidate,
+      onSuccess: withOnSuccess ? onSuccess : undefined,
+      onClose,
+    })
+    return { invalidate, onSuccess, onClose }
+  }
+
+  /**
+   * Both import paths funnel through here, so this is the single place that proves the
+   * warning surface is actually wired — the callsites themselves cannot be driven from
+   * a component test because the antd Modal footer does not render under jsdom.
+   */
+  it('reports warnings alongside the success toast', () => {
+    run()
+
+    expect(message.success).toHaveBeenCalled()
+    expect(message.warning).toHaveBeenCalledWith(SENSITIVE_ENV_WARNING)
+  })
+
+  it('refreshes every list the import can touch, then hands off and closes', () => {
+    const deps = run()
+
+    expect(deps.invalidate.mock.calls.map(([k]) => k)).toEqual(['agents', 'skills', 'mcp-servers'])
+    expect(deps.onSuccess).toHaveBeenCalledWith(result)
+    expect(deps.onClose).toHaveBeenCalled()
+  })
+
+  it('closes even when the caller passes no onSuccess handler', () => {
+    const deps = run({ withOnSuccess: false })
+
+    expect(deps.onClose).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/import-agent-dialog.tsx
+++ b/apps/web/src/components/import-agent-dialog.tsx
@@ -14,6 +14,43 @@ interface ImportResult {
   warnings: string[]
 }
 
+/**
+ * Surface every warning the import reported.
+ *
+ * The server clears credentials it cannot restore — masked env values, Slack and
+ * Discord tokens — and says so here. The dialog closes on success, so an unreported
+ * warning is one the user never sees: the cleared secret is masked back to dots on
+ * the edit page and looks configured, and the first sign of trouble is a run failing
+ * to authenticate. These are already user-facing prose from the API, like the error
+ * strings `formatApiError` passes through.
+ */
+export function reportImportWarnings(warnings: string[] | undefined) {
+  for (const warning of warnings ?? []) message.warning(warning)
+}
+
+/**
+ * Everything both import paths do once the server accepts the bundle.
+ *
+ * Extracted so the two callsites cannot drift: the warning surface in particular is
+ * easy to lose in one branch and keep in the other, and neither dialog handler can be
+ * driven from a component test (the antd Modal footer does not render under jsdom).
+ */
+export function handleImportSuccess(
+  result: ImportResult,
+  deps: {
+    t: (key: string, opts?: Record<string, unknown>) => string
+    invalidate: (key: string) => void
+    onSuccess?: (result: ImportResult) => void
+    onClose: () => void
+  },
+) {
+  message.success(deps.t('agentImport.success', { name: result.agent.name }))
+  reportImportWarnings(result.warnings)
+  for (const key of ['agents', 'skills', 'mcp-servers']) deps.invalidate(key)
+  deps.onSuccess?.(result)
+  deps.onClose()
+}
+
 interface ImportAgentDialogProps {
   open: boolean
   onClose: () => void
@@ -28,6 +65,7 @@ export function ImportAgentDialog({ open, onClose, onSuccess }: ImportAgentDialo
   const [headerKey, setHeaderKey] = useState('')
   const [headerValue, setHeaderValue] = useState('')
   const [activeTab, setActiveTab] = useState('file')
+  const invalidate = (key: string) => queryClient.invalidateQueries({ queryKey: [key] })
 
   const handleFileUpload = async (file: File) => {
     setLoading(true)
@@ -35,12 +73,7 @@ export function ImportAgentDialog({ open, onClose, onSuccess }: ImportAgentDialo
       const formData = new FormData()
       formData.append('file', file)
       const result = await api.upload<ImportResult>('/agents/import', formData)
-      message.success(t('agentImport.success', { name: result.data.agent.name }))
-      queryClient.invalidateQueries({ queryKey: ['agents'] })
-      queryClient.invalidateQueries({ queryKey: ['skills'] })
-      queryClient.invalidateQueries({ queryKey: ['mcp-servers'] })
-      onSuccess?.(result.data)
-      onClose()
+      handleImportSuccess(result.data, { t, invalidate, onSuccess, onClose })
     } catch (err) {
       message.error(formatApiError(err, t))
     } finally {
@@ -61,12 +94,7 @@ export function ImportAgentDialog({ open, onClose, onSuccess }: ImportAgentDialo
         url: url.trim(),
         headers: customHeaders,
       })
-      message.success(t('agentImport.success', { name: result.data.agent.name }))
-      queryClient.invalidateQueries({ queryKey: ['agents'] })
-      queryClient.invalidateQueries({ queryKey: ['skills'] })
-      queryClient.invalidateQueries({ queryKey: ['mcp-servers'] })
-      onSuccess?.(result.data)
-      onClose()
+      handleImportSuccess(result.data, { t, invalidate, onSuccess, onClose })
       setUrl('')
       setHeaderKey('')
       setHeaderValue('')

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1377,7 +1377,6 @@
     "stopFail": "Failed to stop, please try again",
     "resumeSuccess": "Agent resumed",
     "resumeFail": "Failed to resume, please try again",
-    "createFail": "Create failed, please try again",
     "cloneFail": "Clone failed, please try again",
     "deleteFail": "Delete failed, please try again",
     "templateVarsAvailable": "Available variables",

--- a/apps/web/src/locales/zh.json
+++ b/apps/web/src/locales/zh.json
@@ -1377,7 +1377,6 @@
     "stopFail": "停止失败，请重试",
     "resumeSuccess": "Agent 已恢复运行",
     "resumeFail": "恢复失败，请重试",
-    "createFail": "创建失败，请重试",
     "cloneFail": "克隆失败，请重试",
     "deleteFail": "删除失败，请重试",
     "templateVarsAvailable": "可用变量",

--- a/apps/web/src/pages/agent-detail/__tests__/use-agent-form.test.tsx
+++ b/apps/web/src/pages/agent-detail/__tests__/use-agent-form.test.tsx
@@ -416,6 +416,25 @@ describe('useAgentForm — initialization (edit mode)', () => {
     expect(message.error).toHaveBeenCalledWith(diagnosis)
   })
 
+  /**
+   * Create used to swallow every server message behind a generic "create failed"
+   * toast, unlike the update path. The masked-env rejection names the offending
+   * variable, and that name is the only way to act on it — the field itself renders
+   * as dots, so a generic toast leaves the user with nothing to go on.
+   */
+  it('surfaces the server message when creating is rejected', async () => {
+    const diagnosis =
+      "Environment variable 'API_TOKEN' was sent masked but no stored value exists to restore. Re-enter its value."
+    mutateAsyncStub.mockRejectedValueOnce(new Error(diagnosis))
+    const { result } = renderForm({ createMode: true })
+
+    await act(async () => {
+      await result.current.onSubmit(result.current.form.getValues())
+    })
+
+    expect(message.error).toHaveBeenCalledWith(diagnosis)
+  })
+
   it('shows the actionable Provider/MCP diagnosis when publishing is rejected', async () => {
     const diagnosis =
       'Agent "agt_test1" uses MCP-backed capabilities, but Provider "Pi CLI" (pi) does not support MCP delivery; remove mounted MCP Servers and A2A routes, or choose a Provider with MCP support'

--- a/apps/web/src/pages/agent-detail/use-agent-form.ts
+++ b/apps/web/src/pages/agent-detail/use-agent-form.ts
@@ -768,7 +768,11 @@ export function useAgentForm(
         navigate(target, { replace: true })
       } catch (error) {
         console.error('Failed to create agent:', error)
-        message.error(t('agentDetail.createFail'))
+        // Match the update path: the server message often carries the only actionable
+        // detail (which env variable was rejected, which Provider is incompatible),
+        // and a generic toast throws it away. formatApiError falls back to generic
+        // copy when there is no message worth showing.
+        message.error(formatApiError(error, t))
       }
       return
     }


### PR DESCRIPTION
## Problem

Renaming a sensitive env key while leaving its masked value untouched looked up the old value by the **new** key, found nothing, and stored the literal `********` as the credential. The Agent then injected that placeholder at every run, the Provider failed to authenticate, and the original secret was gone — with the UI still rendering dots, so it read as configured. Every later save "preserved" the placeholder again, leaving no way to notice or recover.

Tracing the pattern turned up the same shape on four more paths, all fixed here.

## Changes

| Path | Before | After |
|---|---|---|
| `PATCH /agents/:id` env | Renamed key persisted `********` | Rejected only when a real secret would be stranded |
| `POST /agents` env | Masked value written through on create | Blanked — nothing stored can be stranded |
| Agent import env | Export's placeholder persisted verbatim | Cleared, and **promoted to `sensitive: true`** |
| MCP `env` / `headers` | Placeholder became the header itself | Cleared, with an import warning |
| Feishu / Slack / Discord secrets | Placeholder persisted when no stored value | Falls back to empty, never the placeholder |

**The import promotion matters most.** `sanitizeAgent` masks on `v.sensitive || isSensitiveKey(k)` but preserves the original flag, so a key-name-detected secret exports as dots with `sensitive: false`. Clearing without promoting means the value the user retypes is stored unmasked and returned **in plaintext** by `GET /agents/:id` to every viewer of the Agent — `maskSensitiveEnv` masks on the flag alone.

**Rejection is deliberately narrow.** Only a key whose rename would actually strand a stored secret. A blank stored value (clone and import both persist an empty sensitive entry on purpose) and a plaintext value newly marked sensitive by the eye toggle are states a user reaches *without touching the secret*, so blocking them would demand retyping a value the UI no longer shows. A stored placeholder — a row already corrupted by this bug — is blanked rather than rejected, so those Agents heal in place instead of becoming unsavable in every field.

Also surfaces import warnings in the UI (collected but never rendered), and reports the server message on create failure like the update path already did.

## Testing

TDD throughout — every test was confirmed failing against the pre-fix code first.

- **api** 5469 tests / 348 files · **web** 847 / 103 · **cli** 740 / 32 · **shared** 169 — all pass
- `pnpm typecheck` green; `pnpm lint` 0 errors, warnings unchanged from baseline (426)
- arch-rules / forbidden-tokens / file-lines / check-api-tests gates all pass

`agents.test.ts` crossed the 3000-line ceiling, so the new cases moved into `agents-env-masking-cases.ts`, following the existing `agents-secret-redaction-cases.ts` convention.

Manual update not needed — server-side correctness fix with no user-facing feature change.