### PR TITLE
fix(api): make JSON SQL helpers work on plain-text JSON columns (PostgreSQL)

### DIFF
--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Every column passed to a JSON helper must actually hold JSON — checked on
+ * both dialects, from the real call sites.
+ *
+ * `pgJsonSource`'s guard throws for a column that is neither `mode: 'json'` nor
+ * a known plain-text JSON column, but it sits behind `isPostgresRuntime()`.
+ * SQLite is the supported default, so a developer who never runs PostgreSQL
+ * locally would pass a mistyped column, see `json_extract` quietly return NULL,
+ * and ship it — the failure surfacing only on the backend fewer people run.
+ * That is the same shape as the bug this suite exists for.
+ *
+ * So rather than trust the runtime guard alone, this walks the actual call
+ * sites, resolves each column argument against the schema, and asserts it is
+ * JSON-bearing. Static because it must hold regardless of which dialect the
+ * developer's DATABASE_URL happens to select.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import * as schema from '../../db/schema.sqlite.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SRC = resolve(__dirname, '../..')
+
+const HELPERS = [
+  'jsonExtractNumber',
+  'jsonExtractText',
+  'jsonArrayContainsKeyValue',
+  'jsonSet',
+  'jsonPathIsAbsent',
+]
+
+/** Plain-text columns that legitimately hold hand-serialised JSON. */
+const ALLOWED_PLAIN_TEXT = new Set(['a2aTasks.data'])
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue
+      yield* walk(full)
+      continue
+    }
+    if (entry.endsWith('.ts')) yield full
+  }
+}
+
+function code(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '')
+}
+
+/** Collect `table.column` first arguments passed to any JSON helper. */
+function collectColumnArguments(source: string): string[] {
+  const found: string[] = []
+  for (const helper of HELPERS) {
+    const call = new RegExp(`\\b${helper}\\s*\\(\\s*([A-Za-z_$][\\w$]*\\.[A-Za-z_$][\\w$]*)`, 'g')
+    for (const match of source.matchAll(call)) found.push(match[1])
+  }
+  return found
+}
+
+describe('JSON helper call sites pass JSON-bearing columns', () => {
+  const callSites = new Map<string, string[]>()
+  for (const file of walk(SRC)) {
+    if (file === resolve(SRC, 'lib/json-sql.ts')) continue
+    const columns = collectColumnArguments(code(readFileSync(file, 'utf-8')))
+    if (columns.length) callSites.set(file.slice(SRC.length + 1), columns)
+  }
+
+  it('finds the known call sites, so a broken scan cannot pass vacuously', () => {
+    const all = [...callSites.values()].flat()
+    expect(all.length).toBeGreaterThanOrEqual(10)
+    // The column this whole suite exists for must be among them.
+    expect(all).toContain('a2aTasks.data')
+  })
+
+  it('resolves every column argument to a json column or an allowed text one', () => {
+    const offenders: string[] = []
+
+    for (const [file, columns] of callSites) {
+      for (const reference of columns) {
+        const [tableName, columnName] = reference.split('.')
+        const table = (schema as Record<string, unknown>)[tableName] as
+          | Record<string, { dataType?: string }>
+          | undefined
+        // An unresolvable name means a local alias, not a schema table; the
+        // real schema tables are what this guard is about.
+        if (!table) continue
+        const column = table[columnName]
+        if (!column?.dataType) continue
+
+        if (column.dataType === 'json') continue
+        if (ALLOWED_PLAIN_TEXT.has(reference)) continue
+        offenders.push(`${file}: ${reference} is ${column.dataType}, not json`)
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -87,13 +87,25 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
     const body = code(readFileSync(file, 'utf-8'))
     const relative = file.slice(SRC.length + 1)
 
-    // An aliased import (`jsonExtractText as extract`) renames the call and
-    // would slip past a scan keyed on the original names, so treat it as a
-    // finding in its own right rather than letting the call go unexamined.
+    // Any rebinding of a helper to another name renames the call and would slip
+    // past a scan keyed on the original names, so treat it as a finding rather
+    // than letting the call go unexamined. Two forms: an aliased import
+    // (`jsonExtractText as extract`) and a local rebind (`const extract =
+    // jsonExtractText`), including destructuring off a namespace import.
     for (const helper of HELPERS) {
-      const renamed = new RegExp(`\\b${helper}\\s+as\\s+([A-Za-z_$][\\w$]*)`, 'g')
-      for (const match of body.matchAll(renamed)) {
+      const renamedImport = new RegExp(`\\b${helper}\\s+as\\s+([A-Za-z_$][\\w$]*)`, 'g')
+      for (const match of body.matchAll(renamedImport)) {
         aliasedImports.push(`${relative}: ${helper} imported as ${match[1]}`)
+      }
+
+      // `= jsonExtractText` with no call parenthesis: the function itself is
+      // being passed around rather than invoked here.
+      const rebind = new RegExp(
+        `(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*[\\w$.]*\\b${helper}\\b\\s*(?!\\()`,
+        'g',
+      )
+      for (const match of body.matchAll(rebind)) {
+        aliasedImports.push(`${relative}: ${helper} rebound as ${match[1]}`)
       }
     }
 
@@ -104,7 +116,11 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
 
   it('finds the known call sites, so a broken scan cannot pass vacuously', () => {
     const all = [...callSites.values()].flat()
-    expect(all.length).toBeGreaterThanOrEqual(10)
+    // Pinned to the exact current count, not a floor. A floor of 10 stayed green
+    // while calls silently dropped out of view — which is the failure this file
+    // guards against. Adding or removing a call site is expected to update this
+    // number deliberately.
+    expect(all).toHaveLength(14)
     // The column this whole suite exists for must be among them.
     expect(all).toContain('a2aTasks.data')
   })

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -50,22 +50,56 @@ function code(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '')
 }
 
-/** Collect `table.column` first arguments passed to any JSON helper. */
-function collectColumnArguments(source: string): string[] {
-  const found: string[] = []
+/**
+ * Collect the first argument of every JSON-helper call, split into the
+ * `table.column` references this scan can resolve and everything it cannot.
+ *
+ * The unresolved bucket is the point. A scan that only matched `table.column`
+ * and ignored the rest would silently pass a call whose column arrives as a
+ * local variable or through an aliased import — reporting green for code it
+ * never actually checked. Surfacing those instead forces them to be made
+ * resolvable (or explicitly acknowledged), so "no offenders" means "nothing
+ * unchecked" rather than "nothing recognised".
+ */
+function collectColumnArguments(source: string): { resolved: string[]; unresolved: string[] } {
+  const resolved: string[] = []
+  const unresolved: string[] = []
   for (const helper of HELPERS) {
-    const call = new RegExp(`\\b${helper}\\s*\\(\\s*([A-Za-z_$][\\w$]*\\.[A-Za-z_$][\\w$]*)`, 'g')
-    for (const match of source.matchAll(call)) found.push(match[1])
+    // `[^,)]+` captures whatever the first argument actually is, so a call the
+    // narrow `table.column` form would miss still lands in one bucket or other.
+    const call = new RegExp(`\\b${helper}\\s*\\(\\s*([^,)]+?)\\s*[,)]`, 'g')
+    for (const match of source.matchAll(call)) {
+      const argument = match[1].replace(/\s+/g, ' ').trim()
+      if (/^[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*$/.test(argument)) resolved.push(argument)
+      else unresolved.push(`${helper}(${argument})`)
+    }
   }
-  return found
+  return { resolved, unresolved }
 }
 
 describe('JSON helper call sites pass JSON-bearing columns', () => {
   const callSites = new Map<string, string[]>()
+  const unresolvedSites = new Map<string, string[]>()
+  const aliasedImports: string[] = []
+
   for (const file of walk(SRC)) {
     if (file === resolve(SRC, 'lib/json-sql.ts')) continue
-    const columns = collectColumnArguments(code(readFileSync(file, 'utf-8')))
-    if (columns.length) callSites.set(file.slice(SRC.length + 1), columns)
+    const body = code(readFileSync(file, 'utf-8'))
+    const relative = file.slice(SRC.length + 1)
+
+    // An aliased import (`jsonExtractText as extract`) renames the call and
+    // would slip past a scan keyed on the original names, so treat it as a
+    // finding in its own right rather than letting the call go unexamined.
+    for (const helper of HELPERS) {
+      const renamed = new RegExp(`\\b${helper}\\s+as\\s+([A-Za-z_$][\\w$]*)`, 'g')
+      for (const match of body.matchAll(renamed)) {
+        aliasedImports.push(`${relative}: ${helper} imported as ${match[1]}`)
+      }
+    }
+
+    const { resolved, unresolved } = collectColumnArguments(body)
+    if (resolved.length) callSites.set(relative, resolved)
+    if (unresolved.length) unresolvedSites.set(relative, unresolved)
   }
 
   it('finds the known call sites, so a broken scan cannot pass vacuously', () => {
@@ -73,6 +107,19 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
     expect(all.length).toBeGreaterThanOrEqual(10)
     // The column this whole suite exists for must be among them.
     expect(all).toContain('a2aTasks.data')
+  })
+
+  it('leaves no helper call whose column argument it could not resolve', () => {
+    // A silent skip here is the failure mode: it reads as "checked and clean"
+    // for a call site the scan never inspected. If this trips, either write the
+    // argument as a direct `table.column` or extend the resolver deliberately.
+    expect(
+      [...unresolvedSites].flatMap(([file, calls]) => calls.map((c) => `${file}: ${c}`)),
+    ).toEqual([])
+  })
+
+  it('leaves no aliased helper import that would rename a call out of view', () => {
+    expect(aliasedImports).toEqual([])
   })
 
   it('resolves every column argument to a json column or an allowed text one', () => {
@@ -84,11 +131,17 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
         const table = (schema as Record<string, unknown>)[tableName] as
           | Record<string, { dataType?: string }>
           | undefined
-        // An unresolvable name means a local alias, not a schema table; the
-        // real schema tables are what this guard is about.
-        if (!table) continue
+        // Not a schema table (e.g. a locally-built drizzle fragment). Recorded
+        // rather than skipped, so the scan cannot quietly ignore a call site.
+        if (!table) {
+          offenders.push(`${file}: ${reference} does not resolve to a schema table`)
+          continue
+        }
         const column = table[columnName]
-        if (!column?.dataType) continue
+        if (!column?.dataType) {
+          offenders.push(`${file}: ${reference} is not a column of that table`)
+          continue
+        }
 
         if (column.dataType === 'json') continue
         if (ALLOWED_PLAIN_TEXT.has(reference)) continue

--- a/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
@@ -23,6 +23,7 @@
  * exactly why it went unnoticed.
  */
 import { PgDialect } from 'drizzle-orm/pg-core'
+import { alias } from 'drizzle-orm/sqlite-core'
 import { describe, expect, it, vi } from 'vitest'
 
 // Force the PostgreSQL branch: isPostgresRuntime() reads `isPostgres` off the
@@ -135,6 +136,34 @@ describe('JSON helpers over a plain text column on PostgreSQL', () => {
     expect(() => jsonPathIsAbsent(runs.status, ['k'])).toThrow(/runs\.status/)
     expect(() => jsonSet(runs.status, ['k'], 1)).toThrow(/runs\.status/)
     expect(() => jsonArrayContainsKeyValue(runs.status, ['a'], 'k', 'v')).toThrow(/runs\.status/)
+  })
+
+  it('still recognises the allowlisted column when its table is aliased', () => {
+    // `alias()` is used in this codebase (lib/agent-access.ts) and makes drizzle
+    // report the alias, not the physical table. Keying the allowlist off the
+    // alias would reject the very column it exists to permit — a self-join or
+    // subquery over a2a_tasks would throw at query-build time.
+    const aliased = alias(a2aTasks, 'task_alias')
+
+    expect(renderPg(jsonExtractText(aliased.data, ['scope', 'tenant']))).toBe(
+      '("task_alias"."data")::jsonb -> $1 ->> $2',
+    )
+  })
+
+  it('refuses a multi-segment jsonSet path, which the dialects disagree on', () => {
+    // Verified on PostgreSQL 14 vs SQLite:
+    //   PG     jsonb_set('{}', '{a,b}', '1', true) -> {}            (silent no-op)
+    //   SQLite json_set('{}', '$.a.b', json('1'))  -> {"a":{"b":1}} (creates it)
+    // `jsonb_set` will not create a missing intermediate parent, so a nested
+    // write would silently do nothing on PostgreSQL only. Rejecting the shape
+    // outright beats shipping a helper that quietly means two different things.
+    // @ts-expect-error - a multi-segment path is not assignable to JsonSetPath
+    expect(() => jsonSet(runSteps.output, ['a', 'b'], 1)).toThrow(/single-segment/)
+  })
+
+  it('still refuses an aliased non-JSON column', () => {
+    // The alias must not become a way to smuggle a bad column past the guard.
+    expect(() => jsonExtractText(alias(runs, 'r').status, ['x'])).toThrow(/status/)
   })
 
   it('leaves a jsonb column uncast for every other helper', () => {

--- a/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
@@ -23,13 +23,19 @@
  * exactly why it went unnoticed.
  */
 import { PgDialect } from 'drizzle-orm/pg-core'
-import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
 import { describe, expect, it, vi } from 'vitest'
 
 // Force the PostgreSQL branch: isPostgresRuntime() reads `isPostgres` off the
 // db/client.js module namespace (see db/dialect-runtime.ts).
 vi.mock('../../db/client.js', () => ({ isPostgres: true }))
 
+// The REAL tables, not local look-alikes. The defect is a mismatch between how
+// a column is declared and what the helper assumes, so re-declaring the column
+// here would assert against the test author's belief rather than against the
+// schema the bug lives in — and would keep passing after a schema change that
+// made the cast wrong. Under the mock above, db/schema.js dispatches to the
+// PostgreSQL tables, which is what these queries actually run against.
+import { a2aTasks, runSteps, runs } from '../../db/schema.js'
 import {
   jsonArrayContainsKeyValue,
   jsonExtractNumber,
@@ -37,20 +43,6 @@ import {
   jsonPathIsAbsent,
   jsonSet,
 } from '../json-sql.js'
-
-/**
- * Mirrors the real declarations: `a2a_tasks.data` is plain text holding JSON,
- * while `run_steps.output` is a `mode: 'json'` column that becomes jsonb.
- */
-const a2aTasksLike = sqliteTable('a2a_tasks', {
-  id: text('id').primaryKey(),
-  data: text('data').notNull(),
-})
-
-const runStepsLike = sqliteTable('run_steps', {
-  id: text('id').primaryKey(),
-  output: text('output', { mode: 'json' }).$type<Record<string, unknown>>(),
-})
 
 const dialect = new PgDialect()
 
@@ -60,8 +52,20 @@ function renderPg(fragment: Parameters<PgDialect['sqlToQuery']>[0]): string {
 }
 
 describe('JSON helpers over a plain text column on PostgreSQL', () => {
+  it('pins the schema premise the rest of this file depends on', () => {
+    // Stated explicitly so that changing either declaration fails HERE, with a
+    // reason, rather than silently turning every assertion below into a
+    // tautology about a column that no longer has the shape being tested.
+    // If a2a_tasks.data ever becomes `mode: 'json'`, the cast correctly stops
+    // applying and the expectations below should be deleted, not re-pinned.
+    expect(a2aTasks.data.dataType, 'a2a_tasks.data is a plain text column holding JSON').toBe(
+      'string',
+    )
+    expect(runSteps.output.dataType, 'run_steps.output is a real JSON column').toBe('json')
+  })
+
   it('casts the column to jsonb before extracting text', () => {
-    const rendered = renderPg(jsonExtractText(a2aTasksLike.data, ['scope', 'tenant']))
+    const rendered = renderPg(jsonExtractText(a2aTasks.data, ['scope', 'tenant']))
 
     // Without the cast this is `"a2a_tasks"."data" -> $1 ->> $2`, which
     // PostgreSQL rejects outright with 42883.
@@ -69,13 +73,13 @@ describe('JSON helpers over a plain text column on PostgreSQL', () => {
   })
 
   it('casts before a single-segment text extraction', () => {
-    expect(renderPg(jsonExtractText(a2aTasksLike.data, ['contextId']))).toBe(
+    expect(renderPg(jsonExtractText(a2aTasks.data, ['contextId']))).toBe(
       '("a2a_tasks"."data")::jsonb ->> $1',
     )
   })
 
   it('casts before extracting a number', () => {
-    expect(renderPg(jsonExtractNumber(a2aTasksLike.data, ['persistenceVersion']))).toBe(
+    expect(renderPg(jsonExtractNumber(a2aTasks.data, ['persistenceVersion']))).toBe(
       '(("a2a_tasks"."data")::jsonb ->> $1)::numeric',
     )
   })
@@ -83,27 +87,27 @@ describe('JSON helpers over a plain text column on PostgreSQL', () => {
   it('casts every parent segment chain from the same cast root', () => {
     // The cast applies once, at the column, and the `->` chain then walks the
     // resulting jsonb — not one cast per segment.
-    const rendered = renderPg(jsonExtractText(a2aTasksLike.data, ['task', 'status', 'state']))
+    const rendered = renderPg(jsonExtractText(a2aTasks.data, ['task', 'status', 'state']))
     expect(rendered).toBe('("a2a_tasks"."data")::jsonb -> $1 -> $2 ->> $3')
     expect(rendered.match(/::jsonb/g)).toHaveLength(1)
   })
 
   it('casts before an array containment probe', () => {
     const rendered = renderPg(
-      jsonArrayContainsKeyValue(a2aTasksLike.data, ['chain'], 'providerId', 'prv_1'),
+      jsonArrayContainsKeyValue(a2aTasks.data, ['chain'], 'providerId', 'prv_1'),
     )
     expect(rendered).toContain('("a2a_tasks"."data")::jsonb')
     expect(rendered).toContain('@>')
   })
 
   it('casts before a key-presence check', () => {
-    const rendered = renderPg(jsonPathIsAbsent(a2aTasksLike.data, ['usage']))
+    const rendered = renderPg(jsonPathIsAbsent(a2aTasks.data, ['usage']))
     // `?` is a jsonb operator too, so the same cast is required.
     expect(rendered).toContain('("a2a_tasks"."data")::jsonb')
   })
 
   it('casts before jsonb_set', () => {
-    const rendered = renderPg(jsonSet(a2aTasksLike.data, ['scope'], { tenant: 't' }))
+    const rendered = renderPg(jsonSet(a2aTasks.data, ['scope'], { tenant: 't' }))
     expect(rendered).toContain('("a2a_tasks"."data")::jsonb')
     expect(rendered).toContain('jsonb_set')
   })
@@ -111,21 +115,35 @@ describe('JSON helpers over a plain text column on PostgreSQL', () => {
   it('leaves a real jsonb column uncast, so no redundant work is added', () => {
     // The cast must be driven by the column's declared type, not applied
     // blanket-fashion: every other call site already passes a jsonb column.
-    const rendered = renderPg(jsonExtractText(runStepsLike.output, ['usage', 'inputTokens']))
+    const rendered = renderPg(jsonExtractText(runSteps.output, ['usage', 'inputTokens']))
 
     expect(rendered).toBe('"run_steps"."output" -> $1 ->> $2')
     expect(rendered).not.toContain('::jsonb')
   })
 
+  it('refuses a column that holds no JSON at all, instead of casting it blindly', () => {
+    // `runs.status` is a plain text status string. Casting it would produce
+    // valid-looking SQL that plans fine and then fails per-row with 22P02 —
+    // or, on an empty table, silently matches nothing. Failing at query-build
+    // time keeps that mistake loud and names the column.
+    expect(() => jsonExtractText(runs.status, ['anything'])).toThrow(/runs\.status/)
+    expect(() => jsonExtractText(runs.status, ['anything'])).toThrow(/mode:'json'/)
+  })
+
+  it('refuses non-JSON columns through every helper, not just the read path', () => {
+    expect(() => jsonExtractNumber(runs.status, ['n'])).toThrow(/runs\.status/)
+    expect(() => jsonPathIsAbsent(runs.status, ['k'])).toThrow(/runs\.status/)
+    expect(() => jsonSet(runs.status, ['k'], 1)).toThrow(/runs\.status/)
+    expect(() => jsonArrayContainsKeyValue(runs.status, ['a'], 'k', 'v')).toThrow(/runs\.status/)
+  })
+
   it('leaves a jsonb column uncast for every other helper', () => {
-    expect(renderPg(jsonExtractNumber(runStepsLike.output, ['usage', 'n']))).not.toContain(
-      '::jsonb',
-    )
-    expect(renderPg(jsonPathIsAbsent(runStepsLike.output, ['usage']))).not.toContain(
+    expect(renderPg(jsonExtractNumber(runSteps.output, ['usage', 'n']))).not.toContain('::jsonb')
+    expect(renderPg(jsonPathIsAbsent(runSteps.output, ['usage']))).not.toContain(
       '"run_steps"."output")::jsonb',
     )
-    expect(
-      renderPg(jsonArrayContainsKeyValue(runStepsLike.output, ['chain'], 'k', 'v')),
-    ).not.toContain('"run_steps"."output")::jsonb')
+    expect(renderPg(jsonArrayContainsKeyValue(runSteps.output, ['chain'], 'k', 'v'))).not.toContain(
+      '"run_steps"."output")::jsonb',
+    )
   })
 })

--- a/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
@@ -161,6 +161,18 @@ describe('JSON helpers over a plain text column on PostgreSQL', () => {
     expect(() => jsonSet(runSteps.output, ['a', 'b'], 1)).toThrow(/single-segment/)
   })
 
+  it('binds the jsonSet segment instead of building a path literal', () => {
+    // A key containing a comma is the case a `'{a,b}'` string literal gets
+    // wrong: PostgreSQL parses it as the nested path a->b and (verified on 14)
+    // returns `{}` unchanged, while SQLite writes the single key "a,b". Binding
+    // a one-element ARRAY makes the segment a parameter, so the value can no
+    // longer be reinterpreted as path structure.
+    const rendered = renderPg(jsonSet(runSteps.output, ['a,b'], 1))
+
+    expect(rendered).toContain('ARRAY[')
+    expect(rendered).not.toContain("'{a,b}'")
+  })
+
   it('still refuses an aliased non-JSON column', () => {
     // The alias must not become a way to smuggle a bad column past the guard.
     expect(() => jsonExtractText(alias(runs, 'r').status, ['x'])).toThrow(/status/)

--- a/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
@@ -1,0 +1,131 @@
+/**
+ * PostgreSQL-branch regression: JSON helpers applied to a **plain text** column.
+ *
+ * The helpers were written on the assumption that every JSON-queried column is
+ * declared `text(..., { mode: 'json' })`, which `db/schema-transform.ts` maps to
+ * `jsonb` on PostgreSQL — so the emitted `->` / `->>` / `?` / `@>` operators
+ * always had a jsonb left-hand side.
+ *
+ * `a2a_tasks.data` breaks that assumption. It stores a JSON envelope but is
+ * declared as plain `text`, because `a2a/sqlite-task-store.ts` serialises and
+ * parses it by hand (`encodeTask` returns a string; `JSON.parse(row.data)`
+ * reads one back) rather than letting drizzle do it. The transform keys off
+ * `mode: 'json'` alone, so the column stays `text` on PostgreSQL while
+ * `SqliteTaskStore.list()` builds `data -> 'scope' ->> 'tenant'` over it.
+ *
+ * PostgreSQL defines `->` / `->>` only for json/jsonb, so that is not a
+ * degradation but a hard `42883 operator does not exist: text -> unknown` —
+ * every A2A `tasks/list` call fails on a PostgreSQL deployment.
+ *
+ * The fix casts a non-JSON column to jsonb inside the PostgreSQL branch. These
+ * assertions are on rendered SQL because catching it at runtime needs a live
+ * PostgreSQL server plus a request reaching that specific query — which is
+ * exactly why it went unnoticed.
+ */
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { describe, expect, it, vi } from 'vitest'
+
+// Force the PostgreSQL branch: isPostgresRuntime() reads `isPostgres` off the
+// db/client.js module namespace (see db/dialect-runtime.ts).
+vi.mock('../../db/client.js', () => ({ isPostgres: true }))
+
+import {
+  jsonArrayContainsKeyValue,
+  jsonExtractNumber,
+  jsonExtractText,
+  jsonPathIsAbsent,
+  jsonSet,
+} from '../json-sql.js'
+
+/**
+ * Mirrors the real declarations: `a2a_tasks.data` is plain text holding JSON,
+ * while `run_steps.output` is a `mode: 'json'` column that becomes jsonb.
+ */
+const a2aTasksLike = sqliteTable('a2a_tasks', {
+  id: text('id').primaryKey(),
+  data: text('data').notNull(),
+})
+
+const runStepsLike = sqliteTable('run_steps', {
+  id: text('id').primaryKey(),
+  output: text('output', { mode: 'json' }).$type<Record<string, unknown>>(),
+})
+
+const dialect = new PgDialect()
+
+/** Render a drizzle fragment to the SQL text PostgreSQL would actually receive. */
+function renderPg(fragment: Parameters<PgDialect['sqlToQuery']>[0]): string {
+  return dialect.sqlToQuery(fragment).sql
+}
+
+describe('JSON helpers over a plain text column on PostgreSQL', () => {
+  it('casts the column to jsonb before extracting text', () => {
+    const rendered = renderPg(jsonExtractText(a2aTasksLike.data, ['scope', 'tenant']))
+
+    // Without the cast this is `"a2a_tasks"."data" -> $1 ->> $2`, which
+    // PostgreSQL rejects outright with 42883.
+    expect(rendered).toBe('("a2a_tasks"."data")::jsonb -> $1 ->> $2')
+  })
+
+  it('casts before a single-segment text extraction', () => {
+    expect(renderPg(jsonExtractText(a2aTasksLike.data, ['contextId']))).toBe(
+      '("a2a_tasks"."data")::jsonb ->> $1',
+    )
+  })
+
+  it('casts before extracting a number', () => {
+    expect(renderPg(jsonExtractNumber(a2aTasksLike.data, ['persistenceVersion']))).toBe(
+      '(("a2a_tasks"."data")::jsonb ->> $1)::numeric',
+    )
+  })
+
+  it('casts every parent segment chain from the same cast root', () => {
+    // The cast applies once, at the column, and the `->` chain then walks the
+    // resulting jsonb — not one cast per segment.
+    const rendered = renderPg(jsonExtractText(a2aTasksLike.data, ['task', 'status', 'state']))
+    expect(rendered).toBe('("a2a_tasks"."data")::jsonb -> $1 -> $2 ->> $3')
+    expect(rendered.match(/::jsonb/g)).toHaveLength(1)
+  })
+
+  it('casts before an array containment probe', () => {
+    const rendered = renderPg(
+      jsonArrayContainsKeyValue(a2aTasksLike.data, ['chain'], 'providerId', 'prv_1'),
+    )
+    expect(rendered).toContain('("a2a_tasks"."data")::jsonb')
+    expect(rendered).toContain('@>')
+  })
+
+  it('casts before a key-presence check', () => {
+    const rendered = renderPg(jsonPathIsAbsent(a2aTasksLike.data, ['usage']))
+    // `?` is a jsonb operator too, so the same cast is required.
+    expect(rendered).toContain('("a2a_tasks"."data")::jsonb')
+  })
+
+  it('casts before jsonb_set', () => {
+    const rendered = renderPg(jsonSet(a2aTasksLike.data, ['scope'], { tenant: 't' }))
+    expect(rendered).toContain('("a2a_tasks"."data")::jsonb')
+    expect(rendered).toContain('jsonb_set')
+  })
+
+  it('leaves a real jsonb column uncast, so no redundant work is added', () => {
+    // The cast must be driven by the column's declared type, not applied
+    // blanket-fashion: every other call site already passes a jsonb column.
+    const rendered = renderPg(jsonExtractText(runStepsLike.output, ['usage', 'inputTokens']))
+
+    expect(rendered).toBe('"run_steps"."output" -> $1 ->> $2')
+    expect(rendered).not.toContain('::jsonb')
+  })
+
+  it('leaves a jsonb column uncast for every other helper', () => {
+    expect(renderPg(jsonExtractNumber(runStepsLike.output, ['usage', 'n']))).not.toContain(
+      '::jsonb',
+    )
+    expect(renderPg(jsonPathIsAbsent(runStepsLike.output, ['usage']))).not.toContain(
+      '"run_steps"."output")::jsonb',
+    )
+    expect(
+      renderPg(jsonArrayContainsKeyValue(runStepsLike.output, ['chain'], 'k', 'v')),
+    ).not.toContain('"run_steps"."output")::jsonb')
+  })
+})

--- a/apps/api/src/lib/json-sql.ts
+++ b/apps/api/src/lib/json-sql.ts
@@ -22,6 +22,23 @@ import { isPostgresRuntime } from '../db/dialect-runtime.js'
 type JsonPath = readonly [string, ...string[]]
 
 /**
+ * The PostgreSQL operators below (`->`, `->>`, `?`, `@>`, `jsonb_set`) are
+ * defined for json/jsonb only. Columns declared `text(..., { mode: 'json' })`
+ * become `jsonb` via db/schema-transform.ts and need nothing extra — but a
+ * column holding JSON while declared as plain `text` does, or PostgreSQL fails
+ * the statement outright with `42883 operator does not exist: text -> unknown`.
+ *
+ * `a2a_tasks.data` is that column: a2a/sqlite-task-store.ts serialises and
+ * parses the envelope by hand instead of through drizzle, so it is plain text
+ * on both dialects while `list()` still filters on `scope`/`task` paths inside
+ * it. Keying the cast off the column's declared `dataType` fixes that without
+ * adding a redundant cast to the jsonb columns every other call site passes.
+ */
+function pgJsonSource(column: SQLiteColumn): SQL {
+  return column.dataType === 'json' ? sql`${column}` : sql`(${column})::jsonb`
+}
+
+/**
  * Build the PostgreSQL accessor chain: every segment but the last uses `->`
  * (which yields jsonb, so it can be chained), and the final one uses `->>`
  * (which yields text, so it can be cast or compared).
@@ -29,7 +46,7 @@ type JsonPath = readonly [string, ...string[]]
 function pgAccessor(column: SQLiteColumn, path: JsonPath): SQL {
   const parents = path.slice(0, -1)
   const leaf = path[path.length - 1]
-  let expr = sql`${column}`
+  let expr = pgJsonSource(column)
   for (const segment of parents) {
     expr = sql`${expr} -> ${segment}`
   }
@@ -81,7 +98,7 @@ export function jsonArrayContainsKeyValue(
   value: string,
 ): SQL {
   if (isPostgresRuntime()) {
-    let target = sql`${column}`
+    let target = pgJsonSource(column)
     for (const segment of arrayPath) {
       target = sql`${target} -> ${segment}`
     }
@@ -105,7 +122,7 @@ export function jsonArrayContainsKeyValue(
 export function jsonSet(column: SQLiteColumn, path: JsonPath, value: unknown): SQL {
   const serialized = JSON.stringify(value)
   if (isPostgresRuntime()) {
-    return sql`jsonb_set(COALESCE(${column}, '{}'::jsonb), ${`{${path.join(',')}}`}, ${serialized}::jsonb, true)`
+    return sql`jsonb_set(COALESCE(${pgJsonSource(column)}, '{}'::jsonb), ${`{${path.join(',')}}`}, ${serialized}::jsonb, true)`
   }
   return sql`json_set(COALESCE(${column}, '{}'), ${sqlitePath(path)}, json(${serialized}))`
 }
@@ -120,7 +137,7 @@ export function jsonSet(column: SQLiteColumn, path: JsonPath, value: unknown): S
 export function jsonPathIsAbsent(column: SQLiteColumn, path: JsonPath): SQL {
   if (isPostgresRuntime()) {
     const leaf = path[path.length - 1]
-    let parent = sql`${column}`
+    let parent = pgJsonSource(column)
     for (const segment of path.slice(0, -1)) {
       parent = sql`${parent} -> ${segment}`
     }

--- a/apps/api/src/lib/json-sql.ts
+++ b/apps/api/src/lib/json-sql.ts
@@ -208,7 +208,12 @@ export function jsonSet(column: SQLiteColumn, path: JsonSetPath, value: unknown)
   }
   const serialized = JSON.stringify(value)
   if (isPostgresRuntime()) {
-    return sql`jsonb_set(COALESCE(${pgJsonSource(column)}, '{}'::jsonb), ${`{${path.join(',')}}`}, ${serialized}::jsonb, true)`
+    // `ARRAY[$n]`, not a `'{seg}'` literal. Building the path as text makes the
+    // segment's *content* structural: a key containing a comma — `['a,b']` —
+    // parses as the nested path a->b, which jsonb_set then no-ops on because
+    // `a` is absent (verified on PostgreSQL 14), while SQLite writes the single
+    // key "a,b". Binding a one-element array keeps the segment a value.
+    return sql`jsonb_set(COALESCE(${pgJsonSource(column)}, '{}'::jsonb), ARRAY[${path[0]}], ${serialized}::jsonb, true)`
   }
   return sql`json_set(COALESCE(${column}, '{}'), ${sqlitePath(path)}, json(${serialized}))`
 }

--- a/apps/api/src/lib/json-sql.ts
+++ b/apps/api/src/lib/json-sql.ts
@@ -1,4 +1,4 @@
-import { type SQL, sql } from 'drizzle-orm'
+import { type SQL, getTableName, sql } from 'drizzle-orm'
 import type { SQLiteColumn } from 'drizzle-orm/sqlite-core'
 import { isPostgresRuntime } from '../db/dialect-runtime.js'
 
@@ -10,9 +10,22 @@ import { isPostgresRuntime } from '../db/dialect-runtime.js'
  * Every JSON-reading query therefore has to be built through these helpers
  * rather than written inline, or it silently works on one backend only.
  *
- * A note on storage: these columns are `text` under SQLite but `jsonb` under
- * PostgreSQL (see db/schema-transform.ts). The PostgreSQL operators below are
- * the jsonb ones, which is exactly why that mapping was chosen.
+ * A note on storage: a column declared `text(..., { mode: 'json' })` is `text`
+ * under SQLite and `jsonb` under PostgreSQL (see db/schema-transform.ts). The
+ * PostgreSQL operators below are the jsonb ones, which is exactly why that
+ * mapping was chosen.
+ *
+ * That mapping keys off `mode: 'json'` and nothing else, so it is **not** true
+ * that every JSON-holding column is jsonb on PostgreSQL. A column whose JSON is
+ * serialised by hand is declared plain `text` and stays `text` on both dialects
+ * — `a2a_tasks.data` is exactly that (a2a/sqlite-task-store.ts does its own
+ * JSON.stringify/JSON.parse). Assuming otherwise is what made `tasks/list` fail
+ * with `42883 operator does not exist: text -> unknown` on every PostgreSQL
+ * deployment. The helpers below handle it via `pgJsonSource`; an inline
+ * `->`/`->>` written at a call site would not, and no gate catches that
+ * (no-raw-sqlite-json-sql.test.ts scans for the SQLite-only functions only).
+ * So: route JSON access through these helpers, and do not assume the column
+ * arrived as jsonb.
  *
  * All operators used here predate PostgreSQL 9.6 (`->`/`->>` arrived in 9.3),
  * so nothing here breaks the supported floor.
@@ -22,20 +35,50 @@ import { isPostgresRuntime } from '../db/dialect-runtime.js'
 type JsonPath = readonly [string, ...string[]]
 
 /**
- * The PostgreSQL operators below (`->`, `->>`, `?`, `@>`, `jsonb_set`) are
- * defined for json/jsonb only. Columns declared `text(..., { mode: 'json' })`
- * become `jsonb` via db/schema-transform.ts and need nothing extra — but a
- * column holding JSON while declared as plain `text` does, or PostgreSQL fails
- * the statement outright with `42883 operator does not exist: text -> unknown`.
+ * Plain-text columns that legitimately hold JSON, as `table.column`.
  *
- * `a2a_tasks.data` is that column: a2a/sqlite-task-store.ts serialises and
- * parses the envelope by hand instead of through drizzle, so it is plain text
- * on both dialects while `list()` still filters on `scope`/`task` paths inside
- * it. Keying the cast off the column's declared `dataType` fixes that without
- * adding a redundant cast to the jsonb columns every other call site passes.
+ * Deliberately an allowlist rather than "cast anything that is not json". A
+ * blanket cast also swallows the case these helpers should never see — a
+ * genuinely non-JSON column passed by mistake, say `runs.status`. Pre-cast that
+ * failed at PostgreSQL's parse stage with `42883 operator does not exist`,
+ * naming the operator before a single row was read. Cast blindly it instead
+ * plans fine and fails per-row with `22P02 invalid input syntax for type json`,
+ * pointing at the value rather than the mistake — and on an empty table it does
+ * not fail at all, silently returning no rows so a mis-wired predicate reads as
+ * "nothing matched" instead of a bug.
+ *
+ * Naming the columns keeps the loud, early failure for a real mistake while
+ * still fixing the columns that need it.
+ */
+const PLAIN_TEXT_JSON_COLUMNS: ReadonlySet<string> = new Set([
+  // a2a/sqlite-task-store.ts serialises and parses this envelope by hand
+  // (`encodeTask` returns a string, `JSON.parse(row.data)` reads one back)
+  // instead of letting drizzle do it, so it carries no `mode: 'json'` and stays
+  // `text` on both dialects while `list()` filters on paths inside it.
+  'a2a_tasks.data',
+])
+
+/**
+ * The PostgreSQL operators used below (`->`, `->>`, `?`, `@>`, `jsonb_set`) are
+ * defined for json/jsonb only. A `mode: 'json'` column is already `jsonb` via
+ * db/schema-transform.ts and needs nothing; a plain-text JSON column must be
+ * cast, or the statement dies with `42883 operator does not exist: text ->
+ * unknown` — which is exactly how every A2A `tasks/list` call failed on
+ * PostgreSQL.
+ *
+ * Throws for a column that is neither, since that is a call-site error no cast
+ * can rescue: it fails at query-build time, in-process and with the column
+ * named, rather than reaching the server as a confusing per-row data error.
  */
 function pgJsonSource(column: SQLiteColumn): SQL {
-  return column.dataType === 'json' ? sql`${column}` : sql`(${column})::jsonb`
+  if (column.dataType === 'json') return sql`${column}`
+
+  const qualifiedName = `${getTableName(column.table)}.${column.name}`
+  if (PLAIN_TEXT_JSON_COLUMNS.has(qualifiedName)) return sql`(${column})::jsonb`
+
+  throw new Error(
+    `json-sql: ${qualifiedName} is neither a mode:'json' column nor a known plain-text JSON column. Declare it as text(..., { mode: 'json' }), or add it to PLAIN_TEXT_JSON_COLUMNS if it holds hand-serialised JSON.`,
+  )
 }
 
 /**

--- a/apps/api/src/lib/json-sql.ts
+++ b/apps/api/src/lib/json-sql.ts
@@ -35,6 +35,21 @@ import { isPostgresRuntime } from '../db/dialect-runtime.js'
 type JsonPath = readonly [string, ...string[]]
 
 /**
+ * `jsonSet` accepts a **single** segment only — the two dialects disagree on
+ * anything deeper. Verified on PostgreSQL 14 against SQLite:
+ *
+ *   PG      jsonb_set('{}', '{a,b}', '1', true)  ->  {}
+ *   SQLite  json_set('{}', '$.a.b', json('1'))   ->  {"a":{"b":1}}
+ *
+ * `jsonb_set` refuses to create a missing intermediate parent and returns the
+ * document untouched, so a nested write would silently no-op on PostgreSQL
+ * while succeeding on SQLite — the same "works on the backend you run locally"
+ * trap this module exists to close. Narrowing the type makes the divergence
+ * unreachable rather than merely documented.
+ */
+type JsonSetPath = readonly [string]
+
+/**
  * Plain-text columns that legitimately hold JSON, as `table.column`.
  *
  * Deliberately an allowlist rather than "cast anything that is not json". A
@@ -59,6 +74,25 @@ const PLAIN_TEXT_JSON_COLUMNS: ReadonlySet<string> = new Set([
 ])
 
 /**
+ * The physical table a column belongs to, seeing through `alias()`.
+ *
+ * `getTableName` reports the *alias* — `alias(a2aTasks, 'task_alias')` yields
+ * `task_alias` — which would miss the allowlist above and reject the very
+ * column it exists to permit. `alias()` is already used in this codebase
+ * (lib/agent-access.ts), so a self-join or subquery over a2a_tasks is a live
+ * shape rather than a hypothetical one. drizzle keeps the underlying name on
+ * the table under a globally-registered symbol; fall back to the alias if a
+ * future version stops populating it, since a wrong-but-present name only
+ * costs a clearer error while a crash here would break query building.
+ */
+function physicalTableName(column: SQLiteColumn): string {
+  const original = (column.table as unknown as Record<symbol, unknown>)[
+    Symbol.for('drizzle:OriginalName')
+  ]
+  return typeof original === 'string' ? original : getTableName(column.table)
+}
+
+/**
  * The PostgreSQL operators used below (`->`, `->>`, `?`, `@>`, `jsonb_set`) are
  * defined for json/jsonb only. A `mode: 'json'` column is already `jsonb` via
  * db/schema-transform.ts and needs nothing; a plain-text JSON column must be
@@ -73,7 +107,7 @@ const PLAIN_TEXT_JSON_COLUMNS: ReadonlySet<string> = new Set([
 function pgJsonSource(column: SQLiteColumn): SQL {
   if (column.dataType === 'json') return sql`${column}`
 
-  const qualifiedName = `${getTableName(column.table)}.${column.name}`
+  const qualifiedName = `${physicalTableName(column)}.${column.name}`
   if (PLAIN_TEXT_JSON_COLUMNS.has(qualifiedName)) return sql`(${column})::jsonb`
 
   throw new Error(
@@ -156,13 +190,22 @@ export function jsonArrayContainsKeyValue(
 }
 
 /**
- * Set a JSON path to `value`, treating a NULL column as an empty object.
+ * Set a top-level JSON key to `value`, treating a NULL column as an empty
+ * object. Single-segment only — see `JsonSetPath` for why anything deeper is a
+ * dialect divergence rather than a feature.
  *
  * `jsonb_set` predates the 9.6 floor (it arrived in 9.5). Both branches take the
  * value as a bound parameter rather than interpolating it, so a string inside
  * the payload cannot terminate the literal.
  */
-export function jsonSet(column: SQLiteColumn, path: JsonPath, value: unknown): SQL {
+export function jsonSet(column: SQLiteColumn, path: JsonSetPath, value: unknown): SQL {
+  // The type already forbids this; the runtime check covers a path built
+  // dynamically (`string[]` widened at a call site), where the compiler cannot.
+  if (path.length !== 1) {
+    throw new Error(
+      `json-sql: jsonSet takes a single-segment path, got [${path.join(', ')}]. PostgreSQL's jsonb_set will not create a missing intermediate parent, so a nested write silently no-ops there while succeeding on SQLite.`,
+    )
+  }
   const serialized = JSON.stringify(value)
   if (isPostgresRuntime()) {
     return sql`jsonb_set(COALESCE(${pgJsonSource(column)}, '{}'::jsonb), ${`{${path.join(',')}}`}, ${serialized}::jsonb, true)`


### PR DESCRIPTION
## Problem

`a2a_tasks.data` holds a JSON envelope but is declared as plain `text`, because `a2a/sqlite-task-store.ts` serialises and parses it by hand (`encodeTask` returns a string, `JSON.parse(row.data)` reads one back) rather than letting drizzle do it.

`db/schema-transform.ts` maps a column to `jsonb` based on `mode: 'json'` and nothing else, so this column stays `text` in the PostgreSQL lineage — while `SqliteTaskStore.list()` still builds `data -> 'scope' ->> 'tenant'` over it.

PostgreSQL defines `->` / `->>` for json/jsonb only, so this does not degrade — it fails the statement outright. **Every A2A `tasks/list` call 500s on a PostgreSQL deployment.** Verified against a real PostgreSQL 14 server:

```
SELECT "data" -> 'scope' ->> 'tenant' FROM a2a_tasks;
  ERROR:  operator does not exist: text -> unknown        ← 42883

SELECT ("data")::jsonb -> 'scope' ->> 'tenant' FROM a2a_tasks;
  acme  (1 row)
```

`a2a_tasks.data` is the only such column today — every other JSON-queried column (`runs.result`, `run_steps.output`, `agents.config`, …) is `mode: 'json'` and unaffected.

## Approach

Cast at the column inside the PostgreSQL branch, keyed off the column's declared type, rather than changing the column to `mode: 'json'`. The latter would make drizzle return a parsed object, rippling through `save`/`load`/`list`/`markTaskFailed` and changing the SQLite storage path too — a large change to the storage layer for a query-layer bug.

The cast is an **allowlist**, not "cast anything non-json". A blanket cast would also swallow a genuinely non-JSON column passed by mistake: pre-cast that failed at parse time with `42883` naming the operator, but cast blindly it plans fine and fails per-row with `22P02` — and on an empty table does not fail at all, silently returning no rows. The guard keeps that mistake loud and names the column at query-build time.

## Review rounds

Reviewed with `/code-review high` and two `codex` passes; findings were verified against a live PostgreSQL 14 rather than accepted on argument.

| Finding | Resolution |
|---|---|
| Blanket cast degrades error reporting | Allowlist + build-time throw |
| Module header asserted the disproved invariant | Rewritten |
| Tests used local fixtures, not the real schema | Import real tables + premise assertion |
| Runtime guard only fires on PostgreSQL | Added dialect-independent call-site gate |
| Allowlist rejected `alias()`-wrapped tables | Resolve via drizzle's `OriginalName` |
| `jsonSet` multi-segment path diverges by dialect | Type narrowed to single segment + runtime check |
| Call-site gate had false negatives | Detect aliased imports, local rebinds, unresolved args |
| `jsonSet` segment *content* could still carry a comma | Bind `ARRAY[$n]` instead of a `'{seg}'` literal |

One review finding was **rejected**: the claim that `jsonSet` now fails with `42804` because "pg_cast defines jsonb→text as explicit-only". That pg_cast row does not exist — PostgreSQL falls back to I/O conversion, which is permitted for assignment to a text target. The UPDATE succeeds and round-trips; independently confirmed by codex.

Two dialect divergences found and closed along the way, both verified on real servers:

```
PG      jsonb_set('{}', '{a,b}', '1', true)  ->  {}            (silent no-op)
SQLite  json_set('{}', '$.a.b', json('1'))   ->  {"a":{"b":1}}
```

## Testing

TDD throughout — every fix started from a failing test.

- `json-sql-pg-text-column.test.ts` — cast behaviour, guard, aliasing, `jsonSet` shape
- `json-sql-call-sites.test.ts` — resolves every column argument at every call site against the schema, dialect-independently (the runtime guard only fires on PostgreSQL, and SQLite is the supported default)

Both gates were confirmed to actually catch what they claim: planting a mistyped call site, an aliased import, a local rebind, and flipping the schema to `mode: 'json'` each produce a precise failure.

**Gates:** lint 0 errors (426 pre-existing warnings, none added) · typecheck fully green · api 5507 tests, web 852, scripts 180 — all pass.

## Notes

- Manual update not needed — internal DB helpers and tests only; no pages, routes, or user-visible copy.
- Not addressed: a malformed-JSON row fails the whole statement, on both dialects alike (`::jsonb` and `json_extract` both raise). Pre-existing and dialect-neutral, so out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)