### PR TITLE
fix(api): make JSON SQL helpers work on plain-text JSON columns, and enforce the column invariant on both dialects

### DIFF
--- a/apps/api/src/a2a/__tests__/sqlite-task-store.test.ts
+++ b/apps/api/src/a2a/__tests__/sqlite-task-store.test.ts
@@ -170,6 +170,20 @@ describe('SqliteTaskStore', () => {
     expect(JSON.stringify(JSON.parse(persisted))).toContain('beforeafter')
   })
 
+  it('preserves text that literally spells out a unicode escape', async () => {
+    // The strip runs on the SERIALISED form, so it must not corrupt a user who
+    // typed the six characters backslash-u-0-0-0-0 into a message: stringify escapes that as
+    // \\u0000, and the negative lookbehind keeps it. Getting this wrong would
+    // silently rewrite caller content — worse than the bug being fixed.
+    vi.spyOn(store, 'cleanup').mockResolvedValue(0)
+    const literal = 'a\\u0000b'
+
+    await store.save(task('task_literal', undefined, literal), callContext())
+
+    const persisted = mockInsertValues.mock.calls[0][0].data
+    expect(JSON.parse(persisted).task.contextId).toBe(literal)
+  })
+
   it('rejects an update when the task ID belongs to another scope', async () => {
     mockSelectGet.mockReturnValue({
       id: 'task_shared',

--- a/apps/api/src/a2a/__tests__/sqlite-task-store.test.ts
+++ b/apps/api/src/a2a/__tests__/sqlite-task-store.test.ts
@@ -148,6 +148,28 @@ describe('SqliteTaskStore', () => {
     })
   })
 
+  it('strips NUL from the persisted envelope, which PostgreSQL jsonb cannot hold', async () => {
+    // A2A message text is caller-supplied. `JSON.stringify` renders U+0000 as a
+    // valid \\u0000 escape that SQLite stores happily, but jsonb holds unescaped
+    // text and has no NUL, so `(data)::jsonb` fails with 22P05 — verified on
+    // PostgreSQL 14. Because `list()` casts the WHOLE envelope to filter on
+    // scope.tenant, one NUL in one task's text breaks tasks/list for every task
+    // in that scope, including tasks that contain none.
+    vi.spyOn(store, 'cleanup').mockResolvedValue(0)
+    const nul = String.fromCharCode(0)
+    // contextId round-trips through the SDK codec verbatim, so the NUL is
+    // still present in the serialised envelope unless it is stripped.
+    const withNul = task('task_nul', undefined, `before${nul}after`)
+
+    await store.save(withNul, callContext())
+
+    const persisted = mockInsertValues.mock.calls[0][0].data
+    expect(persisted).not.toContain(nul)
+    expect(persisted).not.toContain('\\u0000')
+    // Still valid JSON, and the surrounding text survives intact.
+    expect(JSON.stringify(JSON.parse(persisted))).toContain('beforeafter')
+  })
+
   it('rejects an update when the task ID belongs to another scope', async () => {
     mockSelectGet.mockReturnValue({
       id: 'task_shared',

--- a/apps/api/src/a2a/__tests__/sqlite-task-store.test.ts
+++ b/apps/api/src/a2a/__tests__/sqlite-task-store.test.ts
@@ -184,6 +184,34 @@ describe('SqliteTaskStore', () => {
     expect(JSON.parse(persisted).task.contextId).toBe(literal)
   })
 
+  it('strips a lone surrogate, which PostgreSQL jsonb also rejects', async () => {
+    // Same failure class as NUL and the same whole-scope blast radius, but it
+    // arrives by accident far more easily: truncating a UTF-16 string mid-emoji
+    // leaves an unpaired half. Verified on PostgreSQL 14 —
+    // `'{"t":"<lone high surrogate>"}'::jsonb` raises 22P02 "Unicode low
+    // surrogate must follow a high surrogate".
+    vi.spyOn(store, 'cleanup').mockResolvedValue(0)
+    const loneHigh = String.fromCharCode(0xd800)
+
+    await store.save(task('task_sur', undefined, `before${loneHigh}after`), callContext())
+
+    const persisted = mockInsertValues.mock.calls[0][0].data
+    expect(persisted).not.toMatch(/[\uD800-\uDFFF]/)
+    expect(JSON.parse(persisted).task.contextId).toBe('beforeafter')
+  })
+
+  it('keeps a valid surrogate pair, which is an ordinary astral character', async () => {
+    // The strip must remove only UNPAIRED halves. An emoji is a legitimate pair
+    // and round-trips through jsonb, so removing it would corrupt caller text.
+    vi.spyOn(store, 'cleanup').mockResolvedValue(0)
+    const emoji = String.fromCodePoint(0x1f600)
+
+    await store.save(task('task_emoji', undefined, `a${emoji}b`), callContext())
+
+    const persisted = mockInsertValues.mock.calls[0][0].data
+    expect(JSON.parse(persisted).task.contextId).toBe(`a${emoji}b`)
+  })
+
   it('rejects an update when the task ID belongs to another scope', async () => {
     mockSelectGet.mockReturnValue({
       id: 'task_shared',

--- a/apps/api/src/a2a/sqlite-task-store.ts
+++ b/apps/api/src/a2a/sqlite-task-store.ts
@@ -51,30 +51,32 @@ function sameScope(left: TaskScope, right: TaskScope): boolean {
 }
 
 /**
- * Strip NUL from the serialised envelope.
+ * Code points that are valid JSON but that PostgreSQL's jsonb cannot hold.
  *
- * `JSON.stringify` renders a U+0000 in any task text as a \\u0000 escape,
- * which is valid JSON and which SQLite stores and reads back happily. On
- * PostgreSQL it is unrepresentable: jsonb holds *unescaped* text and there is no
- * text form of NUL, so `(data)::jsonb` fails the whole statement with
- * `22P05 unsupported Unicode escape sequence` — verified on PostgreSQL 14.
+ * jsonb stores *unescaped* text, so a code point with no text representation
+ * fails the `(data)::jsonb` cast outright. Two shapes qualify, both verified
+ * against a live PostgreSQL 14:
  *
- * The blast radius is what makes this worth handling at the write path. `list()`
- * casts the entire envelope to filter on `scope.tenant`, so a single NUL
- * anywhere in one task's text — a field the query never reads — makes
- * `tasks/list` fail for **every** task in that scope, not just the offending
- * one. A2A message content is caller-supplied, so this is reachable input
- * rather than a hypothetical.
+ *   U+0000          22P05 unsupported Unicode escape sequence
+ *   lone surrogate  22P02 Unicode low surrogate must follow a high surrogate
  *
- * Stripping rather than rejecting: NUL carries no meaning in the message text
- * these envelopes hold, and failing a `tasks/send` for a stray control byte
- * would be a worse outcome than dropping it. The substitution runs on the
- * serialised form, so it can only touch the escape sequence — never a literal
- * backslash-u in the source text, which stringify would have escaped as
- * `\\u0000` and which the negative lookbehind therefore preserves.
+ * A *paired* surrogate is fine — it is just an astral character, and an emoji
+ * round-trips — so only unpaired halves are removed.
+ *
+ * The blast radius is what makes this worth handling at the write path.
+ * `list()` casts the entire envelope to filter on `scope.tenant`, so one bad
+ * code point anywhere in one task's text — a field the query never reads —
+ * makes `tasks/list` fail for **every** task in that scope, not just the
+ * offending one. A2A message content is caller-supplied, and a lone surrogate
+ * is what an ordinary client produces by truncating a UTF-16 string mid-emoji,
+ * so this is reachable input rather than a hypothetical.
+ *
+ * Stripping rather than rejecting: neither shape carries meaning in the message
+ * text these envelopes hold, and failing a `tasks/send` over a stray code unit
+ * would be the worse outcome.
  *
  * This fixes the write path only; a row persisted **before** this change can
- * still carry the escape and would still fail `list()` on PostgreSQL. No
+ * still carry such a code point and would still fail `list()` on PostgreSQL. No
  * backfill ships with it, for two reasons: PostgreSQL is experimental with no
  * SQLite -> PostgreSQL data migration path, so no deployment can have inherited
  * such a row from SQLite; and `cleanup()` retires envelopes past its retention
@@ -83,8 +85,30 @@ function sameScope(left: TaskScope, right: TaskScope): boolean {
  * `load()` and `save()` still work on it, since they read the column directly
  * and only the whole-envelope cast in `list()` raises.
  */
-function stripNulEscapes(serialized: string): string {
-  return serialized.replace(/(?<!\\)((?:\\\\)*)\\u0000/g, '$1')
+const PG_UNREPRESENTABLE = new RegExp(
+  [
+    '\\u0000',
+    '[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])',
+    '(?<![\\uD800-\\uDBFF])[\\uDC00-\\uDFFF]',
+  ].join('|'),
+  'g',
+)
+
+/**
+ * Serialise an envelope, dropping those code points from every string in it.
+ *
+ * Applied to the VALUES during serialisation rather than to the JSON text
+ * afterwards. An earlier revision rewrote the serialised string with a regex
+ * over escape sequences; that worked, but it had to reason about backslash
+ * parity to avoid corrupting a user who typed the escape literally, and it did
+ * not generalise — the surrogate case would have needed a second, subtler
+ * escape-level pattern. Sanitising the data is the level the problem lives at,
+ * so one rule covers both shapes and cannot mangle neighbouring text.
+ */
+function encodeEnvelope(envelope: unknown): string {
+  return JSON.stringify(envelope, (_key, value) =>
+    typeof value === 'string' ? value.replace(PG_UNREPRESENTABLE, '') : value,
+  )
 }
 
 function encodeTask(task: Task, scope: TaskScope): string {
@@ -93,7 +117,7 @@ function encodeTask(task: Task, scope: TaskScope): string {
     scope,
     task: TaskCodec.toJSON(task),
   }
-  return stripNulEscapes(JSON.stringify(envelope))
+  return encodeEnvelope(envelope)
 }
 
 function decodeEnvelope(data: string): PersistedTaskEnvelope | undefined {
@@ -403,7 +427,7 @@ export class SqliteTaskStore implements TaskStore {
     }
     await db
       .update(a2aTasks)
-      .set({ data: stripNulEscapes(JSON.stringify(updated)), updatedAt: now })
+      .set({ data: encodeEnvelope(updated), updatedAt: now })
       .where(eq(a2aTasks.id, taskId))
     return true
   }

--- a/apps/api/src/a2a/sqlite-task-store.ts
+++ b/apps/api/src/a2a/sqlite-task-store.ts
@@ -50,13 +50,40 @@ function sameScope(left: TaskScope, right: TaskScope): boolean {
   return left.tenant === right.tenant && left.owner === right.owner
 }
 
+/**
+ * Strip NUL from the serialised envelope.
+ *
+ * `JSON.stringify` renders a U+0000 in any task text as a \\u0000 escape,
+ * which is valid JSON and which SQLite stores and reads back happily. On
+ * PostgreSQL it is unrepresentable: jsonb holds *unescaped* text and there is no
+ * text form of NUL, so `(data)::jsonb` fails the whole statement with
+ * `22P05 unsupported Unicode escape sequence` — verified on PostgreSQL 14.
+ *
+ * The blast radius is what makes this worth handling at the write path. `list()`
+ * casts the entire envelope to filter on `scope.tenant`, so a single NUL
+ * anywhere in one task's text — a field the query never reads — makes
+ * `tasks/list` fail for **every** task in that scope, not just the offending
+ * one. A2A message content is caller-supplied, so this is reachable input
+ * rather than a hypothetical.
+ *
+ * Stripping rather than rejecting: NUL carries no meaning in the message text
+ * these envelopes hold, and failing a `tasks/send` for a stray control byte
+ * would be a worse outcome than dropping it. The substitution runs on the
+ * serialised form, so it can only touch the escape sequence — never a literal
+ * backslash-u in the source text, which stringify would have escaped as
+ * `\\u0000`.
+ */
+function stripNulEscapes(serialized: string): string {
+  return serialized.replace(/(?<!\\)((?:\\\\)*)\\u0000/g, '$1')
+}
+
 function encodeTask(task: Task, scope: TaskScope): string {
   const envelope: PersistedTaskEnvelope = {
     persistenceVersion: 1,
     scope,
     task: TaskCodec.toJSON(task),
   }
-  return JSON.stringify(envelope)
+  return stripNulEscapes(JSON.stringify(envelope))
 }
 
 function decodeEnvelope(data: string): PersistedTaskEnvelope | undefined {
@@ -366,7 +393,7 @@ export class SqliteTaskStore implements TaskStore {
     }
     await db
       .update(a2aTasks)
-      .set({ data: JSON.stringify(updated), updatedAt: now })
+      .set({ data: stripNulEscapes(JSON.stringify(updated)), updatedAt: now })
       .where(eq(a2aTasks.id, taskId))
     return true
   }

--- a/apps/api/src/a2a/sqlite-task-store.ts
+++ b/apps/api/src/a2a/sqlite-task-store.ts
@@ -71,7 +71,17 @@ function sameScope(left: TaskScope, right: TaskScope): boolean {
  * would be a worse outcome than dropping it. The substitution runs on the
  * serialised form, so it can only touch the escape sequence — never a literal
  * backslash-u in the source text, which stringify would have escaped as
- * `\\u0000`.
+ * `\\u0000` and which the negative lookbehind therefore preserves.
+ *
+ * This fixes the write path only; a row persisted **before** this change can
+ * still carry the escape and would still fail `list()` on PostgreSQL. No
+ * backfill ships with it, for two reasons: PostgreSQL is experimental with no
+ * SQLite -> PostgreSQL data migration path, so no deployment can have inherited
+ * such a row from SQLite; and `cleanup()` retires envelopes past its retention
+ * cutoff, so an affected row ages out rather than persisting indefinitely. A
+ * deployment that hits it before then can delete the offending task by id —
+ * `load()` and `save()` still work on it, since they read the column directly
+ * and only the whole-envelope cast in `list()` raises.
  */
 function stripNulEscapes(serialized: string): string {
   return serialized.replace(/(?<!\\)((?:\\\\)*)\\u0000/g, '$1')

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Every column passed to a JSON helper must actually hold JSON — checked on
+ * both dialects, from the real call sites.
+ *
+ * `pgJsonSource`'s guard throws for a column that is neither `mode: 'json'` nor
+ * a known plain-text JSON column, but it sits behind `isPostgresRuntime()`.
+ * SQLite is the supported default, so a developer who never runs PostgreSQL
+ * locally would pass a mistyped column, see `json_extract` quietly return NULL,
+ * and ship it — the failure surfacing only on the backend fewer people run.
+ * That is the same shape as the bug this suite exists for.
+ *
+ * So rather than trust the runtime guard alone, this walks the actual call
+ * sites, resolves each column argument against the schema, and asserts it is
+ * JSON-bearing. Static because it must hold regardless of which dialect the
+ * developer's DATABASE_URL happens to select.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import * as schema from '../../db/schema.sqlite.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SRC = resolve(__dirname, '../..')
+
+const HELPERS = [
+  'jsonExtractNumber',
+  'jsonExtractText',
+  'jsonArrayContainsKeyValue',
+  'jsonSet',
+  'jsonPathIsAbsent',
+]
+
+/** Plain-text columns that legitimately hold hand-serialised JSON. */
+const ALLOWED_PLAIN_TEXT = new Set(['a2aTasks.data'])
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue
+      yield* walk(full)
+      continue
+    }
+    if (entry.endsWith('.ts')) yield full
+  }
+}
+
+function code(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '')
+}
+
+/** Collect `table.column` first arguments passed to any JSON helper. */
+function collectColumnArguments(source: string): string[] {
+  const found: string[] = []
+  for (const helper of HELPERS) {
+    const call = new RegExp(`\\b${helper}\\s*\\(\\s*([A-Za-z_$][\\w$]*\\.[A-Za-z_$][\\w$]*)`, 'g')
+    for (const match of source.matchAll(call)) found.push(match[1])
+  }
+  return found
+}
+
+describe('JSON helper call sites pass JSON-bearing columns', () => {
+  const callSites = new Map<string, string[]>()
+  for (const file of walk(SRC)) {
+    if (file === resolve(SRC, 'lib/json-sql.ts')) continue
+    const columns = collectColumnArguments(code(readFileSync(file, 'utf-8')))
+    if (columns.length) callSites.set(file.slice(SRC.length + 1), columns)
+  }
+
+  it('finds the known call sites, so a broken scan cannot pass vacuously', () => {
+    const all = [...callSites.values()].flat()
+    expect(all.length).toBeGreaterThanOrEqual(10)
+    // The column this whole suite exists for must be among them.
+    expect(all).toContain('a2aTasks.data')
+  })
+
+  it('resolves every column argument to a json column or an allowed text one', () => {
+    const offenders: string[] = []
+
+    for (const [file, columns] of callSites) {
+      for (const reference of columns) {
+        const [tableName, columnName] = reference.split('.')
+        const table = (schema as Record<string, unknown>)[tableName] as
+          | Record<string, { dataType?: string }>
+          | undefined
+        // An unresolvable name means a local alias, not a schema table; the
+        // real schema tables are what this guard is about.
+        if (!table) continue
+        const column = table[columnName]
+        if (!column?.dataType) continue
+
+        if (column.dataType === 'json') continue
+        if (ALLOWED_PLAIN_TEXT.has(reference)) continue
+        offenders.push(`${file}: ${reference} is ${column.dataType}, not json`)
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -224,6 +224,26 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
         }
       }
 
+      // `await import('.../json-sql.js')` hands back the module as a runtime
+      // value. Whatever is destructured off it is a fresh local binding, not an
+      // alias of the export, so symbol resolution has nothing to follow and the
+      // helper becomes invisible — the one hole the checker cannot close by
+      // resolution alone. Reject the dynamic import itself: this module is only
+      // ever imported statically, so there is nothing legitimate to lose.
+      if (
+        ts.isCallExpression(node) &&
+        node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+        node.arguments[0] &&
+        ts.isStringLiteralLike(node.arguments[0]) &&
+        /json-sql(\.js)?$/.test(node.arguments[0].text)
+      ) {
+        findings.push({
+          file,
+          message:
+            'json-sql imported dynamically; import it statically so call sites stay resolvable',
+        })
+      }
+
       // A helper referenced anywhere other than as the callee of a call is a
       // value escaping into code this analyzer stops tracking.
       if (ts.isIdentifier(node) && !ts.isImportSpecifier(node.parent)) {
@@ -378,6 +398,19 @@ describe('the analyzer itself, against every known evasion shape', () => {
        void fns`,
     ],
     [
+      'dynamic-import destructure',
+      `const { jsonExtractText: extract6 } = await import('../lib/json-sql.js')
+       extract6(users.email, ['x'])`,
+    ],
+    [
+      'dynamic import inside a function, awaited',
+      `async function unsafe() {
+         const { jsonExtractText } = await import('../lib/json-sql.js')
+         return jsonExtractText(users.email, ['x'])
+       }
+       void unsafe`,
+    ],
+    [
       'local shadowing of a schema table',
       `import { jsonExtractText } from '../lib/json-sql.js'
        const shadowed = { result: users.email }
@@ -397,8 +430,8 @@ describe('the analyzer itself, against every known evasion shape', () => {
       // Either the analyzer refuses to vouch for the usage, or it resolved the
       // call through the rename and surfaced the real (non-JSON) column for the
       // schema assertion to reject. Both are detections; silence is not.
-      const surfacedBadColumn = result.resolved.some(
-        (r) => `${r.table}.${r.column}` === 'runs.status',
+      const surfacedBadColumn = result.resolved.some((r) =>
+        ['runs.status', 'users.email'].includes(`${r.table}.${r.column}`),
       )
       expect(result.findings.length > 0 || surfacedBadColumn).toBe(true)
     })

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -87,34 +87,16 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
     const body = code(readFileSync(file, 'utf-8'))
     const relative = file.slice(SRC.length + 1)
 
-    // Any rebinding of a helper to another name renames the call and would slip
-    // past a scan keyed on the original names, so treat it as a finding rather
-    // than letting the call go unexamined. Three forms, all seen in real code:
-    //   import { jsonExtractText as extract } from ...   (aliased import)
-    //   const extract = jsonExtractText                   (local rebind)
-    //   const { jsonExtractText: extract } = jsonSql      (namespace destructure)
-    for (const helper of HELPERS) {
-      const renamedImport = new RegExp(`\\b${helper}\\s+as\\s+([A-Za-z_$][\\w$]*)`, 'g')
-      for (const match of body.matchAll(renamedImport)) {
-        aliasedImports.push(`${relative}: ${helper} imported as ${match[1]}`)
-      }
-
-      // `jsonExtractText: extract` — destructuring renames with a colon, not
-      // `as`, so the import pattern above does not see it.
-      const destructured = new RegExp(`\\b${helper}\\s*:\\s*([A-Za-z_$][\\w$]*)`, 'g')
-      for (const match of body.matchAll(destructured)) {
-        aliasedImports.push(`${relative}: ${helper} destructured as ${match[1]}`)
-      }
-
-      // `= jsonExtractText` with no call parenthesis: the function itself is
-      // being passed around rather than invoked here.
-      const rebind = new RegExp(
-        `(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*[\\w$.]*\\b${helper}\\b\\s*(?!\\()`,
-        'g',
-      )
-      for (const match of body.matchAll(rebind)) {
-        aliasedImports.push(`${relative}: ${helper} rebound as ${match[1]}`)
-      }
+    // A helper is only scannable when every use is a direct call under its
+    // original name. Renaming detectors are a losing game — aliased imports,
+    // `const x = helper`, `const { helper: x } = ns`, and `const x: typeof
+    // helper = helper` were each discovered as separate evasions, and the next
+    // syntax form would evade again. So the rule is inverted: the two ways a
+    // name legitimately appears are its named import and a direct call, and
+    // ANY other appearance of the identifier is a finding.
+    const renamedImport = new RegExp(`\\b(${HELPERS.join('|')})\\s+as\\s+([A-Za-z_$][\\w$]*)`, 'g')
+    for (const match of body.matchAll(renamedImport)) {
+      aliasedImports.push(`${relative}: ${match[1]} imported as ${match[2]}`)
     }
 
     // A namespace import re-exposes every helper under a name this scan cannot
@@ -126,7 +108,20 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
       aliasedImports.push(`${relative}: json-sql imported as namespace ${match[1]}`)
     }
 
-    const { resolved, unresolved } = collectColumnArguments(body)
+    // Strip the (legitimate) import statements, then flag every remaining
+    // appearance of a helper name that is not immediately invoked. This is the
+    // catch-all: whatever syntax carries the function value away from its name
+    // — rebind, destructure, type annotation, passing it as an argument — the
+    // identifier itself must appear somewhere without a call parenthesis.
+    const withoutImports = body.replace(/import\s[^;]*?from\s*['"][^'"]*json-sql\.js['"]\s*;?/g, '')
+    for (const helper of HELPERS) {
+      const bareReference = new RegExp(`\\b${helper}\\b(?!\\s*\\()`, 'g')
+      for (const _match of withoutImports.matchAll(bareReference)) {
+        aliasedImports.push(`${relative}: ${helper} referenced without being called`)
+      }
+    }
+
+    const { resolved, unresolved } = collectColumnArguments(withoutImports)
     if (resolved.length) callSites.set(relative, resolved)
     if (unresolved.length) unresolvedSites.set(relative, unresolved)
   }

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -63,16 +63,31 @@
  */
 import { dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import type { SQLiteColumn } from 'drizzle-orm/sqlite-core'
 import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import * as schema from '../../db/schema.sqlite.js'
+import { jsonExtractText } from '../json-sql.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const API_ROOT = resolve(__dirname, '../../..')
 const SRC = resolve(API_ROOT, 'src')
 const JSON_SQL = resolve(SRC, 'lib/json-sql.ts')
 
-/** Plain-text columns that legitimately hold hand-serialised JSON. */
+/**
+ * Plain-text columns that legitimately hold hand-serialised JSON, as
+ * `tsTableName.tsColumnName`.
+ *
+ * This mirrors `PLAIN_TEXT_JSON_COLUMNS` in json-sql.ts, which is keyed by
+ * PHYSICAL name (`a2a_tasks.data`) because that is what a drizzle column
+ * reports at runtime, while the analyzer only ever sees the TypeScript
+ * identifiers. The two lists therefore cannot be one constant.
+ *
+ * They are pinned to each other instead: the assertion below resolves every
+ * entry here through the real schema and fails if the physical name it maps to
+ * is missing from the runtime list, so adding a column to one and not the other
+ * is caught rather than silently diverging.
+ */
 const ALLOWED_PLAIN_TEXT = new Set(['a2aTasks.data'])
 
 /**
@@ -84,13 +99,19 @@ const ALLOWED_PLAIN_TEXT = new Set(['a2aTasks.data'])
  * interpolated part stayed free to name json-sql. A fragment cannot prove the
  * whole, so shape-based exemption is abandoned entirely.
  *
- * A named file is a reviewed decision that shows up in the diff when it changes.
- * Adding one means confirming by hand that the import cannot reach json-sql.
+ * Each entry is `<file>::<specifier source text>`, so it pins the ONE import
+ * that was reviewed rather than the file it lives in. Keying by file alone
+ * would exempt any dynamic import added to that file later — the allowlist
+ * would widen with no diff to the allowlist itself, which is precisely the
+ * silent-broadening this list exists to prevent.
+ *
+ * Adding an entry means confirming by hand that the import cannot reach
+ * json-sql, and it shows up in review when it changes.
  *
  * `lib/cli-installer.ts` loads `install.mjs` by absolute resolved path — a
  * script that ships beside the CLI lock, not a module in this source tree.
  */
-const DYNAMIC_IMPORT_ALLOWLIST = new Set(['lib/cli-installer.ts'])
+const DYNAMIC_IMPORT_ALLOWLIST = new Set(['lib/cli-installer.ts::`file://${path}`'])
 
 /**
  * Helpers whose first parameter is a column and whose second is a JSON path.
@@ -265,17 +286,31 @@ function helperNameOf(
   const byProvenance = helperNameByProvenance(checker, symbol, helperSymbols, helperTypes)
   if (byProvenance) return byProvenance
 
-  // Type identity is the last resort, and only for a node with no declaration
-  // of its own — a bare reference the checker types as the helper.
+  // Type identity is the last resort, and it is skipped only where the
+  // declaration itself already ASSIGNS a value — that assignment is the real
+  // provenance, and it did not come from json-sql.
   //
   // `const fake: typeof jsonExtractText = (c, p) => ...` shares the helper's
   // exact type object while holding an unrelated local function, so deciding by
   // type alone reported it as the helper escaping. Type identity proves what a
-  // value LOOKS like, never where it CAME FROM; it can corroborate provenance
-  // but cannot stand in for it.
-  if (symbol?.valueDeclaration && !ts.isBindingElement(symbol.valueDeclaration)) {
-    return undefined
-  }
+  // value LOOKS like, never where it CAME FROM.
+  //
+  // The exclusion is deliberately narrow. An earlier revision skipped every
+  // declaration that was not a BindingElement, which also silenced parameters,
+  // loop variables and object-literal shorthand — a `f: typeof jsonExtractText`
+  // parameter became completely invisible, and passing a non-JSON column
+  // through it produced no finding at all. Those bind a value supplied
+  // elsewhere rather than asserting one here, so the checker's type is the best
+  // evidence available and is worth acting on.
+  const declaration = symbol?.valueDeclaration
+  const declaresItsOwnValue =
+    declaration &&
+    (ts.isVariableDeclaration(declaration) ||
+      ts.isPropertyDeclaration(declaration) ||
+      ts.isPropertyAssignment(declaration)) &&
+    Boolean(declaration.initializer)
+  if (declaresItsOwnValue) return undefined
+
   return helperTypes.get(checker.getTypeAtLocation(node))
 }
 
@@ -424,24 +459,33 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
         const elementNamespaceType = elementAccess
           ? checker.getTypeAtLocation(elementAccess.expression)
           : undefined
+        // "Does this object carry a helper?" is asked by SYMBOL, then by TYPE.
+        // Symbol alone missed a structural copy of the namespace — `const bag:
+        // { [K in keyof typeof jsonSql]: (typeof jsonSql)[K] } = jsonSql` has
+        // the same callable members, but a mapped type's properties are fresh
+        // symbols rather than export aliases, so `bag[k](...)` looked like an
+        // ordinary object and the dynamic-key finding never fired.
+        const namespacePropertyHelper = (property: ts.Symbol): string | undefined => {
+          const target =
+            property.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(property) : property
+          const bySymbol = helperSymbols.get(target)
+          if (bySymbol) return bySymbol
+          // `getTypeOfSymbol`, not `getTypeOfSymbolAtLocation`: a mapped type's
+          // property is synthesised and has NO valueDeclaration, so asking for a
+          // type "at" a declaration finds nothing and the copy stays invisible.
+          return helperTypes.get(checker.getTypeOfSymbol(target))
+        }
         const isJsonSqlNamespace = Boolean(
-          elementNamespaceType?.getProperties().some((property) => {
-            const target =
-              property.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(property) : property
-            return helperSymbols.has(target)
-          }),
+          elementNamespaceType
+            ?.getProperties()
+            .some((property) => namespacePropertyHelper(property)),
         )
         const helper = ts.isIdentifier(callee)
           ? helperNameOf(checker, callee, helperSymbols, helperTypes)
           : elementAccess && elementKey && elementNamespaceType
             ? (() => {
                 const property = checker.getPropertyOfType(elementNamespaceType, elementKey)
-                if (!property) return undefined
-                const target =
-                  property.flags & ts.SymbolFlags.Alias
-                    ? checker.getAliasedSymbol(property)
-                    : property
-                return helperSymbols.get(target)
+                return property ? namespacePropertyHelper(property) : undefined
               })()
             : undefined
 
@@ -511,7 +555,8 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
         node.arguments[0]
       ) {
         const specifier = staticStringValue(checker, node.arguments[0])
-        if (specifier === undefined && !DYNAMIC_IMPORT_ALLOWLIST.has(file)) {
+        const importSite = `${file}::${node.arguments[0].getText()}`
+        if (specifier === undefined && !DYNAMIC_IMPORT_ALLOWLIST.has(importSite)) {
           // Fail closed, with NO exemptions. Treating "unresolvable" as "not
           // json-sql" is what let `'../lib/' + 'json-sql.js'` through: the check
           // passed because the *analyzer* failed, not because the code was safe.
@@ -604,9 +649,37 @@ describe('the helper inventory is derived, not hand-maintained', () => {
 
 describe('JSON helper call sites pass JSON-bearing columns', () => {
   it('finds the known call sites, so a broken scan cannot pass vacuously', () => {
-    expect(analysis.resolved).toHaveLength(14)
+    // A floor, not an exact count. The point is that the walk actually reached
+    // the codebase; pinning the precise number made every unrelated commit that
+    // added a legitimate JSON query fail here with "expected 15 to be 14",
+    // which names neither the new call site nor what to do about it.
+    expect(analysis.resolved.length).toBeGreaterThanOrEqual(14)
     // The column this whole suite exists for must be among them.
     expect(analysis.resolved.map((r) => `${r.table}.${r.column}`)).toContain('a2aTasks.data')
+  })
+
+  it('keeps the plain-text allowlist in step with the one json-sql.ts enforces', () => {
+    // This list is keyed by TS name and json-sql.ts's by physical name, so they
+    // cannot be one constant. Pin them: every entry here must resolve to a real
+    // column that the RUNTIME guard also accepts, which is what stops the two
+    // from drifting apart unnoticed.
+    for (const entry of ALLOWED_PLAIN_TEXT) {
+      const [table, column] = entry.split('.')
+      const tableObject = (schema as Record<string, unknown>)[table as string] as
+        | Record<string, { name?: string; dataType?: string }>
+        | undefined
+      const columnObject = tableObject?.[column as string]
+      expect(columnObject, `${entry} should resolve in the schema module`).toBeDefined()
+
+      // A mode:'json' column would not need the allowlist at all.
+      expect(columnObject?.dataType).not.toBe('json')
+
+      // The runtime guard must accept it, or the analyzer permits a column the
+      // helpers themselves would throw on.
+      expect(() =>
+        jsonExtractText(columnObject as unknown as SQLiteColumn, ['probe']),
+      ).not.toThrow()
+    }
   })
 
   it('leaves no helper usage the analyzer cannot vouch for', () => {
@@ -759,6 +832,44 @@ describe('the analyzer itself, against every known evasion shape', () => {
        type Extractor = (c: SQLiteColumn, p: readonly [string, ...string[]]) => SQL<string | null>
        const { jsonExtractText: extract15 } = jsonSql as { jsonExtractText: Extractor }
        extract15(users.email, ['x'])`,
+    ],
+    [
+      'helper reached through a typed parameter',
+      `import type { jsonExtractText } from '../lib/json-sql.js'
+       export function go(f: typeof jsonExtractText) {
+         return f(users.email, ['x'])
+       }`,
+    ],
+    [
+      'helper reached through a typed class-method parameter',
+      `import type { jsonExtractText } from '../lib/json-sql.js'
+       export class Q {
+         run(f: typeof jsonExtractText) {
+           return f(users.email, ['x'])
+         }
+       }`,
+    ],
+    [
+      'helper reached through a loop variable',
+      `import type { jsonExtractText } from '../lib/json-sql.js'
+       declare const list: Array<typeof jsonExtractText>
+       for (const f of list) {
+         f(users.email, ['x'])
+       }`,
+    ],
+    [
+      'mapped-type copy of the namespace, indexed by a key',
+      `import * as jsonSql from '../lib/json-sql.js'
+       declare const k: 'jsonExtractText'
+       const bag: { [K in keyof typeof jsonSql]: (typeof jsonSql)[K] } = jsonSql
+       bag[k](users.email, ['x'])`,
+    ],
+    [
+      'assignment-pattern destructure',
+      `import * as jsonSql from '../lib/json-sql.js'
+       let e: typeof jsonSql.jsonExtractText
+       ;({ jsonExtractText: e } = jsonSql)
+       e(users.email, ['x'])`,
     ],
     [
       'dynamic import through a concatenated specifier',

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -9,200 +9,307 @@
  * and ship it — the failure surfacing only on the backend fewer people run.
  * That is the same shape as the bug this suite exists for.
  *
- * So rather than trust the runtime guard alone, this walks the actual call
- * sites, resolves each column argument against the schema, and asserts it is
- * JSON-bearing. Static because it must hold regardless of which dialect the
- * developer's DATABASE_URL happens to select.
+ * ## Why this uses the TypeScript compiler rather than a regex
  *
- * The scan does not try to understand TypeScript. It enforces a convention
- * narrow enough that a regex CAN follow it, and flags every departure:
+ * Earlier revisions scanned the source text. Five review rounds each found a
+ * new way past it — aliased import, local rebind, namespace destructure,
+ * type-annotated rebind, quoted ES2022 specifier — and every fix was another
+ * pattern chasing another syntax form. Two defects then landed that no amount
+ * of pattern-tightening could reach:
  *
- *   1. json-sql may only be imported as a plain named list —
- *      `import { jsonSet, jsonExtractText } from '.../json-sql.js'`.
- *      Anything else (an `as` rename, a quoted ES2022 specifier
- *      `{ 'jsonSet' as x }`, `* as ns`, a default clause) is a finding.
- *   2. Outside that import, a helper identifier may only appear immediately
- *      invoked. Any bare appearance — rebind, destructure, type annotation,
- *      re-export, passed as a value — is a finding.
+ *   const runs = { result: users.email }   // local shadowing: the text says
+ *   jsonExtractText(runs.result, ['x'])    // `runs.result`, the symbol is
+ *                                          // users.email (a non-JSON column)
  *
- * Each rule was arrived at by inversion after individual detectors kept being
- * evaded (aliased import, local rebind, namespace destructure, type-annotated
- * rebind, quoted import alias — one per review round). The fixture suite at
- * the bottom pins every one of those shapes so the analyzer cannot regress.
+ *   jsonExtractBoolean(runs.status, [...]) // a helper absent from a hand-kept
+ *                                          // list is simply invisible
+ *
+ * The first is a scoping question and the second an export-inventory question;
+ * text matching answers neither. So the analysis is now symbol-based: the
+ * helper set is derived from what `json-sql.ts` actually exports, and each
+ * column argument is resolved to the declaration it really refers to. Shadowing
+ * and renaming stop being special cases — a renamed binding resolves to the
+ * same symbol, and a shadowed one resolves to the local declaration, which is
+ * not a schema column and is reported.
  */
-import { readFileSync, readdirSync, statSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import * as schema from '../../db/schema.sqlite.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const SRC = resolve(__dirname, '../..')
-
-const HELPERS = [
-  'jsonExtractNumber',
-  'jsonExtractText',
-  'jsonArrayContainsKeyValue',
-  'jsonSet',
-  'jsonPathIsAbsent',
-]
+const API_ROOT = resolve(__dirname, '../../..')
+const SRC = resolve(API_ROOT, 'src')
+const JSON_SQL = resolve(SRC, 'lib/json-sql.ts')
 
 /** Plain-text columns that legitimately hold hand-serialised JSON. */
 const ALLOWED_PLAIN_TEXT = new Set(['a2aTasks.data'])
 
-function* walk(dir: string): Generator<string> {
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry)
-    if (statSync(full).isDirectory()) {
-      if (entry === '__tests__' || entry === 'node_modules') continue
-      yield* walk(full)
-      continue
-    }
-    if (entry.endsWith('.ts')) yield full
+/**
+ * Helpers whose first parameter is a column and whose second is a JSON path.
+ * Everything `json-sql.ts` exports is expected to have that shape; a future
+ * export that does not must be added here deliberately, and the inventory
+ * assertion below fails until it is.
+ */
+const NON_COLUMN_EXPORTS = new Set<string>()
+
+interface Finding {
+  file: string
+  message: string
+}
+
+interface Analysis {
+  /** Helper names derived from the module's real exports. */
+  helpers: string[]
+  /** Usages the analyzer refuses to vouch for. */
+  findings: Finding[]
+  /** `table.column` references resolved back to their true declarations. */
+  resolved: Array<{ file: string; table: string; column: string }>
+}
+
+let cachedOptions: ts.CompilerOptions | undefined
+let cachedFileNames: string[] | undefined
+
+function tsconfig(): { options: ts.CompilerOptions; fileNames: string[] } {
+  if (!cachedOptions || !cachedFileNames) {
+    const configPath = resolve(API_ROOT, 'tsconfig.json')
+    const config = ts.readConfigFile(configPath, ts.sys.readFile)
+    const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, API_ROOT)
+    cachedOptions = parsed.options
+    cachedFileNames = parsed.fileNames
   }
-}
-
-/** Strip comments so prose naming the helpers cannot trip the scan. */
-function code(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '')
+  return { options: cachedOptions, fileNames: cachedFileNames }
 }
 
 /**
- * Static `import ... from '.../json-sql.js'` statements. The clause is
- * tempered to never cross a `from`, so an earlier unrelated import cannot be
- * swallowed into the match in this semicolon-free codebase.
+ * Build a program. The repo-wide pass needs every file; a fixture only needs
+ * itself plus the modules it imports, which the compiler pulls in transitively
+ * — passing all ~350 roots per fixture made this suite take 38s instead of 6s.
  */
-function jsonSqlImportPattern(): RegExp {
-  return /import\s+((?:(?!\bfrom\b)[\s\S])*?)\s+from\s*['"][^'"]*json-sql(?:\.js)?['"]/g
+function createProgram(
+  extraFiles: Record<string, string> = {},
+  scope: 'project' | 'fixture' = 'project',
+): {
+  program: ts.Program
+  checker: ts.TypeChecker
+} {
+  const parsed = tsconfig()
+
+  const rootNames =
+    scope === 'fixture'
+      ? Object.keys(extraFiles)
+      : [...parsed.fileNames, ...Object.keys(extraFiles)]
+  const options: ts.CompilerOptions = { ...parsed.options, noEmit: true }
+  const host = ts.createCompilerHost(options, true)
+
+  const originalGetSourceFile = host.getSourceFile.bind(host)
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreate) => {
+    const injected = extraFiles[fileName]
+    if (injected !== undefined) {
+      return ts.createSourceFile(fileName, injected, languageVersion, true)
+    }
+    return originalGetSourceFile(fileName, languageVersion, onError, shouldCreate)
+  }
+  const originalFileExists = host.fileExists.bind(host)
+  host.fileExists = (fileName) => fileName in extraFiles || originalFileExists(fileName)
+  const originalReadFile = host.readFile.bind(host)
+  host.readFile = (fileName) => extraFiles[fileName] ?? originalReadFile(fileName)
+
+  const program = ts.createProgram(rootNames, options, host)
+  return { program, checker: program.getTypeChecker() }
+}
+
+/** The column-taking helpers `json-sql.ts` actually exports. */
+function deriveHelpers(program: ts.Program, checker: ts.TypeChecker): string[] {
+  const source = program.getSourceFile(JSON_SQL)
+  if (!source) throw new Error(`json-sql.ts not in program: ${JSON_SQL}`)
+  const moduleSymbol = checker.getSymbolAtLocation(source)
+  if (!moduleSymbol) throw new Error('json-sql.ts exports no module symbol')
+
+  return checker
+    .getExportsOfModule(moduleSymbol)
+    .map((symbol) => symbol.getName())
+    .filter((name) => !NON_COLUMN_EXPORTS.has(name))
+    .sort()
+}
+
+/** The symbol a name ultimately refers to, following imports and aliases. */
+function resolveSymbol(checker: ts.TypeChecker, node: ts.Node): ts.Symbol | undefined {
+  const symbol = checker.getSymbolAtLocation(node)
+  if (!symbol) return undefined
+  return symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
+}
+
+/** Is this symbol one of the json-sql helpers, however it was named locally? */
+function helperNameOf(
+  checker: ts.TypeChecker,
+  node: ts.Node,
+  helperSymbols: Map<ts.Symbol, string>,
+): string | undefined {
+  const symbol = resolveSymbol(checker, node)
+  return symbol ? helperSymbols.get(symbol) : undefined
 }
 
 /**
- * The one import shape the scan can follow: `{ a, b }` or `type { a }` or
- * `{ type a, b }`, every specifier a plain identifier. A quoted specifier, an
- * `as` rename, `* as ns`, or a default clause all carry a helper away under a
- * name the body scan cannot connect back to the module.
+ * Walk every source file, resolving helper calls and their column arguments
+ * through the checker rather than through their spelling.
  */
-function isVanillaNamedImport(clause: string): boolean {
-  const named = /^(?:type\s+)?\{([\s\S]*)\}$/.exec(clause.trim())
-  if (!named) return false
-  const entries = named[1].split(',').map((entry) => entry.trim())
-  if (entries.at(-1) === '') entries.pop() // multi-line lists carry a trailing comma
-  return (
-    entries.length > 0 && entries.every((entry) => /^(?:type\s+)?[A-Za-z_$][\w$]*$/.test(entry))
+function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceFile[]): Analysis {
+  const helpers = deriveHelpers(program, checker)
+
+  const jsonSqlSource = program.getSourceFile(JSON_SQL)
+  const moduleSymbol = jsonSqlSource ? checker.getSymbolAtLocation(jsonSqlSource) : undefined
+  const helperSymbols = new Map<ts.Symbol, string>()
+  if (moduleSymbol) {
+    for (const symbol of checker.getExportsOfModule(moduleSymbol)) {
+      const name = symbol.getName()
+      if (helpers.includes(name)) {
+        const target =
+          symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
+        helperSymbols.set(target, name)
+      }
+    }
+  }
+
+  const findings: Finding[] = []
+  const resolved: Analysis['resolved'] = []
+
+  for (const source of files) {
+    const file = relative(SRC, source.fileName)
+
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node)) {
+        const callee = ts.isPropertyAccessExpression(node.expression)
+          ? node.expression.name
+          : node.expression
+        const helper = ts.isIdentifier(callee)
+          ? helperNameOf(checker, callee, helperSymbols)
+          : undefined
+
+        if (helper) {
+          const argument = node.arguments[0]
+          if (!argument) {
+            findings.push({ file, message: `${helper}() called with no column argument` })
+          } else if (
+            ts.isPropertyAccessExpression(argument) &&
+            ts.isIdentifier(argument.expression)
+          ) {
+            // Resolve the TABLE identifier to its declaration. A local
+            // `const runs = {...}` resolves to that variable, not to the schema
+            // table, which is exactly the shadowing case text matching missed.
+            const tableSymbol = resolveSymbol(checker, argument.expression)
+            const declaration = tableSymbol?.declarations?.[0]
+            const declaredIn = declaration?.getSourceFile().fileName ?? ''
+            const isSchemaTable = /db[\\/]schema(\.sqlite|\.pg)?\.ts$/.test(declaredIn)
+
+            if (!isSchemaTable) {
+              findings.push({
+                file,
+                message: `${helper}(${argument.expression.text}.${argument.name.text}) — ${argument.expression.text} is not a schema table (declared in ${relative(SRC, declaredIn) || 'an unknown location'})`,
+              })
+            } else {
+              resolved.push({
+                file,
+                table: argument.expression.text,
+                column: argument.name.text,
+              })
+            }
+          } else {
+            findings.push({
+              file,
+              message: `${helper}(${argument.getText()}) — first argument is not a direct table.column reference`,
+            })
+          }
+        }
+      }
+
+      // A helper referenced anywhere other than as the callee of a call is a
+      // value escaping into code this analyzer stops tracking.
+      if (ts.isIdentifier(node) && !ts.isImportSpecifier(node.parent)) {
+        const helper = helperNameOf(checker, node, helperSymbols)
+        const isCallee = ts.isCallExpression(node.parent) && node.parent.expression === node
+        const isPropertyCallee =
+          ts.isPropertyAccessExpression(node.parent) &&
+          node.parent.name === node &&
+          ts.isCallExpression(node.parent.parent) &&
+          node.parent.parent.expression === node.parent
+        if (helper && !isCallee && !isPropertyCallee) {
+          findings.push({ file, message: `${helper} referenced without being called` })
+        }
+      }
+
+      ts.forEachChild(node, visit)
+    }
+
+    visit(source)
+  }
+
+  return { helpers, findings, resolved }
+}
+
+const { program, checker } = createProgram()
+const projectFiles = program
+  .getSourceFiles()
+  .filter(
+    (source) =>
+      !source.isDeclarationFile &&
+      source.fileName.startsWith(`${SRC}/`) &&
+      source.fileName !== JSON_SQL &&
+      !source.fileName.includes('/__tests__/'),
   )
-}
+const analysis = analyze(program, checker, projectFiles)
 
-interface SourceAnalysis {
-  /** Usages the scan cannot follow — each one is a gate failure. */
-  findings: string[]
-  /** First arguments of helper calls, as resolvable `table.column` strings. */
-  resolved: string[]
-  /** First arguments the scan could not resolve — also gate failures. */
-  unresolved: string[]
-}
+describe('the helper inventory is derived, not hand-maintained', () => {
+  it('matches what json-sql.ts actually exports', () => {
+    // A new export is picked up automatically. This assertion exists so that
+    // adding one is a deliberate act: it fails until the list is updated, which
+    // is the moment to confirm the new helper really takes (column, path).
+    expect(analysis.helpers).toEqual([
+      'jsonArrayContainsKeyValue',
+      'jsonExtractNumber',
+      'jsonExtractText',
+      'jsonPathIsAbsent',
+      'jsonSet',
+    ])
+  })
 
-/** Analyze one file's source. Exercised against fixtures below, then the repo. */
-function analyzeSource(rawSource: string): SourceAnalysis {
-  const body = code(rawSource)
-  const findings: string[] = []
-
-  for (const match of body.matchAll(jsonSqlImportPattern())) {
-    const clause = match[1].replace(/\s+/g, ' ').trim()
-    if (!isVanillaNamedImport(clause)) {
-      findings.push(`non-vanilla json-sql import: ${clause}`)
-    }
-  }
-
-  // With the (legitimate) imports stripped, a helper identifier may only
-  // appear immediately invoked. Whatever syntax carries the function value
-  // away from its name, the identifier itself must first appear bare.
-  const withoutImports = body.replace(jsonSqlImportPattern(), '')
-  for (const helper of HELPERS) {
-    const bareReference = new RegExp(`\\b${helper}\\b(?!\\s*\\()`, 'g')
-    for (const _match of withoutImports.matchAll(bareReference)) {
-      findings.push(`${helper} referenced without being called`)
-    }
-  }
-
-  const resolved: string[] = []
-  const unresolved: string[] = []
-  for (const helper of HELPERS) {
-    // `[^,)]+` captures whatever the first argument actually is, so a call the
-    // narrow `table.column` form would miss still lands in one bucket or other.
-    const call = new RegExp(`\\b${helper}\\s*\\(\\s*([^,)]+?)\\s*[,)]`, 'g')
-    for (const match of withoutImports.matchAll(call)) {
-      const argument = match[1].replace(/\s+/g, ' ').trim()
-      if (/^[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*$/.test(argument)) resolved.push(argument)
-      else unresolved.push(`${helper}(${argument})`)
-    }
-  }
-
-  return { findings, resolved, unresolved }
-}
+  it('scans a meaningful number of files, so a broken walk cannot pass vacuously', () => {
+    expect(projectFiles.length).toBeGreaterThan(100)
+  })
+})
 
 describe('JSON helper call sites pass JSON-bearing columns', () => {
-  const callSites = new Map<string, string[]>()
-  const unresolvedSites = new Map<string, string[]>()
-  const escapedUsages: string[] = []
-
-  for (const file of walk(SRC)) {
-    if (file === resolve(SRC, 'lib/json-sql.ts')) continue
-    const relative = file.slice(SRC.length + 1)
-    const analysis = analyzeSource(readFileSync(file, 'utf-8'))
-    escapedUsages.push(...analysis.findings.map((finding) => `${relative}: ${finding}`))
-    if (analysis.resolved.length) callSites.set(relative, analysis.resolved)
-    if (analysis.unresolved.length) unresolvedSites.set(relative, analysis.unresolved)
-  }
-
   it('finds the known call sites, so a broken scan cannot pass vacuously', () => {
-    const all = [...callSites.values()].flat()
-    // Pinned to the exact current count, not a floor. A floor of 10 stayed green
-    // while calls silently dropped out of view — which is the failure this file
-    // guards against. Adding or removing a call site is expected to update this
-    // number deliberately.
-    expect(all).toHaveLength(14)
+    expect(analysis.resolved).toHaveLength(14)
     // The column this whole suite exists for must be among them.
-    expect(all).toContain('a2aTasks.data')
+    expect(analysis.resolved.map((r) => `${r.table}.${r.column}`)).toContain('a2aTasks.data')
   })
 
-  it('leaves no helper call whose column argument it could not resolve', () => {
-    // A silent skip here is the failure mode: it reads as "checked and clean"
-    // for a call site the scan never inspected. If this trips, either write the
-    // argument as a direct `table.column` or extend the resolver deliberately.
-    expect(
-      [...unresolvedSites].flatMap(([file, calls]) => calls.map((c) => `${file}: ${c}`)),
-    ).toEqual([])
-  })
-
-  it('leaves no helper usage the scan cannot follow', () => {
-    expect(escapedUsages).toEqual([])
+  it('leaves no helper usage the analyzer cannot vouch for', () => {
+    expect(analysis.findings.map((f) => `${f.file}: ${f.message}`)).toEqual([])
   })
 
   it('resolves every column argument to a json column or an allowed text one', () => {
     const offenders: string[] = []
 
-    for (const [file, columns] of callSites) {
-      for (const reference of columns) {
-        const [tableName, columnName] = reference.split('.')
-        const table = (schema as Record<string, unknown>)[tableName] as
-          | Record<string, { dataType?: string }>
-          | undefined
-        // Not a schema table (e.g. a locally-built drizzle fragment). Recorded
-        // rather than skipped, so the scan cannot quietly ignore a call site.
-        if (!table) {
-          offenders.push(`${file}: ${reference} does not resolve to a schema table`)
-          continue
-        }
-        const column = table[columnName]
-        if (!column?.dataType) {
-          offenders.push(`${file}: ${reference} is not a column of that table`)
-          continue
-        }
-
-        if (column.dataType === 'json') continue
-        if (ALLOWED_PLAIN_TEXT.has(reference)) continue
-        offenders.push(`${file}: ${reference} is ${column.dataType}, not json`)
+    for (const { file, table, column } of analysis.resolved) {
+      const tableObject = (schema as Record<string, unknown>)[table] as
+        | Record<string, { dataType?: string }>
+        | undefined
+      if (!tableObject) {
+        offenders.push(`${file}: ${table}.${column} does not resolve to a schema table`)
+        continue
       }
+      const columnObject = tableObject[column]
+      if (!columnObject?.dataType) {
+        offenders.push(`${file}: ${table}.${column} is not a column of that table`)
+        continue
+      }
+
+      if (columnObject.dataType === 'json') continue
+      if (ALLOWED_PLAIN_TEXT.has(`${table}.${column}`)) continue
+      offenders.push(`${file}: ${table}.${column} is ${columnObject.dataType}, not json`)
     }
 
     expect(offenders).toEqual([])
@@ -212,9 +319,24 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
 /**
  * Every evasion shape a review round has found, pinned as a fixture. Each one
  * previously passed the then-current scan while smuggling an unchecked column
- * through; the analyzer must flag all of them, forever.
+ * through, so the analyzer must keep flagging all of them.
+ *
+ * These are type-checked as real program files, which is what lets the last
+ * two — local shadowing and an undeclared helper — be caught at all.
  */
 describe('the analyzer itself, against every known evasion shape', () => {
+  const analyzeFixture = (body: string) => {
+    const fileName = resolve(SRC, 'routes/__fixture__.ts')
+    const preamble = `import { runs, users, runSteps } from '../db/schema.js'\nvoid runs; void users; void runSteps;\n`
+    const { program: fixtureProgram, checker: fixtureChecker } = createProgram(
+      { [fileName]: preamble + body },
+      'fixture',
+    )
+    const source = fixtureProgram.getSourceFile(fileName)
+    if (!source) throw new Error('fixture not in program')
+    return analyze(fixtureProgram, fixtureChecker, [source])
+  }
+
   const EVASIONS: Array<[string, string]> = [
     [
       'aliased import',
@@ -223,8 +345,8 @@ describe('the analyzer itself, against every known evasion shape', () => {
     ],
     [
       'quoted-specifier import alias (ES2022)',
-      `import { 'jsonExtractText' as extract } from '../lib/json-sql.js'
-       extract(runs.status, ['x'])`,
+      `import { 'jsonExtractText' as extract2 } from '../lib/json-sql.js'
+       extract2(runs.status, ['x'])`,
     ],
     [
       'namespace import',
@@ -234,70 +356,72 @@ describe('the analyzer itself, against every known evasion shape', () => {
     [
       'namespace destructure',
       `import * as jsonSql from '../lib/json-sql.js'
-       const { jsonExtractText: extract } = jsonSql
-       extract(runs.status, ['x'])`,
+       const { jsonExtractText: extract3 } = jsonSql
+       extract3(runs.status, ['x'])`,
     ],
     [
       'local rebind',
       `import { jsonExtractText } from '../lib/json-sql.js'
-       const extract = jsonExtractText
-       extract(runs.status, ['x'])`,
+       const extract4 = jsonExtractText
+       extract4(runs.status, ['x'])`,
     ],
     [
       'type-annotated rebind',
       `import { jsonExtractText } from '../lib/json-sql.js'
-       const extract: typeof jsonExtractText = jsonExtractText
-       extract(runs.status, ['x'])`,
-    ],
-    ['renamed re-export', `export { jsonExtractText as extract } from '../lib/json-sql.js'`],
-    [
-      'dynamic-import destructure',
-      `const { jsonExtractText: extract } = await import('../lib/json-sql.js')
-       extract(runs.status, ['x'])`,
+       const extract5: typeof jsonExtractText = jsonExtractText
+       extract5(runs.status, ['x'])`,
     ],
     [
       'passed as a value',
       `import { jsonExtractText } from '../lib/json-sql.js'
-       columns.map(jsonExtractText)`,
+       const fns = [jsonExtractText]
+       void fns`,
+    ],
+    [
+      'local shadowing of a schema table',
+      `import { jsonExtractText } from '../lib/json-sql.js'
+       const shadowed = { result: users.email }
+       jsonExtractText(shadowed.result, ['x'])`,
+    ],
+    [
+      'column argument that is not a direct table.column',
+      `import { jsonExtractText } from '../lib/json-sql.js'
+       const col = runs.result
+       jsonExtractText(col, ['x'])`,
     ],
   ]
 
   for (const [name, source] of EVASIONS) {
     it(`flags: ${name}`, () => {
-      expect(analyzeSource(source).findings).not.toEqual([])
+      const result = analyzeFixture(source)
+      // Either the analyzer refuses to vouch for the usage, or it resolved the
+      // call through the rename and surfaced the real (non-JSON) column for the
+      // schema assertion to reject. Both are detections; silence is not.
+      const surfacedBadColumn = result.resolved.some(
+        (r) => `${r.table}.${r.column}` === 'runs.status',
+      )
+      expect(result.findings.length > 0 || surfacedBadColumn).toBe(true)
     })
   }
 
-  it('passes the vanilla shape and resolves its column', () => {
-    const analysis = analyzeSource(
+  it('passes the vanilla shape and resolves its column to the real table', () => {
+    const result = analyzeFixture(
       `import { jsonExtractText } from '../lib/json-sql.js'
        jsonExtractText(runs.result, ['durationMs'])`,
     )
-    expect(analysis.findings).toEqual([])
-    expect(analysis.unresolved).toEqual([])
-    expect(analysis.resolved).toEqual(['runs.result'])
+    expect(result.findings).toEqual([])
+    expect(result.resolved.map((r) => `${r.table}.${r.column}`)).toEqual(['runs.result'])
   })
 
-  it('passes a multi-line vanilla import with type specifiers and a trailing comma', () => {
-    const analysis = analyzeSource(
-      `import {
-         type jsonSet,
-         jsonExtractText,
-       } from '../lib/json-sql.js'
-       jsonExtractText(runs.result, ['durationMs'])`,
+  it('sees through a rename to the same underlying column', () => {
+    // A renamed *table* import is legitimate: the symbol still resolves to the
+    // schema declaration, so the analyzer follows it rather than flagging it.
+    const result = analyzeFixture(
+      `import { jsonExtractText } from '../lib/json-sql.js'
+       import { runSteps as steps } from '../db/schema.js'
+       jsonExtractText(steps.output, ['usage'])`,
     )
-    expect(analysis.findings).toEqual([])
-  })
-
-  it('does not swallow an unrelated preceding import into the clause', () => {
-    // The clause pattern must stop at `from`; in this semicolon-free codebase a
-    // greedy match would otherwise span from an earlier import statement and
-    // misreport its text as a malformed json-sql clause.
-    const analysis = analyzeSource(
-      `import { eq } from 'drizzle-orm'
-       import { jsonExtractText } from '../lib/json-sql.js'
-       jsonExtractText(runs.result, ['durationMs'])`,
-    )
-    expect(analysis.findings).toEqual([])
+    expect(result.findings).toEqual([])
+    expect(result.resolved.map((r) => `${r.table}.${r.column}`)).toEqual(['steps.output'])
   })
 })

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -76,6 +76,23 @@ const JSON_SQL = resolve(SRC, 'lib/json-sql.ts')
 const ALLOWED_PLAIN_TEXT = new Set(['a2aTasks.data'])
 
 /**
+ * Files with a reviewed dynamic import whose specifier cannot be proven static.
+ *
+ * An explicit list of *locations*, deliberately not a rule about code shape.
+ * Two attempts to exempt a shape were both wrong in the same way — a `.js` tail
+ * and a `file://` head each constrained one fragment of the specifier while the
+ * interpolated part stayed free to name json-sql. A fragment cannot prove the
+ * whole, so shape-based exemption is abandoned entirely.
+ *
+ * A named file is a reviewed decision that shows up in the diff when it changes.
+ * Adding one means confirming by hand that the import cannot reach json-sql.
+ *
+ * `lib/cli-installer.ts` loads `install.mjs` by absolute resolved path — a
+ * script that ships beside the CLI lock, not a module in this source tree.
+ */
+const DYNAMIC_IMPORT_ALLOWLIST = new Set(['lib/cli-installer.ts'])
+
+/**
  * Helpers whose first parameter is a column and whose second is a JSON path.
  * Everything `json-sql.ts` exports is expected to have that shape; a future
  * export that does not must be added here deliberately, and the inventory
@@ -171,31 +188,6 @@ function resolveSymbol(checker: ts.TypeChecker, node: ts.Node): ts.Symbol | unde
 }
 
 /**
- * Can this unresolvable specifier be ruled out as naming json-sql?
- *
- * Conservative by construction: it returns true only for a template literal
- * whose trailing static text makes a `json-sql` ending impossible — the shape
- * `` `file://${path}` `` cannot be ruled out by its tail, but one ending in a
- * fixed `install.mjs`-style suffix can. Anything it cannot prove stays reported,
- * so the fail-closed default is preserved; this only spares call sites where the
- * evidence is in the syntax itself.
- */
-function isProvablyNotJsonSql(node: ts.Expression): boolean {
-  if (!ts.isTemplateExpression(node)) return false
-
-  // ONLY an absolute-URL or absolute-path head is exempt. Such a specifier names
-  // a resolved file on disk rather than a module specifier; json-sql is imported
-  // only as a relative `../lib/json-sql.js`, so this form cannot reach it.
-  //
-  // A trailing-suffix exemption used to live here too, and it was wrong: in
-  // `` `../lib/${part}.js` `` the tail `.js` says nothing about the substitution
-  // before it, so `const part: string = 'json-sql'` imported the real module
-  // while the analyzer stayed silent. Proving a *suffix* never proves the
-  // *module*; only an interpolation-free prefix that cannot resolve here does.
-  return /^(file:\/\/|https?:\/\/|\/)/.test(node.head.text)
-}
-
-/**
  * Is this identifier inside a type annotation, rather than a runtime value?
  *
  * `type Extractor = typeof jsonExtractText` and `const f: typeof jsonExtractText`
@@ -267,10 +259,44 @@ function helperNameOf(
     if (direct) return direct
   }
 
-  const byType = helperTypes.get(checker.getTypeAtLocation(node))
-  if (byType) return byType
+  // Provenance BEFORE type identity. A binding whose value demonstrably came
+  // out of the json-sql module is the helper; a binding that merely shares its
+  // type is not.
+  const byProvenance = helperNameByProvenance(checker, symbol, helperSymbols, helperTypes)
+  if (byProvenance) return byProvenance
 
-  return helperNameByProvenance(checker, symbol, helperSymbols, helperTypes)
+  // Type identity is the last resort, and only for a node with no declaration
+  // of its own — a bare reference the checker types as the helper.
+  //
+  // `const fake: typeof jsonExtractText = (c, p) => ...` shares the helper's
+  // exact type object while holding an unrelated local function, so deciding by
+  // type alone reported it as the helper escaping. Type identity proves what a
+  // value LOOKS like, never where it CAME FROM; it can corroborate provenance
+  // but cannot stand in for it.
+  if (symbol?.valueDeclaration && !ts.isBindingElement(symbol.valueDeclaration)) {
+    return undefined
+  }
+  return helperTypes.get(checker.getTypeAtLocation(node))
+}
+
+/**
+ * Look through `as T`, `satisfies T`, `<T>x`, parentheses and `!`.
+ *
+ * These change what the checker *says* a value is without changing what it is,
+ * so any question about provenance has to be asked of the operand underneath.
+ */
+function unwrapAssertions(node: ts.Expression): ts.Expression {
+  let current = node
+  while (
+    ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isParenthesizedExpression(current) ||
+    ts.isNonNullExpression(current)
+  ) {
+    current = current.expression
+  }
+  return current
 }
 
 /**
@@ -281,6 +307,12 @@ function helperNameOf(
  * *initializer's* type — the namespace, whose properties are the real export
  * aliases — recovers the helper even when an annotation has replaced the
  * binding's own type.
+ *
+ * The initializer is unwrapped through assertions first. `jsonSql as { ... }`
+ * substitutes a structural type whose properties are plain members of that type
+ * literal, not the export aliases, so reading the property off the *asserted*
+ * type recovers nothing. Looking through to the operand asks the question of the
+ * namespace itself, which is what actually determines where the value came from.
  */
 function helperNameByProvenance(
   checker: ts.TypeChecker,
@@ -301,7 +333,7 @@ function helperNameByProvenance(
   if (!ts.isVariableDeclaration(variable) || !variable.initializer) return undefined
 
   const property = checker.getPropertyOfType(
-    checker.getTypeAtLocation(variable.initializer),
+    checker.getTypeAtLocation(unwrapAssertions(variable.initializer)),
     key.text,
   )
   if (!property) return undefined
@@ -425,13 +457,17 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
           const argument = node.arguments[0]
           if (!argument) {
             findings.push({ file, message: `${helper}() called with no column argument` })
-          } else if (
-            ts.isPropertyAccessExpression(argument) &&
-            ts.isIdentifier(argument.expression)
-          ) {
-            // Resolve the TABLE identifier to its declaration. A local
+          } else if (ts.isPropertyAccessExpression(argument)) {
+            // Resolve the TABLE expression to its declaration. A local
             // `const runs = {...}` resolves to that variable, not to the schema
             // table, which is exactly the shadowing case text matching missed.
+            //
+            // The table half is an arbitrary expression, not necessarily an
+            // Identifier: `schema.runSteps.output` reaches a real json column
+            // through a namespace, and requiring an Identifier here rejected it
+            // for its *spelling* while the symbol proved it correct. Resolve the
+            // expression and let the declaration decide, which is the same
+            // inversion the rest of this file is built on.
             const tableSymbol = resolveSymbol(checker, argument.expression)
             const declaration = tableSymbol?.declarations?.[0]
             const declaredIn = declaration?.getSourceFile().fileName ?? ''
@@ -440,7 +476,7 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
             if (!isSchemaTable) {
               findings.push({
                 file,
-                message: `${helper}(${argument.expression.text}.${argument.name.text}) — ${argument.expression.text} is not a schema table (declared in ${relative(SRC, declaredIn) || 'an unknown location'})`,
+                message: `${helper}(${argument.getText()}) — ${argument.expression.getText()} is not a schema table (declared in ${relative(SRC, declaredIn) || 'an unknown location'})`,
               })
             } else {
               // Record the CANONICAL export name, not the local spelling. The
@@ -450,7 +486,7 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
               // as "not a schema table" and fail the gate on correct code.
               resolved.push({
                 file,
-                table: tableSymbol?.getName() ?? argument.expression.text,
+                table: tableSymbol?.getName() ?? argument.expression.getText(),
                 column: argument.name.text,
               })
             }
@@ -475,19 +511,20 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
         node.arguments[0]
       ) {
         const specifier = staticStringValue(checker, node.arguments[0])
-        if (specifier === undefined && !isProvablyNotJsonSql(node.arguments[0])) {
-          // Fail closed, but only for a specifier that could actually name this
-          // module. Treating "unresolvable" as "not json-sql" is what let
-          // `'../lib/' + 'json-sql.js'` through: the check passed because the
-          // *analyzer* failed, not because the code was safe.
+        if (specifier === undefined && !DYNAMIC_IMPORT_ALLOWLIST.has(file)) {
+          // Fail closed, with NO exemptions. Treating "unresolvable" as "not
+          // json-sql" is what let `'../lib/' + 'json-sql.js'` through: the check
+          // passed because the *analyzer* failed, not because the code was safe.
           //
-          // A genuinely runtime path that cannot contain 'json-sql' (loading a
-          // resolved .mjs by absolute path, say) is left alone — the goal is to
-          // stop this module escaping, not to ban dynamic import.
+          // Two attempts to carve out an exemption were both wrong in the same
+          // way — `../lib/${part}.js` (a `.js` tail) and `file://${target}` (a
+          // `file://` head) each constrained one fragment while the substitution
+          // stayed free to name json-sql. A fragment of a specifier cannot prove
+          // the whole, so no shape is exempt.
           findings.push({
             file,
             message:
-              'dynamic import whose specifier is not statically resolvable and could name json-sql; use a literal specifier so the target can be checked',
+              'dynamic import whose specifier is not statically resolvable; use a literal specifier so the target can be checked',
           })
         } else if (specifier !== undefined && /json-sql(\.js)?$/.test(specifier)) {
           findings.push({
@@ -709,6 +746,21 @@ describe('the analyzer itself, against every known evasion shape', () => {
        extract13(users.email, ['x'])`,
     ],
     [
+      'dynamic import through a file:// interpolation',
+      `declare const target: string
+       const { jsonExtractText: extract14 } = await import(\`file://\${target}\`)
+       extract14(users.email, ['x'])`,
+    ],
+    [
+      'structural type assertion erasing provenance',
+      `import type { SQL } from 'drizzle-orm'
+       import type { SQLiteColumn } from 'drizzle-orm/sqlite-core'
+       import * as jsonSql from '../lib/json-sql.js'
+       type Extractor = (c: SQLiteColumn, p: readonly [string, ...string[]]) => SQL<string | null>
+       const { jsonExtractText: extract15 } = jsonSql as { jsonExtractText: Extractor }
+       extract15(users.email, ['x'])`,
+    ],
+    [
       'dynamic import through a concatenated specifier',
       `const specifier = '../lib/' + 'json-sql.js'
        const { jsonExtractText: extract11 } = await import(specifier)
@@ -778,16 +830,23 @@ describe('the analyzer itself, against every known evasion shape', () => {
     })
   }
 
-  it('leaves a genuinely unrelated dynamic import alone', () => {
-    // `loadInstaller()` in lib/cli-installer.ts imports a resolved .mjs by
-    // absolute file:// path. Fail-closed must not tax code that provably cannot
-    // be reaching json-sql, or the rule gets reverted rather than obeyed.
+  it('flags an interpolated file:// specifier, which cannot be proven safe', () => {
+    // This is the shape `loadInstaller()` uses. It is reported anyway: a
+    // `file://` head constrains only the head, and the substitution is free to
+    // be the absolute path of json-sql.js. Exempting it read as "proven safe"
+    // while proving nothing — the same mistake as the earlier `.js`-tail rule.
+    // `path` is computed at runtime (resolve(...)), so nothing is foldable —
+    // exactly the real shape. A `const path = '/tmp/x.mjs'` would instead be
+    // constant-folded by the checker into one literal type and is legitimately
+    // resolvable, so it is NOT reported; that is `staticStringValue` working.
     const result = analyzeFixture(
-      `const path = '/tmp/install.mjs'
+      `declare const path: string
        const mod = await import(\`file://\${path}\`)
        void mod`,
     )
-    expect(result.findings).toEqual([])
+    expect(result.findings.map((f) => f.message)).toEqual([
+      'dynamic import whose specifier is not statically resolvable; use a literal specifier so the target can be checked',
+    ])
   })
 
   it('still flags an interpolated specifier that could name json-sql', () => {
@@ -797,6 +856,31 @@ describe('the analyzer itself, against every known evasion shape', () => {
        void mod`,
     )
     expect(result.findings.length).toBeGreaterThan(0)
+  })
+
+  it('does not misreport a namespace-qualified schema reference', () => {
+    // `schema.runSteps.output` is a legitimate way to reach a real json column.
+    const result = analyzeFixture(
+      `import { jsonExtractText } from '../lib/json-sql.js'
+       import * as schemaNs from '../db/schema.js'
+       jsonExtractText(schemaNs.runSteps.output, ['usage'])`,
+    )
+    expect(result.findings).toEqual([])
+  })
+
+  it('does not mistake an unrelated local function for a helper', () => {
+    // `typeof jsonExtractText` gives `fake` the helper's own type object. If
+    // type identity alone decided provenance, this local would be reported as
+    // the helper escaping — a false positive on code that never touches it.
+    // `typeof jsonExtractText` is a TYPE position, so importing the name here
+    // is not itself an escape; only `fake` is a runtime value, and it holds an
+    // unrelated local function.
+    const result = analyzeFixture(
+      `import type { jsonExtractText } from '../lib/json-sql.js'
+       const fake: typeof jsonExtractText = (c, p) => { throw new Error(String([c, p])) }
+       void fake`,
+    )
+    expect(result.findings).toEqual([])
   })
 
   it('passes the vanilla shape and resolves its column to the real table', () => {

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -13,6 +13,22 @@
  * sites, resolves each column argument against the schema, and asserts it is
  * JSON-bearing. Static because it must hold regardless of which dialect the
  * developer's DATABASE_URL happens to select.
+ *
+ * The scan does not try to understand TypeScript. It enforces a convention
+ * narrow enough that a regex CAN follow it, and flags every departure:
+ *
+ *   1. json-sql may only be imported as a plain named list —
+ *      `import { jsonSet, jsonExtractText } from '.../json-sql.js'`.
+ *      Anything else (an `as` rename, a quoted ES2022 specifier
+ *      `{ 'jsonSet' as x }`, `* as ns`, a default clause) is a finding.
+ *   2. Outside that import, a helper identifier may only appear immediately
+ *      invoked. Any bare appearance — rebind, destructure, type annotation,
+ *      re-export, passed as a value — is a finding.
+ *
+ * Each rule was arrived at by inversion after individual detectors kept being
+ * evaded (aliased import, local rebind, namespace destructure, type-annotated
+ * rebind, quoted import alias — one per review round). The fixture suite at
+ * the bottom pins every one of those shapes so the analyzer cannot regress.
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
@@ -46,84 +62,96 @@ function* walk(dir: string): Generator<string> {
   }
 }
 
+/** Strip comments so prose naming the helpers cannot trip the scan. */
 function code(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '')
 }
 
 /**
- * Collect the first argument of every JSON-helper call, split into the
- * `table.column` references this scan can resolve and everything it cannot.
- *
- * The unresolved bucket is the point. A scan that only matched `table.column`
- * and ignored the rest would silently pass a call whose column arrives as a
- * local variable or through an aliased import — reporting green for code it
- * never actually checked. Surfacing those instead forces them to be made
- * resolvable (or explicitly acknowledged), so "no offenders" means "nothing
- * unchecked" rather than "nothing recognised".
+ * Static `import ... from '.../json-sql.js'` statements. The clause is
+ * tempered to never cross a `from`, so an earlier unrelated import cannot be
+ * swallowed into the match in this semicolon-free codebase.
  */
-function collectColumnArguments(source: string): { resolved: string[]; unresolved: string[] } {
+function jsonSqlImportPattern(): RegExp {
+  return /import\s+((?:(?!\bfrom\b)[\s\S])*?)\s+from\s*['"][^'"]*json-sql(?:\.js)?['"]/g
+}
+
+/**
+ * The one import shape the scan can follow: `{ a, b }` or `type { a }` or
+ * `{ type a, b }`, every specifier a plain identifier. A quoted specifier, an
+ * `as` rename, `* as ns`, or a default clause all carry a helper away under a
+ * name the body scan cannot connect back to the module.
+ */
+function isVanillaNamedImport(clause: string): boolean {
+  const named = /^(?:type\s+)?\{([\s\S]*)\}$/.exec(clause.trim())
+  if (!named) return false
+  const entries = named[1].split(',').map((entry) => entry.trim())
+  if (entries.at(-1) === '') entries.pop() // multi-line lists carry a trailing comma
+  return (
+    entries.length > 0 && entries.every((entry) => /^(?:type\s+)?[A-Za-z_$][\w$]*$/.test(entry))
+  )
+}
+
+interface SourceAnalysis {
+  /** Usages the scan cannot follow — each one is a gate failure. */
+  findings: string[]
+  /** First arguments of helper calls, as resolvable `table.column` strings. */
+  resolved: string[]
+  /** First arguments the scan could not resolve — also gate failures. */
+  unresolved: string[]
+}
+
+/** Analyze one file's source. Exercised against fixtures below, then the repo. */
+function analyzeSource(rawSource: string): SourceAnalysis {
+  const body = code(rawSource)
+  const findings: string[] = []
+
+  for (const match of body.matchAll(jsonSqlImportPattern())) {
+    const clause = match[1].replace(/\s+/g, ' ').trim()
+    if (!isVanillaNamedImport(clause)) {
+      findings.push(`non-vanilla json-sql import: ${clause}`)
+    }
+  }
+
+  // With the (legitimate) imports stripped, a helper identifier may only
+  // appear immediately invoked. Whatever syntax carries the function value
+  // away from its name, the identifier itself must first appear bare.
+  const withoutImports = body.replace(jsonSqlImportPattern(), '')
+  for (const helper of HELPERS) {
+    const bareReference = new RegExp(`\\b${helper}\\b(?!\\s*\\()`, 'g')
+    for (const _match of withoutImports.matchAll(bareReference)) {
+      findings.push(`${helper} referenced without being called`)
+    }
+  }
+
   const resolved: string[] = []
   const unresolved: string[] = []
   for (const helper of HELPERS) {
     // `[^,)]+` captures whatever the first argument actually is, so a call the
     // narrow `table.column` form would miss still lands in one bucket or other.
     const call = new RegExp(`\\b${helper}\\s*\\(\\s*([^,)]+?)\\s*[,)]`, 'g')
-    for (const match of source.matchAll(call)) {
+    for (const match of withoutImports.matchAll(call)) {
       const argument = match[1].replace(/\s+/g, ' ').trim()
       if (/^[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*$/.test(argument)) resolved.push(argument)
       else unresolved.push(`${helper}(${argument})`)
     }
   }
-  return { resolved, unresolved }
+
+  return { findings, resolved, unresolved }
 }
 
 describe('JSON helper call sites pass JSON-bearing columns', () => {
   const callSites = new Map<string, string[]>()
   const unresolvedSites = new Map<string, string[]>()
-  const aliasedImports: string[] = []
+  const escapedUsages: string[] = []
 
   for (const file of walk(SRC)) {
     if (file === resolve(SRC, 'lib/json-sql.ts')) continue
-    const body = code(readFileSync(file, 'utf-8'))
     const relative = file.slice(SRC.length + 1)
-
-    // A helper is only scannable when every use is a direct call under its
-    // original name. Renaming detectors are a losing game — aliased imports,
-    // `const x = helper`, `const { helper: x } = ns`, and `const x: typeof
-    // helper = helper` were each discovered as separate evasions, and the next
-    // syntax form would evade again. So the rule is inverted: the two ways a
-    // name legitimately appears are its named import and a direct call, and
-    // ANY other appearance of the identifier is a finding.
-    const renamedImport = new RegExp(`\\b(${HELPERS.join('|')})\\s+as\\s+([A-Za-z_$][\\w$]*)`, 'g')
-    for (const match of body.matchAll(renamedImport)) {
-      aliasedImports.push(`${relative}: ${match[1]} imported as ${match[2]}`)
-    }
-
-    // A namespace import re-exposes every helper under a name this scan cannot
-    // follow (`jsonSql.jsonExtractText(...)`, or any local rebind of it), so
-    // the module is only safely scannable through named imports.
-    const namespaceImport =
-      /import\s+\*\s+as\s+([A-Za-z_$][\w$]*)\s+from\s+['"][^'"]*json-sql\.js['"]/g
-    for (const match of body.matchAll(namespaceImport)) {
-      aliasedImports.push(`${relative}: json-sql imported as namespace ${match[1]}`)
-    }
-
-    // Strip the (legitimate) import statements, then flag every remaining
-    // appearance of a helper name that is not immediately invoked. This is the
-    // catch-all: whatever syntax carries the function value away from its name
-    // — rebind, destructure, type annotation, passing it as an argument — the
-    // identifier itself must appear somewhere without a call parenthesis.
-    const withoutImports = body.replace(/import\s[^;]*?from\s*['"][^'"]*json-sql\.js['"]\s*;?/g, '')
-    for (const helper of HELPERS) {
-      const bareReference = new RegExp(`\\b${helper}\\b(?!\\s*\\()`, 'g')
-      for (const _match of withoutImports.matchAll(bareReference)) {
-        aliasedImports.push(`${relative}: ${helper} referenced without being called`)
-      }
-    }
-
-    const { resolved, unresolved } = collectColumnArguments(withoutImports)
-    if (resolved.length) callSites.set(relative, resolved)
-    if (unresolved.length) unresolvedSites.set(relative, unresolved)
+    const analysis = analyzeSource(readFileSync(file, 'utf-8'))
+    escapedUsages.push(...analysis.findings.map((finding) => `${relative}: ${finding}`))
+    if (analysis.resolved.length) callSites.set(relative, analysis.resolved)
+    if (analysis.unresolved.length) unresolvedSites.set(relative, analysis.unresolved)
   }
 
   it('finds the known call sites, so a broken scan cannot pass vacuously', () => {
@@ -146,8 +174,8 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
     ).toEqual([])
   })
 
-  it('leaves no aliased helper import that would rename a call out of view', () => {
-    expect(aliasedImports).toEqual([])
+  it('leaves no helper usage the scan cannot follow', () => {
+    expect(escapedUsages).toEqual([])
   })
 
   it('resolves every column argument to a json column or an allowed text one', () => {
@@ -178,5 +206,98 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
     }
 
     expect(offenders).toEqual([])
+  })
+})
+
+/**
+ * Every evasion shape a review round has found, pinned as a fixture. Each one
+ * previously passed the then-current scan while smuggling an unchecked column
+ * through; the analyzer must flag all of them, forever.
+ */
+describe('the analyzer itself, against every known evasion shape', () => {
+  const EVASIONS: Array<[string, string]> = [
+    [
+      'aliased import',
+      `import { jsonExtractText as extract } from '../lib/json-sql.js'
+       extract(runs.status, ['x'])`,
+    ],
+    [
+      'quoted-specifier import alias (ES2022)',
+      `import { 'jsonExtractText' as extract } from '../lib/json-sql.js'
+       extract(runs.status, ['x'])`,
+    ],
+    [
+      'namespace import',
+      `import * as jsonSql from '../lib/json-sql.js'
+       jsonSql.jsonExtractText(runs.status, ['x'])`,
+    ],
+    [
+      'namespace destructure',
+      `import * as jsonSql from '../lib/json-sql.js'
+       const { jsonExtractText: extract } = jsonSql
+       extract(runs.status, ['x'])`,
+    ],
+    [
+      'local rebind',
+      `import { jsonExtractText } from '../lib/json-sql.js'
+       const extract = jsonExtractText
+       extract(runs.status, ['x'])`,
+    ],
+    [
+      'type-annotated rebind',
+      `import { jsonExtractText } from '../lib/json-sql.js'
+       const extract: typeof jsonExtractText = jsonExtractText
+       extract(runs.status, ['x'])`,
+    ],
+    ['renamed re-export', `export { jsonExtractText as extract } from '../lib/json-sql.js'`],
+    [
+      'dynamic-import destructure',
+      `const { jsonExtractText: extract } = await import('../lib/json-sql.js')
+       extract(runs.status, ['x'])`,
+    ],
+    [
+      'passed as a value',
+      `import { jsonExtractText } from '../lib/json-sql.js'
+       columns.map(jsonExtractText)`,
+    ],
+  ]
+
+  for (const [name, source] of EVASIONS) {
+    it(`flags: ${name}`, () => {
+      expect(analyzeSource(source).findings).not.toEqual([])
+    })
+  }
+
+  it('passes the vanilla shape and resolves its column', () => {
+    const analysis = analyzeSource(
+      `import { jsonExtractText } from '../lib/json-sql.js'
+       jsonExtractText(runs.result, ['durationMs'])`,
+    )
+    expect(analysis.findings).toEqual([])
+    expect(analysis.unresolved).toEqual([])
+    expect(analysis.resolved).toEqual(['runs.result'])
+  })
+
+  it('passes a multi-line vanilla import with type specifiers and a trailing comma', () => {
+    const analysis = analyzeSource(
+      `import {
+         type jsonSet,
+         jsonExtractText,
+       } from '../lib/json-sql.js'
+       jsonExtractText(runs.result, ['durationMs'])`,
+    )
+    expect(analysis.findings).toEqual([])
+  })
+
+  it('does not swallow an unrelated preceding import into the clause', () => {
+    // The clause pattern must stop at `from`; in this semicolon-free codebase a
+    // greedy match would otherwise span from an earlier import statement and
+    // misreport its text as a malformed json-sql clause.
+    const analysis = analyzeSource(
+      `import { eq } from 'drizzle-orm'
+       import { jsonExtractText } from '../lib/json-sql.js'
+       jsonExtractText(runs.result, ['durationMs'])`,
+    )
+    expect(analysis.findings).toEqual([])
   })
 })

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -183,18 +183,16 @@ function resolveSymbol(checker: ts.TypeChecker, node: ts.Node): ts.Symbol | unde
 function isProvablyNotJsonSql(node: ts.Expression): boolean {
   if (!ts.isTemplateExpression(node)) return false
 
-  // A specifier that starts with an absolute-URL or absolute-path scheme names a
-  // resolved file on disk, not a module specifier. json-sql is imported only as
-  // a relative `../lib/json-sql.js`, and TypeScript would not resolve this form
-  // to it in the first place, so such an import cannot be the escape hatch this
-  // check exists to close.
-  const head = node.head.text
-  if (/^(file:\/\/|https?:\/\/|\/)/.test(head)) return true
-
-  // Otherwise, a non-empty tail that is a concrete non-json-sql file suffix pins
-  // the module loaded; a substitution before it cannot change the ending.
-  const tail = node.templateSpans[node.templateSpans.length - 1]?.literal.text ?? ''
-  return tail.length > 0 && !/json-sql/.test(tail) && /\.[a-z]+$/.test(tail)
+  // ONLY an absolute-URL or absolute-path head is exempt. Such a specifier names
+  // a resolved file on disk rather than a module specifier; json-sql is imported
+  // only as a relative `../lib/json-sql.js`, so this form cannot reach it.
+  //
+  // A trailing-suffix exemption used to live here too, and it was wrong: in
+  // `` `../lib/${part}.js` `` the tail `.js` says nothing about the substitution
+  // before it, so `const part: string = 'json-sql'` imported the real module
+  // while the analyzer stayed silent. Proving a *suffix* never proves the
+  // *module*; only an interpolation-free prefix that cannot resolve here does.
+  return /^(file:\/\/|https?:\/\/|\/)/.test(node.head.text)
 }
 
 /**
@@ -245,6 +243,17 @@ function isPropertyNameOfBinding(node: ts.Node): boolean {
  * and nothing else in the program declares a function assignable to either by
  * identity. It is compared by the type object's own identity, not structurally,
  * so an unrelated `(c, p) => SQL` does not collide.
+ *
+ * Type identity alone is not quite enough, because a use site can be given a
+ * *different* type object than the declaration:
+ *
+ *   const { jsonExtractText: extract }: { jsonExtractText: Extractor } = jsonSql
+ *
+ * The annotation supplies a fresh `Extractor` type, so the binding is neither
+ * the export symbol nor the declaration's type object. Provenance closes it: ask
+ * what object the binding was destructured *from*, and look the property up
+ * there. That is still not syntax-enumeration — it is one more identity
+ * question, asked of the source rather than the binding.
  */
 function helperNameOf(
   checker: ts.TypeChecker,
@@ -258,7 +267,54 @@ function helperNameOf(
     if (direct) return direct
   }
 
-  return helperTypes.get(checker.getTypeAtLocation(node))
+  const byType = helperTypes.get(checker.getTypeAtLocation(node))
+  if (byType) return byType
+
+  return helperNameByProvenance(checker, symbol, helperSymbols, helperTypes)
+}
+
+/**
+ * Resolve a destructured binding through the object it came from.
+ *
+ * `const { jsonExtractText: extract }: {...} = jsonSql` creates a local symbol
+ * whose declaration is a BindingElement. Reading the property off the
+ * *initializer's* type — the namespace, whose properties are the real export
+ * aliases — recovers the helper even when an annotation has replaced the
+ * binding's own type.
+ */
+function helperNameByProvenance(
+  checker: ts.TypeChecker,
+  symbol: ts.Symbol | undefined,
+  helperSymbols: Map<ts.Symbol, string>,
+  helperTypes: Map<ts.Type, string>,
+): string | undefined {
+  const declaration = symbol?.valueDeclaration
+  if (!declaration || !ts.isBindingElement(declaration)) return undefined
+
+  // The property read: `{ key: local }` uses propertyName, `{ key }` uses name.
+  const key = declaration.propertyName ?? declaration.name
+  if (!ts.isIdentifier(key) && !ts.isStringLiteralLike(key)) return undefined
+
+  const pattern = declaration.parent
+  if (!ts.isObjectBindingPattern(pattern)) return undefined
+  const variable = pattern.parent
+  if (!ts.isVariableDeclaration(variable) || !variable.initializer) return undefined
+
+  const property = checker.getPropertyOfType(
+    checker.getTypeAtLocation(variable.initializer),
+    key.text,
+  )
+  if (!property) return undefined
+
+  const target =
+    property.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(property) : property
+  const bySymbol = helperSymbols.get(target)
+  if (bySymbol) return bySymbol
+
+  const valueDeclaration = target.valueDeclaration
+  return valueDeclaration
+    ? helperTypes.get(checker.getTypeOfSymbolAtLocation(target, valueDeclaration))
+    : undefined
 }
 
 /**
@@ -387,9 +443,14 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
                 message: `${helper}(${argument.expression.text}.${argument.name.text}) — ${argument.expression.text} is not a schema table (declared in ${relative(SRC, declaredIn) || 'an unknown location'})`,
               })
             } else {
+              // Record the CANONICAL export name, not the local spelling. The
+              // schema assertion below looks the table up in the real schema
+              // module, so `import { runSteps as steps }` must be stored as
+              // `runSteps` — storing `steps` would report the legitimate alias
+              // as "not a schema table" and fail the gate on correct code.
               resolved.push({
                 file,
-                table: argument.expression.text,
+                table: tableSymbol?.getName() ?? argument.expression.text,
                 column: argument.name.text,
               })
             }
@@ -633,6 +694,21 @@ describe('the analyzer itself, against every known evasion shape', () => {
        extract10(users.email, ['x'])`,
     ],
     [
+      'dynamic import through a widened interpolation with a static tail',
+      `const part: string = 'json-sql'
+       const { jsonExtractText: extract12 } = await import(\`../lib/\${part}.js\`)
+       extract12(users.email, ['x'])`,
+    ],
+    [
+      'contextually typed namespace destructure',
+      `import type { SQL } from 'drizzle-orm'
+       import type { SQLiteColumn } from 'drizzle-orm/sqlite-core'
+       import * as jsonSql from '../lib/json-sql.js'
+       type Extractor = (c: SQLiteColumn, p: readonly [string, ...string[]]) => SQL<string | null>
+       const { jsonExtractText: extract13 }: { jsonExtractText: Extractor } = jsonSql
+       extract13(users.email, ['x'])`,
+    ],
+    [
       'dynamic import through a concatenated specifier',
       `const specifier = '../lib/' + 'json-sql.js'
        const { jsonExtractText: extract11 } = await import(specifier)
@@ -741,6 +817,27 @@ describe('the analyzer itself, against every known evasion shape', () => {
        jsonExtractText(steps.output, ['usage'])`,
     )
     expect(result.findings).toEqual([])
-    expect(result.resolved.map((r) => `${r.table}.${r.column}`)).toEqual(['steps.output'])
+    // The CANONICAL name, not the local alias `steps`. The schema assertion
+    // resolves this against the real schema module, so recording the alias
+    // would fail the repo-wide gate on legitimate code.
+    expect(result.resolved.map((r) => `${r.table}.${r.column}`)).toEqual(['runSteps.output'])
+  })
+
+  it('resolves an aliased table against the real schema, not just by name', () => {
+    // The assertion above pins the string; this one proves the string is
+    // usable — the alias must reach a real json column in the schema module,
+    // which is what the repo-wide gate does with every resolved entry.
+    const result = analyzeFixture(
+      `import { jsonExtractText } from '../lib/json-sql.js'
+       import { runSteps as steps } from '../db/schema.js'
+       jsonExtractText(steps.output, ['usage'])`,
+    )
+    for (const { table, column } of result.resolved) {
+      const tableObject = (schema as Record<string, unknown>)[table] as
+        | Record<string, { dataType?: string }>
+        | undefined
+      expect(tableObject, `${table} should resolve in the schema module`).toBeDefined()
+      expect(tableObject?.[column]?.dataType).toBe('json')
+    }
   })
 })

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -89,13 +89,21 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
 
     // Any rebinding of a helper to another name renames the call and would slip
     // past a scan keyed on the original names, so treat it as a finding rather
-    // than letting the call go unexamined. Two forms: an aliased import
-    // (`jsonExtractText as extract`) and a local rebind (`const extract =
-    // jsonExtractText`), including destructuring off a namespace import.
+    // than letting the call go unexamined. Three forms, all seen in real code:
+    //   import { jsonExtractText as extract } from ...   (aliased import)
+    //   const extract = jsonExtractText                   (local rebind)
+    //   const { jsonExtractText: extract } = jsonSql      (namespace destructure)
     for (const helper of HELPERS) {
       const renamedImport = new RegExp(`\\b${helper}\\s+as\\s+([A-Za-z_$][\\w$]*)`, 'g')
       for (const match of body.matchAll(renamedImport)) {
         aliasedImports.push(`${relative}: ${helper} imported as ${match[1]}`)
+      }
+
+      // `jsonExtractText: extract` — destructuring renames with a colon, not
+      // `as`, so the import pattern above does not see it.
+      const destructured = new RegExp(`\\b${helper}\\s*:\\s*([A-Za-z_$][\\w$]*)`, 'g')
+      for (const match of body.matchAll(destructured)) {
+        aliasedImports.push(`${relative}: ${helper} destructured as ${match[1]}`)
       }
 
       // `= jsonExtractText` with no call parenthesis: the function itself is
@@ -107,6 +115,15 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
       for (const match of body.matchAll(rebind)) {
         aliasedImports.push(`${relative}: ${helper} rebound as ${match[1]}`)
       }
+    }
+
+    // A namespace import re-exposes every helper under a name this scan cannot
+    // follow (`jsonSql.jsonExtractText(...)`, or any local rebind of it), so
+    // the module is only safely scannable through named imports.
+    const namespaceImport =
+      /import\s+\*\s+as\s+([A-Za-z_$][\w$]*)\s+from\s+['"][^'"]*json-sql\.js['"]/g
+    for (const match of body.matchAll(namespaceImport)) {
+      aliasedImports.push(`${relative}: json-sql imported as namespace ${match[1]}`)
     }
 
     const { resolved, unresolved } = collectColumnArguments(body)

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -2,12 +2,22 @@
  * Every column passed to a JSON helper must actually hold JSON — checked on
  * both dialects, from the real call sites.
  *
- * `pgJsonSource`'s guard throws for a column that is neither `mode: 'json'` nor
- * a known plain-text JSON column, but it sits behind `isPostgresRuntime()`.
- * SQLite is the supported default, so a developer who never runs PostgreSQL
- * locally would pass a mistyped column, see `json_extract` quietly return NULL,
- * and ship it — the failure surfacing only on the backend fewer people run.
- * That is the same shape as the bug this suite exists for.
+ * ## This is the second line of defence, not the only one
+ *
+ * The column-type invariant is enforced at runtime by `assertJsonBearingColumn`
+ * inside json-sql.ts, on **both** dialects. That guard sees every call however
+ * it was spelled, so no aliasing or destructuring evades it — which is why the
+ * check belongs there and why this file no longer carries the whole burden.
+ *
+ * It still earns its place for the reason a runtime guard cannot cover: a guard
+ * only fires on a path that actually executes, and api coverage is ~82%, not
+ * 100%. A mistyped column on an untested branch would reach production with the
+ * runtime check never having run. This analyzer reads the code instead of
+ * running it, so it covers the branches tests do not — and it reports at
+ * `pnpm test` rather than at query-build time in production.
+ *
+ * The two layers answer different questions, so keep both: the guard catches
+ * what reaches it, this catches what the types say.
  *
  * ## Why this uses the TypeScript compiler rather than a regex
  *
@@ -31,6 +41,25 @@
  * and renaming stop being special cases — a renamed binding resolves to the
  * same symbol, and a shadowed one resolves to the local declaration, which is
  * not a schema column and is reported.
+ *
+ * ## Ask what a thing *is*, never how it was written
+ *
+ * Moving to the checker was not by itself enough, because the first version
+ * still asked the *forward* question — "which syntactic route produced this
+ * binding?" — and answered it with one branch per route: named destructure,
+ * then quoted, then shorthand, then computed. That direction is unbounded, so
+ * each review round legitimately found a shape the last had not enumerated.
+ *
+ * Two inversions ended it. `helperNameOf` asks `getTypeAtLocation` what a
+ * binding *is*, so every destructuring form collapses into one check; and
+ * `staticStringValue` reads a string-literal *type*, so `as const`, `satisfies`
+ * and constant-folded concatenation need no cases of their own.
+ *
+ * The rule this file is now built on: **resolve by identity, and fail closed
+ * when identity cannot be established.** An unresolvable specifier that could
+ * name json-sql is reported rather than ignored — silence used to mean "the
+ * analyzer failed", which read identically to "the code is safe". If a future
+ * round finds another evasion, the fix is another inversion, not another branch.
  */
 import { dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -141,67 +170,121 @@ function resolveSymbol(checker: ts.TypeChecker, node: ts.Node): ts.Symbol | unde
   return symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
 }
 
-/** Is this symbol one of the json-sql helpers, however it was named locally? */
+/**
+ * Can this unresolvable specifier be ruled out as naming json-sql?
+ *
+ * Conservative by construction: it returns true only for a template literal
+ * whose trailing static text makes a `json-sql` ending impossible — the shape
+ * `` `file://${path}` `` cannot be ruled out by its tail, but one ending in a
+ * fixed `install.mjs`-style suffix can. Anything it cannot prove stays reported,
+ * so the fail-closed default is preserved; this only spares call sites where the
+ * evidence is in the syntax itself.
+ */
+function isProvablyNotJsonSql(node: ts.Expression): boolean {
+  if (!ts.isTemplateExpression(node)) return false
+
+  // A specifier that starts with an absolute-URL or absolute-path scheme names a
+  // resolved file on disk, not a module specifier. json-sql is imported only as
+  // a relative `../lib/json-sql.js`, and TypeScript would not resolve this form
+  // to it in the first place, so such an import cannot be the escape hatch this
+  // check exists to close.
+  const head = node.head.text
+  if (/^(file:\/\/|https?:\/\/|\/)/.test(head)) return true
+
+  // Otherwise, a non-empty tail that is a concrete non-json-sql file suffix pins
+  // the module loaded; a substitution before it cannot change the ending.
+  const tail = node.templateSpans[node.templateSpans.length - 1]?.literal.text ?? ''
+  return tail.length > 0 && !/json-sql/.test(tail) && /\.[a-z]+$/.test(tail)
+}
+
+/**
+ * Is this identifier inside a type annotation, rather than a runtime value?
+ *
+ * `type Extractor = typeof jsonExtractText` and `const f: typeof jsonExtractText`
+ * both mention a helper in a position that is erased at compile time, so neither
+ * is a value escaping the analyzer's view.
+ */
+function isInTypePosition(node: ts.Node): boolean {
+  for (let current = node.parent; current; current = current.parent) {
+    if (ts.isTypeNode(current) || ts.isTypeAliasDeclaration(current)) return true
+    // A `typeof x` type query is a type node, but its argument is an
+    // EntityName rather than a TypeNode, so check the query itself.
+    if (ts.isTypeQueryNode(current)) return true
+    if (ts.isSourceFile(current) || ts.isBlock(current)) return false
+  }
+  return false
+}
+
+/**
+ * The `key` half of `const { key: local } = ns` — the property being read, not
+ * the binding being created. The binding is reported on its own, so counting
+ * this too would double-report one escape.
+ */
+function isPropertyNameOfBinding(node: ts.Node): boolean {
+  return ts.isBindingElement(node.parent) && node.parent.propertyName === node
+}
+
+/**
+ * Is this identifier one of the json-sql helpers, however it was named locally?
+ *
+ * Resolution is by **symbol first, then type identity** — deliberately not by
+ * walking the syntax that produced the binding.
+ *
+ * Every earlier revision asked the forward question: "which syntactic route led
+ * from the export to this name?" — and answered it with one branch per route
+ * (named destructure, then quoted destructure, then shorthand, then computed…).
+ * That direction is unbounded, because TypeScript keeps offering new spellings
+ * for "take a value out of a module", so each review round legitimately found a
+ * shape the previous round had not enumerated. `getTypeAtLocation` asks the
+ * inverse, shape-free question instead: *what is this thing?* A binding produced
+ * by any destructuring form still has the helper's own function type, so all of
+ * those routes collapse into one check that no new syntax can sidestep.
+ *
+ * Type identity is sound here because each helper's type is its unique
+ * declaration — `jsonExtractText` and `jsonExtractNumber` differ in return type,
+ * and nothing else in the program declares a function assignable to either by
+ * identity. It is compared by the type object's own identity, not structurally,
+ * so an unrelated `(c, p) => SQL` does not collide.
+ */
 function helperNameOf(
   checker: ts.TypeChecker,
   node: ts.Node,
   helperSymbols: Map<ts.Symbol, string>,
+  helperTypes: Map<ts.Type, string>,
 ): string | undefined {
   const symbol = resolveSymbol(checker, node)
-  if (!symbol) return undefined
-
-  const direct = helperSymbols.get(symbol)
-  if (direct) return direct
-
-  const declaration = symbol.valueDeclaration
-  if (
-    !declaration ||
-    !ts.isBindingElement(declaration) ||
-    !declaration.propertyName ||
-    !ts.isStringLiteralLike(declaration.propertyName) ||
-    !ts.isObjectBindingPattern(declaration.parent) ||
-    !ts.isVariableDeclaration(declaration.parent.parent) ||
-    !declaration.parent.parent.initializer
-  ) {
-    return undefined
+  if (symbol) {
+    const direct = helperSymbols.get(symbol)
+    if (direct) return direct
   }
 
-  const property = checker.getPropertyOfType(
-    checker.getTypeAtLocation(declaration.parent.parent.initializer),
-    declaration.propertyName.text,
-  )
-  if (!property) return undefined
-  const target =
-    property.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(property) : property
-  return helperSymbols.get(target)
+  return helperTypes.get(checker.getTypeAtLocation(node))
 }
 
-/** Resolve a module specifier that is a string literal or a chain of const aliases. */
-function staticStringValue(
-  checker: ts.TypeChecker,
-  node: ts.Expression,
-  seen = new Set<ts.Symbol>(),
-): string | undefined {
-  if (ts.isStringLiteralLike(node)) return node.text
-  if (ts.isParenthesizedExpression(node)) return staticStringValue(checker, node.expression, seen)
-  if (!ts.isIdentifier(node)) return undefined
-
-  const symbol = resolveSymbol(checker, node)
-  const declaration = symbol?.valueDeclaration
-  if (
-    !symbol ||
-    seen.has(symbol) ||
-    !declaration ||
-    !ts.isVariableDeclaration(declaration) ||
-    !declaration.initializer ||
-    !ts.isVariableDeclarationList(declaration.parent) ||
-    !(declaration.parent.flags & ts.NodeFlags.Const)
-  ) {
-    return undefined
-  }
-
-  seen.add(symbol)
-  return staticStringValue(checker, declaration.initializer, seen)
+/**
+ * The compile-time value of a string expression, or `undefined` when it cannot
+ * be proven.
+ *
+ * This asks the checker for the type and reads a string-literal type off it,
+ * rather than pattern-matching the expression. `as const`, `satisfies`,
+ * parentheses, a `const` alias chain and constant-folded concatenation all
+ * produce a string-literal *type*, so one question covers every form — the same
+ * inversion `helperNameOf` makes, for the same reason: enumerating expression
+ * shapes is unbounded, asking what the value is is not.
+ *
+ * The literal-type route also fixes a false positive the syntactic version
+ * caused: `const key = 'jsonExtractText' as const` used in `jsonSql[key](...)`
+ * was unresolvable, so a legitimate call was reported as a dynamic key.
+ */
+function staticStringValue(checker: ts.TypeChecker, node: ts.Expression): string | undefined {
+  const type = checker.getTypeAtLocation(node)
+  const literal = type.isStringLiteral()
+    ? type
+    : // A `satisfies`/widened position can yield a union of one literal.
+      type.isUnion() && type.types.length === 1 && type.types[0]?.isStringLiteral()
+      ? (type.types[0] as ts.StringLiteralType)
+      : undefined
+  return literal?.value
 }
 
 /**
@@ -214,6 +297,10 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
   const jsonSqlSource = program.getSourceFile(JSON_SQL)
   const moduleSymbol = jsonSqlSource ? checker.getSymbolAtLocation(jsonSqlSource) : undefined
   const helperSymbols = new Map<ts.Symbol, string>()
+  // Keyed by the checker's own type object, so lookup is identity-based: a
+  // structurally similar but unrelated function is a different type object and
+  // does not match.
+  const helperTypes = new Map<ts.Type, string>()
   if (moduleSymbol) {
     for (const symbol of checker.getExportsOfModule(moduleSymbol)) {
       const name = symbol.getName()
@@ -221,6 +308,10 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
         const target =
           symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
         helperSymbols.set(target, name)
+        const declaration = target.valueDeclaration
+        if (declaration) {
+          helperTypes.set(checker.getTypeOfSymbolAtLocation(target, declaration), name)
+        }
       }
     }
   }
@@ -253,7 +344,7 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
           }),
         )
         const helper = ts.isIdentifier(callee)
-          ? helperNameOf(checker, callee, helperSymbols)
+          ? helperNameOf(checker, callee, helperSymbols, helperTypes)
           : elementAccess && elementKey && elementNamespaceType
             ? (() => {
                 const property = checker.getPropertyOfType(elementNamespaceType, elementKey)
@@ -320,20 +411,48 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
       if (
         ts.isCallExpression(node) &&
         node.expression.kind === ts.SyntaxKind.ImportKeyword &&
-        node.arguments[0] &&
-        /json-sql(\.js)?$/.test(staticStringValue(checker, node.arguments[0]) ?? '')
+        node.arguments[0]
       ) {
-        findings.push({
-          file,
-          message:
-            'json-sql imported dynamically; import it statically so call sites stay resolvable',
-        })
+        const specifier = staticStringValue(checker, node.arguments[0])
+        if (specifier === undefined && !isProvablyNotJsonSql(node.arguments[0])) {
+          // Fail closed, but only for a specifier that could actually name this
+          // module. Treating "unresolvable" as "not json-sql" is what let
+          // `'../lib/' + 'json-sql.js'` through: the check passed because the
+          // *analyzer* failed, not because the code was safe.
+          //
+          // A genuinely runtime path that cannot contain 'json-sql' (loading a
+          // resolved .mjs by absolute path, say) is left alone — the goal is to
+          // stop this module escaping, not to ban dynamic import.
+          findings.push({
+            file,
+            message:
+              'dynamic import whose specifier is not statically resolvable and could name json-sql; use a literal specifier so the target can be checked',
+          })
+        } else if (specifier !== undefined && /json-sql(\.js)?$/.test(specifier)) {
+          findings.push({
+            file,
+            message:
+              'json-sql imported dynamically; import it statically so call sites stay resolvable',
+          })
+        }
       }
 
       // A helper referenced anywhere other than as the callee of a call is a
-      // value escaping into code this analyzer stops tracking.
-      if (ts.isIdentifier(node) && !ts.isImportSpecifier(node.parent)) {
-        const helper = helperNameOf(checker, node, helperSymbols)
+      // value escaping into code this analyzer stops tracking. With type-based
+      // resolution this is also what catches every destructuring form: the new
+      // binding is an identifier carrying the helper's type, so it is reported
+      // here at the point it is created, whatever syntax created it.
+      //
+      // Type positions are excluded. `type Extractor = typeof jsonExtractText`
+      // names the helper's type without ever holding the function at runtime, so
+      // it cannot smuggle a column past anything and is not an escape.
+      if (
+        ts.isIdentifier(node) &&
+        !ts.isImportSpecifier(node.parent) &&
+        !isInTypePosition(node) &&
+        !isPropertyNameOfBinding(node)
+      ) {
+        const helper = helperNameOf(checker, node, helperSymbols, helperTypes)
         const isCallee = ts.isCallExpression(node.parent) && node.parent.expression === node
         const isPropertyCallee =
           ts.isPropertyAccessExpression(node.parent) &&
@@ -489,6 +608,37 @@ describe('the analyzer itself, against every known evasion shape', () => {
        extract4(users.email, ['x'])`,
     ],
     [
+      'shorthand namespace destructure',
+      `import * as jsonSql from '../lib/json-sql.js'
+       const { jsonExtractText } = jsonSql
+       jsonExtractText(users.email, ['x'])`,
+    ],
+    [
+      'computed namespace destructure',
+      `import * as jsonSql from '../lib/json-sql.js'
+       const key = 'jsonExtractText'
+       const { [key]: extract8 } = jsonSql
+       extract8(users.email, ['x'])`,
+    ],
+    [
+      'dynamic import through an as-const specifier',
+      `const specifier = '../lib/json-sql.js' as const
+       const { jsonExtractText: extract9 } = await import(specifier)
+       extract9(users.email, ['x'])`,
+    ],
+    [
+      'dynamic import through a satisfies specifier',
+      `const specifier = '../lib/json-sql.js' satisfies string
+       const { jsonExtractText: extract10 } = await import(specifier)
+       extract10(users.email, ['x'])`,
+    ],
+    [
+      'dynamic import through a concatenated specifier',
+      `const specifier = '../lib/' + 'json-sql.js'
+       const { jsonExtractText: extract11 } = await import(specifier)
+       extract11(users.email, ['x'])`,
+    ],
+    [
       'local rebind',
       `import { jsonExtractText } from '../lib/json-sql.js'
        const extract4 = jsonExtractText
@@ -551,6 +701,27 @@ describe('the analyzer itself, against every known evasion shape', () => {
       expect(result.findings.length > 0 || surfacedBadColumn).toBe(true)
     })
   }
+
+  it('leaves a genuinely unrelated dynamic import alone', () => {
+    // `loadInstaller()` in lib/cli-installer.ts imports a resolved .mjs by
+    // absolute file:// path. Fail-closed must not tax code that provably cannot
+    // be reaching json-sql, or the rule gets reverted rather than obeyed.
+    const result = analyzeFixture(
+      `const path = '/tmp/install.mjs'
+       const mod = await import(\`file://\${path}\`)
+       void mod`,
+    )
+    expect(result.findings).toEqual([])
+  })
+
+  it('still flags an interpolated specifier that could name json-sql', () => {
+    const result = analyzeFixture(
+      `declare const dir: string
+       const mod = await import(\`../\${dir}/json-sql.js\`)
+       void mod`,
+    )
+    expect(result.findings.length).toBeGreaterThan(0)
+  })
 
   it('passes the vanilla shape and resolves its column to the real table', () => {
     const result = analyzeFixture(

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -87,13 +87,25 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
     const body = code(readFileSync(file, 'utf-8'))
     const relative = file.slice(SRC.length + 1)
 
-    // An aliased import (`jsonExtractText as extract`) renames the call and
-    // would slip past a scan keyed on the original names, so treat it as a
-    // finding in its own right rather than letting the call go unexamined.
+    // Any rebinding of a helper to another name renames the call and would slip
+    // past a scan keyed on the original names, so treat it as a finding rather
+    // than letting the call go unexamined. Two forms: an aliased import
+    // (`jsonExtractText as extract`) and a local rebind (`const extract =
+    // jsonExtractText`), including destructuring off a namespace import.
     for (const helper of HELPERS) {
-      const renamed = new RegExp(`\\b${helper}\\s+as\\s+([A-Za-z_$][\\w$]*)`, 'g')
-      for (const match of body.matchAll(renamed)) {
+      const renamedImport = new RegExp(`\\b${helper}\\s+as\\s+([A-Za-z_$][\\w$]*)`, 'g')
+      for (const match of body.matchAll(renamedImport)) {
         aliasedImports.push(`${relative}: ${helper} imported as ${match[1]}`)
+      }
+
+      // `= jsonExtractText` with no call parenthesis: the function itself is
+      // being passed around rather than invoked here.
+      const rebind = new RegExp(
+        `(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*[\\w$.]*\\b${helper}\\b\\s*(?!\\()`,
+        'g',
+      )
+      for (const match of body.matchAll(rebind)) {
+        aliasedImports.push(`${relative}: ${helper} rebound as ${match[1]}`)
       }
     }
 
@@ -104,7 +116,11 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
 
   it('finds the known call sites, so a broken scan cannot pass vacuously', () => {
     const all = [...callSites.values()].flat()
-    expect(all.length).toBeGreaterThanOrEqual(10)
+    // Pinned to the exact current count, not a floor. A floor of 10 stayed green
+    // while calls silently dropped out of view — which is the failure this file
+    // guards against. Adding or removing a call site is expected to update this
+    // number deliberately.
+    expect(all).toHaveLength(14)
     // The column this whole suite exists for must be among them.
     expect(all).toContain('a2aTasks.data')
   })

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -50,22 +50,56 @@ function code(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '')
 }
 
-/** Collect `table.column` first arguments passed to any JSON helper. */
-function collectColumnArguments(source: string): string[] {
-  const found: string[] = []
+/**
+ * Collect the first argument of every JSON-helper call, split into the
+ * `table.column` references this scan can resolve and everything it cannot.
+ *
+ * The unresolved bucket is the point. A scan that only matched `table.column`
+ * and ignored the rest would silently pass a call whose column arrives as a
+ * local variable or through an aliased import — reporting green for code it
+ * never actually checked. Surfacing those instead forces them to be made
+ * resolvable (or explicitly acknowledged), so "no offenders" means "nothing
+ * unchecked" rather than "nothing recognised".
+ */
+function collectColumnArguments(source: string): { resolved: string[]; unresolved: string[] } {
+  const resolved: string[] = []
+  const unresolved: string[] = []
   for (const helper of HELPERS) {
-    const call = new RegExp(`\\b${helper}\\s*\\(\\s*([A-Za-z_$][\\w$]*\\.[A-Za-z_$][\\w$]*)`, 'g')
-    for (const match of source.matchAll(call)) found.push(match[1])
+    // `[^,)]+` captures whatever the first argument actually is, so a call the
+    // narrow `table.column` form would miss still lands in one bucket or other.
+    const call = new RegExp(`\\b${helper}\\s*\\(\\s*([^,)]+?)\\s*[,)]`, 'g')
+    for (const match of source.matchAll(call)) {
+      const argument = match[1].replace(/\s+/g, ' ').trim()
+      if (/^[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*$/.test(argument)) resolved.push(argument)
+      else unresolved.push(`${helper}(${argument})`)
+    }
   }
-  return found
+  return { resolved, unresolved }
 }
 
 describe('JSON helper call sites pass JSON-bearing columns', () => {
   const callSites = new Map<string, string[]>()
+  const unresolvedSites = new Map<string, string[]>()
+  const aliasedImports: string[] = []
+
   for (const file of walk(SRC)) {
     if (file === resolve(SRC, 'lib/json-sql.ts')) continue
-    const columns = collectColumnArguments(code(readFileSync(file, 'utf-8')))
-    if (columns.length) callSites.set(file.slice(SRC.length + 1), columns)
+    const body = code(readFileSync(file, 'utf-8'))
+    const relative = file.slice(SRC.length + 1)
+
+    // An aliased import (`jsonExtractText as extract`) renames the call and
+    // would slip past a scan keyed on the original names, so treat it as a
+    // finding in its own right rather than letting the call go unexamined.
+    for (const helper of HELPERS) {
+      const renamed = new RegExp(`\\b${helper}\\s+as\\s+([A-Za-z_$][\\w$]*)`, 'g')
+      for (const match of body.matchAll(renamed)) {
+        aliasedImports.push(`${relative}: ${helper} imported as ${match[1]}`)
+      }
+    }
+
+    const { resolved, unresolved } = collectColumnArguments(body)
+    if (resolved.length) callSites.set(relative, resolved)
+    if (unresolved.length) unresolvedSites.set(relative, unresolved)
   }
 
   it('finds the known call sites, so a broken scan cannot pass vacuously', () => {
@@ -73,6 +107,19 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
     expect(all.length).toBeGreaterThanOrEqual(10)
     // The column this whole suite exists for must be among them.
     expect(all).toContain('a2aTasks.data')
+  })
+
+  it('leaves no helper call whose column argument it could not resolve', () => {
+    // A silent skip here is the failure mode: it reads as "checked and clean"
+    // for a call site the scan never inspected. If this trips, either write the
+    // argument as a direct `table.column` or extend the resolver deliberately.
+    expect(
+      [...unresolvedSites].flatMap(([file, calls]) => calls.map((c) => `${file}: ${c}`)),
+    ).toEqual([])
+  })
+
+  it('leaves no aliased helper import that would rename a call out of view', () => {
+    expect(aliasedImports).toEqual([])
   })
 
   it('resolves every column argument to a json column or an allowed text one', () => {
@@ -84,11 +131,17 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
         const table = (schema as Record<string, unknown>)[tableName] as
           | Record<string, { dataType?: string }>
           | undefined
-        // An unresolvable name means a local alias, not a schema table; the
-        // real schema tables are what this guard is about.
-        if (!table) continue
+        // Not a schema table (e.g. a locally-built drizzle fragment). Recorded
+        // rather than skipped, so the scan cannot quietly ignore a call site.
+        if (!table) {
+          offenders.push(`${file}: ${reference} does not resolve to a schema table`)
+          continue
+        }
         const column = table[columnName]
-        if (!column?.dataType) continue
+        if (!column?.dataType) {
+          offenders.push(`${file}: ${reference} is not a column of that table`)
+          continue
+        }
 
         if (column.dataType === 'json') continue
         if (ALLOWED_PLAIN_TEXT.has(reference)) continue

--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -98,7 +98,7 @@ function createProgram(
 
   const rootNames =
     scope === 'fixture'
-      ? Object.keys(extraFiles)
+      ? [...Object.keys(extraFiles), JSON_SQL]
       : [...parsed.fileNames, ...Object.keys(extraFiles)]
   const options: ts.CompilerOptions = { ...parsed.options, noEmit: true }
   const host = ts.createCompilerHost(options, true)
@@ -148,7 +148,60 @@ function helperNameOf(
   helperSymbols: Map<ts.Symbol, string>,
 ): string | undefined {
   const symbol = resolveSymbol(checker, node)
-  return symbol ? helperSymbols.get(symbol) : undefined
+  if (!symbol) return undefined
+
+  const direct = helperSymbols.get(symbol)
+  if (direct) return direct
+
+  const declaration = symbol.valueDeclaration
+  if (
+    !declaration ||
+    !ts.isBindingElement(declaration) ||
+    !declaration.propertyName ||
+    !ts.isStringLiteralLike(declaration.propertyName) ||
+    !ts.isObjectBindingPattern(declaration.parent) ||
+    !ts.isVariableDeclaration(declaration.parent.parent) ||
+    !declaration.parent.parent.initializer
+  ) {
+    return undefined
+  }
+
+  const property = checker.getPropertyOfType(
+    checker.getTypeAtLocation(declaration.parent.parent.initializer),
+    declaration.propertyName.text,
+  )
+  if (!property) return undefined
+  const target =
+    property.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(property) : property
+  return helperSymbols.get(target)
+}
+
+/** Resolve a module specifier that is a string literal or a chain of const aliases. */
+function staticStringValue(
+  checker: ts.TypeChecker,
+  node: ts.Expression,
+  seen = new Set<ts.Symbol>(),
+): string | undefined {
+  if (ts.isStringLiteralLike(node)) return node.text
+  if (ts.isParenthesizedExpression(node)) return staticStringValue(checker, node.expression, seen)
+  if (!ts.isIdentifier(node)) return undefined
+
+  const symbol = resolveSymbol(checker, node)
+  const declaration = symbol?.valueDeclaration
+  if (
+    !symbol ||
+    seen.has(symbol) ||
+    !declaration ||
+    !ts.isVariableDeclaration(declaration) ||
+    !declaration.initializer ||
+    !ts.isVariableDeclarationList(declaration.parent) ||
+    !(declaration.parent.flags & ts.NodeFlags.Const)
+  ) {
+    return undefined
+  }
+
+  seen.add(symbol)
+  return staticStringValue(checker, declaration.initializer, seen)
 }
 
 /**
@@ -183,9 +236,43 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
         const callee = ts.isPropertyAccessExpression(node.expression)
           ? node.expression.name
           : node.expression
+        const elementAccess = ts.isElementAccessExpression(node.expression)
+          ? node.expression
+          : undefined
+        const elementKey = elementAccess
+          ? staticStringValue(checker, elementAccess.argumentExpression)
+          : undefined
+        const elementNamespaceType = elementAccess
+          ? checker.getTypeAtLocation(elementAccess.expression)
+          : undefined
+        const isJsonSqlNamespace = Boolean(
+          elementNamespaceType?.getProperties().some((property) => {
+            const target =
+              property.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(property) : property
+            return helperSymbols.has(target)
+          }),
+        )
         const helper = ts.isIdentifier(callee)
           ? helperNameOf(checker, callee, helperSymbols)
-          : undefined
+          : elementAccess && elementKey && elementNamespaceType
+            ? (() => {
+                const property = checker.getPropertyOfType(elementNamespaceType, elementKey)
+                if (!property) return undefined
+                const target =
+                  property.flags & ts.SymbolFlags.Alias
+                    ? checker.getAliasedSymbol(property)
+                    : property
+                return helperSymbols.get(target)
+              })()
+            : undefined
+
+        if (elementAccess && isJsonSqlNamespace && !elementKey) {
+          findings.push({
+            file,
+            message:
+              'json-sql namespace called with a dynamically computed property; use a statically resolvable helper name',
+          })
+        }
 
         if (helper) {
           const argument = node.arguments[0]
@@ -234,8 +321,7 @@ function analyze(program: ts.Program, checker: ts.TypeChecker, files: ts.SourceF
         ts.isCallExpression(node) &&
         node.expression.kind === ts.SyntaxKind.ImportKeyword &&
         node.arguments[0] &&
-        ts.isStringLiteralLike(node.arguments[0]) &&
-        /json-sql(\.js)?$/.test(node.arguments[0].text)
+        /json-sql(\.js)?$/.test(staticStringValue(checker, node.arguments[0]) ?? '')
       ) {
         findings.push({
           file,
@@ -374,10 +460,33 @@ describe('the analyzer itself, against every known evasion shape', () => {
        jsonSql.jsonExtractText(runs.status, ['x'])`,
     ],
     [
+      'namespace bracket access',
+      `import * as jsonSql from '../lib/json-sql.js'
+       jsonSql['jsonExtractText'](users.email, ['x'])`,
+    ],
+    [
+      'namespace bracket access through a static key',
+      `import * as jsonSql from '../lib/json-sql.js'
+       const key = 'jsonExtractText'
+       jsonSql[key](users.email, ['x'])`,
+    ],
+    [
+      'namespace bracket access through a runtime key',
+      `import * as jsonSql from '../lib/json-sql.js'
+       declare const key: keyof typeof jsonSql
+       jsonSql[key](users.email, ['x'])`,
+    ],
+    [
       'namespace destructure',
       `import * as jsonSql from '../lib/json-sql.js'
        const { jsonExtractText: extract3 } = jsonSql
        extract3(runs.status, ['x'])`,
+    ],
+    [
+      'quoted namespace destructure',
+      `import * as jsonSql from '../lib/json-sql.js'
+       const { 'jsonExtractText': extract4 } = jsonSql
+       extract4(users.email, ['x'])`,
     ],
     [
       'local rebind',
@@ -401,6 +510,12 @@ describe('the analyzer itself, against every known evasion shape', () => {
       'dynamic-import destructure',
       `const { jsonExtractText: extract6 } = await import('../lib/json-sql.js')
        extract6(users.email, ['x'])`,
+    ],
+    [
+      'dynamic-import destructure through a static specifier',
+      `const specifier = '../lib/json-sql.js'
+       const { jsonExtractText: extract7 } = await import(specifier)
+       extract7(users.email, ['x'])`,
     ],
     [
       'dynamic import inside a function, awaited',

--- a/apps/api/src/lib/__tests__/json-sql-path-segments.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-path-segments.test.ts
@@ -2,22 +2,21 @@
  * Path segments must mean the same thing on both backends.
  *
  * PostgreSQL binds each segment as a parameter, so it is always a literal key.
- * SQLite receives the whole path as one `$.a.b` string, in which `.` and `[]`
- * are path *syntax*. A single segment therefore addresses two different things
- * depending on the backend — confirmed against both engines:
+ * SQLite receives the whole path as one `$.a.b` string, where an unquoted
+ * label runs until the next `.` or `[`, a *leading* `"` opens a quoted label,
+ * and an empty label is invalid. Exactly those four shapes diverge; the
+ * helpers reject them at the boundary, before the dialect branch.
  *
- *   ['a.b']   PG the key "a.b";   SQLite descends a -> b
- *   ['a[0]']  PG the key "a[0]";  SQLite indexes into the array a
- *   ['']      PG the empty key;   SQLite raises "bad JSON path"
+ * Just as load-bearing: nothing else is rejected. Commas, spaces, unicode,
+ * leading digits, hyphens, colons, `$`, `#`, `]`, backslashes, interior and
+ * trailing quotes are all literal keys on BOTH engines — proven below with
+ * real SQLite round-trips, not asserted from documentation. An earlier
+ * revision used an identifier allowlist, which mislabelled every one of those
+ * dialect-consistent keys as divergent and made the helpers throw on paths
+ * the two backends agree on.
  *
- * That is the same class of defect as the comma-in-path bug: content inside a
- * segment silently reinterpreted as structure. The helpers reject these shapes
- * rather than escaping them, since every real segment is a TypeScript object
- * key and escaping would mean tracking two engines' quoting rules forever.
- *
- * This file runs on the SQLite branch (the default backend) so the rejection is
- * proven where most developers actually run, and pairs each case with the real
- * SQLite behaviour that makes the rejection necessary.
+ * This file runs on the SQLite branch (the default backend) so the rejection
+ * is proven where most developers actually run.
  */
 import Database from 'better-sqlite3'
 import { describe, expect, it, vi } from 'vitest'
@@ -35,64 +34,104 @@ import {
   jsonSet,
 } from '../json-sql.js'
 
-/** Segments whose meaning differs between the two engines. */
-const AMBIGUOUS = ['a.b', 'a[0]', '', 'a,b', 'a"b', '$', 'a b']
+/** The four shapes SQLite reads as path syntax rather than a literal key. */
+const DIVERGENT = ['a.b', 'task.status', 'a[0]', 'items[3]', '"ab', '']
 
-describe('ambiguous path segments are rejected on every helper', () => {
-  for (const segment of AMBIGUOUS) {
+/**
+ * Keys that LOOK special but are literal on both engines. Kept in sync with
+ * the real-engine round-trip suite at the bottom of this file — every entry
+ * here must also prove itself there.
+ */
+const LITERAL_SPECIAL = [
+  'a,b',
+  'a"b',
+  'ab"',
+  '$',
+  '#',
+  'a b',
+  '9key',
+  'hy-phen',
+  '中文',
+  'a:b',
+  'a]b',
+  'a\\b',
+]
+
+describe('dialect-divergent path segments are rejected on every helper', () => {
+  for (const segment of DIVERGENT) {
     it(`rejects ${JSON.stringify(segment)}`, () => {
-      expect(() => jsonExtractText(runSteps.output, [segment])).toThrow(/not a plain key/)
-      expect(() => jsonExtractNumber(runSteps.output, [segment])).toThrow(/not a plain key/)
-      expect(() => jsonPathIsAbsent(runSteps.output, [segment])).toThrow(/not a plain key/)
-      expect(() => jsonSet(runSteps.output, [segment], 1)).toThrow(/not a plain key/)
+      expect(() => jsonExtractText(runSteps.output, [segment])).toThrow(/path syntax/)
+      expect(() => jsonExtractNumber(runSteps.output, [segment])).toThrow(/path syntax/)
+      expect(() => jsonPathIsAbsent(runSteps.output, [segment])).toThrow(/path syntax/)
+      expect(() => jsonSet(runSteps.output, [segment], 1)).toThrow(/path syntax/)
       expect(() => jsonArrayContainsKeyValue(runSteps.output, [segment], 'k', 'v')).toThrow(
-        /not a plain key/,
+        /path syntax/,
       )
     })
   }
 
-  it('rejects an ambiguous segment anywhere in a multi-segment path', () => {
-    expect(() => jsonExtractText(runSteps.output, ['task', 'a.b', 'state'])).toThrow(
-      /not a plain key/,
-    )
+  it('rejects a divergent segment anywhere in a multi-segment path', () => {
+    expect(() => jsonExtractText(runSteps.output, ['task', 'a.b', 'state'])).toThrow(/path syntax/)
   })
 
-  it('rejects an ambiguous elementKey, which SQLite also splices into a path', () => {
+  it('rejects a divergent elementKey, which SQLite also splices into a path', () => {
     expect(() => jsonArrayContainsKeyValue(runSteps.output, ['chain'], 'a.b', 'v')).toThrow(
-      /not a plain key/,
+      /path syntax/,
     )
   })
+})
 
-  it('still accepts the ordinary keys the codebase actually uses', () => {
+describe('dialect-consistent keys are NOT rejected', () => {
+  it('accepts the ordinary keys the codebase actually uses', () => {
     for (const segment of ['usage', 'inputTokens', 'contextId', 'scope', '_private', 'a1']) {
       expect(() => jsonExtractText(runSteps.output, [segment])).not.toThrow()
     }
   })
+
+  for (const segment of LITERAL_SPECIAL) {
+    it(`accepts ${JSON.stringify(segment)}, a literal key on both engines`, () => {
+      expect(() => jsonExtractText(runSteps.output, [segment])).not.toThrow()
+      expect(() => jsonSet(runSteps.output, [segment], 1)).not.toThrow()
+      expect(() =>
+        jsonArrayContainsKeyValue(runSteps.output, ['chain'], segment, 'v'),
+      ).not.toThrow()
+    })
+  }
 })
 
-describe('why those segments are rejected: real SQLite behaviour', () => {
-  const query = (sql: string): unknown => {
-    const db = new Database(':memory:')
+describe('the classification itself, against the real SQLite engine', () => {
+  const db = new Database(':memory:')
+
+  /** True when `$.${segment}` writes and reads back exactly the literal key. */
+  const isLiteralOnSqlite = (segment: string): boolean => {
+    const path = `$.${segment}`
     try {
-      return db.prepare(sql).pluck().get()
-    } finally {
-      db.close()
+      const set = db.prepare("SELECT json_set('{}', ?, json('1'))").pluck().get(path)
+      if (set !== JSON.stringify({ [segment]: 1 })) return false
+      const doc = JSON.stringify({ [segment]: 7 })
+      return db.prepare('SELECT json_extract(?, ?)').pluck().get(doc, path) === 7
+    } catch {
+      return false
     }
   }
 
-  it("treats '.' inside a segment as a descent, unlike PostgreSQL's literal key", () => {
+  for (const segment of LITERAL_SPECIAL) {
+    it(`${JSON.stringify(segment)} round-trips literally, so allowing it is sound`, () => {
+      expect(isLiteralOnSqlite(segment)).toBe(true)
+    })
+  }
+
+  for (const segment of DIVERGENT) {
+    it(`${JSON.stringify(segment)} does NOT round-trip literally, so rejecting it is sound`, () => {
+      expect(isLiteralOnSqlite(segment)).toBe(false)
+    })
+  }
+
+  it("shows the flagship divergence: '.' descends on SQLite, is literal on PostgreSQL", () => {
     // The document has BOTH a nested a->b and a top-level "a.b". SQLite's path
-    // reaches the nested 9; PostgreSQL, binding 'a.b' as one key, reads 7.
-    const document = `'{"a":{"b":9},"a.b":7}'`
-    expect(query(`SELECT json_extract(${document}, '$.a.b')`)).toBe(9)
-    expect(query(`SELECT json_extract(${document}, '$."a.b"')`)).toBe(7)
-  })
-
-  it("treats '[]' inside a segment as an index", () => {
-    expect(query(`SELECT json_set('{}', '$.a[0]', json('1'))`)).toBe('{"a":[1]}')
-  })
-
-  it('rejects an empty segment outright, where PostgreSQL accepts the empty key', () => {
-    expect(() => query(`SELECT json_set('{}', '$.', json('1'))`)).toThrow(/bad JSON path|malformed/)
+    // reaches the nested 9; PostgreSQL, binding 'a.b' as one key, would read 7.
+    const document = `{"a":{"b":9},"a.b":7}`
+    expect(db.prepare('SELECT json_extract(?, ?)').pluck().get(document, '$.a.b')).toBe(9)
+    expect(db.prepare('SELECT json_extract(?, ?)').pluck().get(document, '$."a.b"')).toBe(7)
   })
 })

--- a/apps/api/src/lib/__tests__/json-sql-path-segments.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-path-segments.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Path segments must mean the same thing on both backends.
+ *
+ * PostgreSQL binds each segment as a parameter, so it is always a literal key.
+ * SQLite receives the whole path as one `$.a.b` string, in which `.` and `[]`
+ * are path *syntax*. A single segment therefore addresses two different things
+ * depending on the backend — confirmed against both engines:
+ *
+ *   ['a.b']   PG the key "a.b";   SQLite descends a -> b
+ *   ['a[0]']  PG the key "a[0]";  SQLite indexes into the array a
+ *   ['']      PG the empty key;   SQLite raises "bad JSON path"
+ *
+ * That is the same class of defect as the comma-in-path bug: content inside a
+ * segment silently reinterpreted as structure. The helpers reject these shapes
+ * rather than escaping them, since every real segment is a TypeScript object
+ * key and escaping would mean tracking two engines' quoting rules forever.
+ *
+ * This file runs on the SQLite branch (the default backend) so the rejection is
+ * proven where most developers actually run, and pairs each case with the real
+ * SQLite behaviour that makes the rejection necessary.
+ */
+import Database from 'better-sqlite3'
+import { describe, expect, it, vi } from 'vitest'
+
+// Pin the SQLite branch: a developer whose .env selects PostgreSQL would
+// otherwise flip these helpers to the `->>` form (see json-sql.test.ts).
+vi.mock('../../db/client.js', () => ({ isPostgres: false }))
+
+import { runSteps } from '../../db/schema.js'
+import {
+  jsonArrayContainsKeyValue,
+  jsonExtractNumber,
+  jsonExtractText,
+  jsonPathIsAbsent,
+  jsonSet,
+} from '../json-sql.js'
+
+/** Segments whose meaning differs between the two engines. */
+const AMBIGUOUS = ['a.b', 'a[0]', '', 'a,b', 'a"b', '$', 'a b']
+
+describe('ambiguous path segments are rejected on every helper', () => {
+  for (const segment of AMBIGUOUS) {
+    it(`rejects ${JSON.stringify(segment)}`, () => {
+      expect(() => jsonExtractText(runSteps.output, [segment])).toThrow(/not a plain key/)
+      expect(() => jsonExtractNumber(runSteps.output, [segment])).toThrow(/not a plain key/)
+      expect(() => jsonPathIsAbsent(runSteps.output, [segment])).toThrow(/not a plain key/)
+      expect(() => jsonSet(runSteps.output, [segment], 1)).toThrow(/not a plain key/)
+      expect(() => jsonArrayContainsKeyValue(runSteps.output, [segment], 'k', 'v')).toThrow(
+        /not a plain key/,
+      )
+    })
+  }
+
+  it('rejects an ambiguous segment anywhere in a multi-segment path', () => {
+    expect(() => jsonExtractText(runSteps.output, ['task', 'a.b', 'state'])).toThrow(
+      /not a plain key/,
+    )
+  })
+
+  it('rejects an ambiguous elementKey, which SQLite also splices into a path', () => {
+    expect(() => jsonArrayContainsKeyValue(runSteps.output, ['chain'], 'a.b', 'v')).toThrow(
+      /not a plain key/,
+    )
+  })
+
+  it('still accepts the ordinary keys the codebase actually uses', () => {
+    for (const segment of ['usage', 'inputTokens', 'contextId', 'scope', '_private', 'a1']) {
+      expect(() => jsonExtractText(runSteps.output, [segment])).not.toThrow()
+    }
+  })
+})
+
+describe('why those segments are rejected: real SQLite behaviour', () => {
+  const query = (sql: string): unknown => {
+    const db = new Database(':memory:')
+    try {
+      return db.prepare(sql).pluck().get()
+    } finally {
+      db.close()
+    }
+  }
+
+  it("treats '.' inside a segment as a descent, unlike PostgreSQL's literal key", () => {
+    // The document has BOTH a nested a->b and a top-level "a.b". SQLite's path
+    // reaches the nested 9; PostgreSQL, binding 'a.b' as one key, reads 7.
+    const document = `'{"a":{"b":9},"a.b":7}'`
+    expect(query(`SELECT json_extract(${document}, '$.a.b')`)).toBe(9)
+    expect(query(`SELECT json_extract(${document}, '$."a.b"')`)).toBe(7)
+  })
+
+  it("treats '[]' inside a segment as an index", () => {
+    expect(query(`SELECT json_set('{}', '$.a[0]', json('1'))`)).toBe('{"a":[1]}')
+  })
+
+  it('rejects an empty segment outright, where PostgreSQL accepts the empty key', () => {
+    expect(() => query(`SELECT json_set('{}', '$.', json('1'))`)).toThrow(/bad JSON path|malformed/)
+  })
+})

--- a/apps/api/src/lib/__tests__/json-sql-path-segments.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-path-segments.test.ts
@@ -34,8 +34,14 @@ import {
   jsonSet,
 } from '../json-sql.js'
 
-/** The four shapes SQLite reads as path syntax rather than a literal key. */
-const DIVERGENT = ['a.b', 'task.status', 'a[0]', 'items[3]', '"ab', '']
+/**
+ * The five shapes SQLite reads as something other than the literal key.
+ *
+ * The NUL entries cover all three positions. SQLite's path is a C string, so an
+ * interior or trailing NUL silently truncates the key — `a\0b` reads `a`, which
+ * is a wrong-row read rather than an error — while a leading one throws.
+ */
+const DIVERGENT = ['a.b', 'task.status', 'a[0]', 'items[3]', '"ab', '', 'a\0b', 'ab\0', '\0ab']
 
 /**
  * Keys that LOOK special but are literal on both engines. Kept in sync with
@@ -126,6 +132,18 @@ describe('the classification itself, against the real SQLite engine', () => {
       expect(isLiteralOnSqlite(segment)).toBe(false)
     })
   }
+
+  it('shows the NUL divergence: SQLite truncates the key and reads a different value', () => {
+    // The quietest of the five shapes — the only one that returns a wrong row
+    // instead of raising. SQLite's path is a C string, so `$.a\0b` stops at the
+    // NUL and reads key "a" (1); PostgreSQL binds the whole segment and reads
+    // key "a\0b" (3). Neither errors, so nothing would have surfaced this.
+    const document = JSON.stringify({ a: 1, 'a\0b': 3 })
+    expect(db.prepare('SELECT json_extract(?, ?)').pluck().get(document, '$.a\0b')).toBe(1)
+    // A trailing NUL degrades the same way, reading the untruncated key.
+    const trailing = JSON.stringify({ ab: 2, 'ab\0': 4 })
+    expect(db.prepare('SELECT json_extract(?, ?)').pluck().get(trailing, '$.ab\0')).toBe(2)
+  })
 
   it("shows the flagship divergence: '.' descends on SQLite, is literal on PostgreSQL", () => {
     // The document has BOTH a nested a->b and a top-level "a.b". SQLite's path

--- a/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
@@ -23,6 +23,7 @@
  * exactly why it went unnoticed.
  */
 import { PgDialect } from 'drizzle-orm/pg-core'
+import { alias } from 'drizzle-orm/sqlite-core'
 import { describe, expect, it, vi } from 'vitest'
 
 // Force the PostgreSQL branch: isPostgresRuntime() reads `isPostgres` off the
@@ -135,6 +136,34 @@ describe('JSON helpers over a plain text column on PostgreSQL', () => {
     expect(() => jsonPathIsAbsent(runs.status, ['k'])).toThrow(/runs\.status/)
     expect(() => jsonSet(runs.status, ['k'], 1)).toThrow(/runs\.status/)
     expect(() => jsonArrayContainsKeyValue(runs.status, ['a'], 'k', 'v')).toThrow(/runs\.status/)
+  })
+
+  it('still recognises the allowlisted column when its table is aliased', () => {
+    // `alias()` is used in this codebase (lib/agent-access.ts) and makes drizzle
+    // report the alias, not the physical table. Keying the allowlist off the
+    // alias would reject the very column it exists to permit — a self-join or
+    // subquery over a2a_tasks would throw at query-build time.
+    const aliased = alias(a2aTasks, 'task_alias')
+
+    expect(renderPg(jsonExtractText(aliased.data, ['scope', 'tenant']))).toBe(
+      '("task_alias"."data")::jsonb -> $1 ->> $2',
+    )
+  })
+
+  it('refuses a multi-segment jsonSet path, which the dialects disagree on', () => {
+    // Verified on PostgreSQL 14 vs SQLite:
+    //   PG     jsonb_set('{}', '{a,b}', '1', true) -> {}            (silent no-op)
+    //   SQLite json_set('{}', '$.a.b', json('1'))  -> {"a":{"b":1}} (creates it)
+    // `jsonb_set` will not create a missing intermediate parent, so a nested
+    // write would silently do nothing on PostgreSQL only. Rejecting the shape
+    // outright beats shipping a helper that quietly means two different things.
+    // @ts-expect-error - a multi-segment path is not assignable to JsonSetPath
+    expect(() => jsonSet(runSteps.output, ['a', 'b'], 1)).toThrow(/single-segment/)
+  })
+
+  it('still refuses an aliased non-JSON column', () => {
+    // The alias must not become a way to smuggle a bad column past the guard.
+    expect(() => jsonExtractText(alias(runs, 'r').status, ['x'])).toThrow(/status/)
   })
 
   it('leaves a jsonb column uncast for every other helper', () => {

--- a/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
@@ -23,13 +23,19 @@
  * exactly why it went unnoticed.
  */
 import { PgDialect } from 'drizzle-orm/pg-core'
-import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
 import { describe, expect, it, vi } from 'vitest'
 
 // Force the PostgreSQL branch: isPostgresRuntime() reads `isPostgres` off the
 // db/client.js module namespace (see db/dialect-runtime.ts).
 vi.mock('../../db/client.js', () => ({ isPostgres: true }))
 
+// The REAL tables, not local look-alikes. The defect is a mismatch between how
+// a column is declared and what the helper assumes, so re-declaring the column
+// here would assert against the test author's belief rather than against the
+// schema the bug lives in — and would keep passing after a schema change that
+// made the cast wrong. Under the mock above, db/schema.js dispatches to the
+// PostgreSQL tables, which is what these queries actually run against.
+import { a2aTasks, runSteps, runs } from '../../db/schema.js'
 import {
   jsonArrayContainsKeyValue,
   jsonExtractNumber,
@@ -37,20 +43,6 @@ import {
   jsonPathIsAbsent,
   jsonSet,
 } from '../json-sql.js'
-
-/**
- * Mirrors the real declarations: `a2a_tasks.data` is plain text holding JSON,
- * while `run_steps.output` is a `mode: 'json'` column that becomes jsonb.
- */
-const a2aTasksLike = sqliteTable('a2a_tasks', {
-  id: text('id').primaryKey(),
-  data: text('data').notNull(),
-})
-
-const runStepsLike = sqliteTable('run_steps', {
-  id: text('id').primaryKey(),
-  output: text('output', { mode: 'json' }).$type<Record<string, unknown>>(),
-})
 
 const dialect = new PgDialect()
 
@@ -60,8 +52,20 @@ function renderPg(fragment: Parameters<PgDialect['sqlToQuery']>[0]): string {
 }
 
 describe('JSON helpers over a plain text column on PostgreSQL', () => {
+  it('pins the schema premise the rest of this file depends on', () => {
+    // Stated explicitly so that changing either declaration fails HERE, with a
+    // reason, rather than silently turning every assertion below into a
+    // tautology about a column that no longer has the shape being tested.
+    // If a2a_tasks.data ever becomes `mode: 'json'`, the cast correctly stops
+    // applying and the expectations below should be deleted, not re-pinned.
+    expect(a2aTasks.data.dataType, 'a2a_tasks.data is a plain text column holding JSON').toBe(
+      'string',
+    )
+    expect(runSteps.output.dataType, 'run_steps.output is a real JSON column').toBe('json')
+  })
+
   it('casts the column to jsonb before extracting text', () => {
-    const rendered = renderPg(jsonExtractText(a2aTasksLike.data, ['scope', 'tenant']))
+    const rendered = renderPg(jsonExtractText(a2aTasks.data, ['scope', 'tenant']))
 
     // Without the cast this is `"a2a_tasks"."data" -> $1 ->> $2`, which
     // PostgreSQL rejects outright with 42883.
@@ -69,13 +73,13 @@ describe('JSON helpers over a plain text column on PostgreSQL', () => {
   })
 
   it('casts before a single-segment text extraction', () => {
-    expect(renderPg(jsonExtractText(a2aTasksLike.data, ['contextId']))).toBe(
+    expect(renderPg(jsonExtractText(a2aTasks.data, ['contextId']))).toBe(
       '("a2a_tasks"."data")::jsonb ->> $1',
     )
   })
 
   it('casts before extracting a number', () => {
-    expect(renderPg(jsonExtractNumber(a2aTasksLike.data, ['persistenceVersion']))).toBe(
+    expect(renderPg(jsonExtractNumber(a2aTasks.data, ['persistenceVersion']))).toBe(
       '(("a2a_tasks"."data")::jsonb ->> $1)::numeric',
     )
   })
@@ -83,27 +87,27 @@ describe('JSON helpers over a plain text column on PostgreSQL', () => {
   it('casts every parent segment chain from the same cast root', () => {
     // The cast applies once, at the column, and the `->` chain then walks the
     // resulting jsonb — not one cast per segment.
-    const rendered = renderPg(jsonExtractText(a2aTasksLike.data, ['task', 'status', 'state']))
+    const rendered = renderPg(jsonExtractText(a2aTasks.data, ['task', 'status', 'state']))
     expect(rendered).toBe('("a2a_tasks"."data")::jsonb -> $1 -> $2 ->> $3')
     expect(rendered.match(/::jsonb/g)).toHaveLength(1)
   })
 
   it('casts before an array containment probe', () => {
     const rendered = renderPg(
-      jsonArrayContainsKeyValue(a2aTasksLike.data, ['chain'], 'providerId', 'prv_1'),
+      jsonArrayContainsKeyValue(a2aTasks.data, ['chain'], 'providerId', 'prv_1'),
     )
     expect(rendered).toContain('("a2a_tasks"."data")::jsonb')
     expect(rendered).toContain('@>')
   })
 
   it('casts before a key-presence check', () => {
-    const rendered = renderPg(jsonPathIsAbsent(a2aTasksLike.data, ['usage']))
+    const rendered = renderPg(jsonPathIsAbsent(a2aTasks.data, ['usage']))
     // `?` is a jsonb operator too, so the same cast is required.
     expect(rendered).toContain('("a2a_tasks"."data")::jsonb')
   })
 
   it('casts before jsonb_set', () => {
-    const rendered = renderPg(jsonSet(a2aTasksLike.data, ['scope'], { tenant: 't' }))
+    const rendered = renderPg(jsonSet(a2aTasks.data, ['scope'], { tenant: 't' }))
     expect(rendered).toContain('("a2a_tasks"."data")::jsonb')
     expect(rendered).toContain('jsonb_set')
   })
@@ -111,21 +115,35 @@ describe('JSON helpers over a plain text column on PostgreSQL', () => {
   it('leaves a real jsonb column uncast, so no redundant work is added', () => {
     // The cast must be driven by the column's declared type, not applied
     // blanket-fashion: every other call site already passes a jsonb column.
-    const rendered = renderPg(jsonExtractText(runStepsLike.output, ['usage', 'inputTokens']))
+    const rendered = renderPg(jsonExtractText(runSteps.output, ['usage', 'inputTokens']))
 
     expect(rendered).toBe('"run_steps"."output" -> $1 ->> $2')
     expect(rendered).not.toContain('::jsonb')
   })
 
+  it('refuses a column that holds no JSON at all, instead of casting it blindly', () => {
+    // `runs.status` is a plain text status string. Casting it would produce
+    // valid-looking SQL that plans fine and then fails per-row with 22P02 —
+    // or, on an empty table, silently matches nothing. Failing at query-build
+    // time keeps that mistake loud and names the column.
+    expect(() => jsonExtractText(runs.status, ['anything'])).toThrow(/runs\.status/)
+    expect(() => jsonExtractText(runs.status, ['anything'])).toThrow(/mode:'json'/)
+  })
+
+  it('refuses non-JSON columns through every helper, not just the read path', () => {
+    expect(() => jsonExtractNumber(runs.status, ['n'])).toThrow(/runs\.status/)
+    expect(() => jsonPathIsAbsent(runs.status, ['k'])).toThrow(/runs\.status/)
+    expect(() => jsonSet(runs.status, ['k'], 1)).toThrow(/runs\.status/)
+    expect(() => jsonArrayContainsKeyValue(runs.status, ['a'], 'k', 'v')).toThrow(/runs\.status/)
+  })
+
   it('leaves a jsonb column uncast for every other helper', () => {
-    expect(renderPg(jsonExtractNumber(runStepsLike.output, ['usage', 'n']))).not.toContain(
-      '::jsonb',
-    )
-    expect(renderPg(jsonPathIsAbsent(runStepsLike.output, ['usage']))).not.toContain(
+    expect(renderPg(jsonExtractNumber(runSteps.output, ['usage', 'n']))).not.toContain('::jsonb')
+    expect(renderPg(jsonPathIsAbsent(runSteps.output, ['usage']))).not.toContain(
       '"run_steps"."output")::jsonb',
     )
-    expect(
-      renderPg(jsonArrayContainsKeyValue(runStepsLike.output, ['chain'], 'k', 'v')),
-    ).not.toContain('"run_steps"."output")::jsonb')
+    expect(renderPg(jsonArrayContainsKeyValue(runSteps.output, ['chain'], 'k', 'v'))).not.toContain(
+      '"run_steps"."output")::jsonb',
+    )
   })
 })

--- a/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
@@ -161,6 +161,18 @@ describe('JSON helpers over a plain text column on PostgreSQL', () => {
     expect(() => jsonSet(runSteps.output, ['a', 'b'], 1)).toThrow(/single-segment/)
   })
 
+  it('binds the jsonSet segment instead of building a path literal', () => {
+    // A key containing a comma is the case a `'{a,b}'` string literal gets
+    // wrong: PostgreSQL parses it as the nested path a->b and (verified on 14)
+    // returns `{}` unchanged, while SQLite writes the single key "a,b". Binding
+    // a one-element ARRAY makes the segment a parameter, so the value can no
+    // longer be reinterpreted as path structure.
+    const rendered = renderPg(jsonSet(runSteps.output, ['a,b'], 1))
+
+    expect(rendered).toContain('ARRAY[')
+    expect(rendered).not.toContain("'{a,b}'")
+  })
+
   it('still refuses an aliased non-JSON column', () => {
     // The alias must not become a way to smuggle a bad column past the guard.
     expect(() => jsonExtractText(alias(runs, 'r').status, ['x'])).toThrow(/status/)

--- a/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
@@ -1,0 +1,131 @@
+/**
+ * PostgreSQL-branch regression: JSON helpers applied to a **plain text** column.
+ *
+ * The helpers were written on the assumption that every JSON-queried column is
+ * declared `text(..., { mode: 'json' })`, which `db/schema-transform.ts` maps to
+ * `jsonb` on PostgreSQL — so the emitted `->` / `->>` / `?` / `@>` operators
+ * always had a jsonb left-hand side.
+ *
+ * `a2a_tasks.data` breaks that assumption. It stores a JSON envelope but is
+ * declared as plain `text`, because `a2a/sqlite-task-store.ts` serialises and
+ * parses it by hand (`encodeTask` returns a string; `JSON.parse(row.data)`
+ * reads one back) rather than letting drizzle do it. The transform keys off
+ * `mode: 'json'` alone, so the column stays `text` on PostgreSQL while
+ * `SqliteTaskStore.list()` builds `data -> 'scope' ->> 'tenant'` over it.
+ *
+ * PostgreSQL defines `->` / `->>` only for json/jsonb, so that is not a
+ * degradation but a hard `42883 operator does not exist: text -> unknown` —
+ * every A2A `tasks/list` call fails on a PostgreSQL deployment.
+ *
+ * The fix casts a non-JSON column to jsonb inside the PostgreSQL branch. These
+ * assertions are on rendered SQL because catching it at runtime needs a live
+ * PostgreSQL server plus a request reaching that specific query — which is
+ * exactly why it went unnoticed.
+ */
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { describe, expect, it, vi } from 'vitest'
+
+// Force the PostgreSQL branch: isPostgresRuntime() reads `isPostgres` off the
+// db/client.js module namespace (see db/dialect-runtime.ts).
+vi.mock('../../db/client.js', () => ({ isPostgres: true }))
+
+import {
+  jsonArrayContainsKeyValue,
+  jsonExtractNumber,
+  jsonExtractText,
+  jsonPathIsAbsent,
+  jsonSet,
+} from '../json-sql.js'
+
+/**
+ * Mirrors the real declarations: `a2a_tasks.data` is plain text holding JSON,
+ * while `run_steps.output` is a `mode: 'json'` column that becomes jsonb.
+ */
+const a2aTasksLike = sqliteTable('a2a_tasks', {
+  id: text('id').primaryKey(),
+  data: text('data').notNull(),
+})
+
+const runStepsLike = sqliteTable('run_steps', {
+  id: text('id').primaryKey(),
+  output: text('output', { mode: 'json' }).$type<Record<string, unknown>>(),
+})
+
+const dialect = new PgDialect()
+
+/** Render a drizzle fragment to the SQL text PostgreSQL would actually receive. */
+function renderPg(fragment: Parameters<PgDialect['sqlToQuery']>[0]): string {
+  return dialect.sqlToQuery(fragment).sql
+}
+
+describe('JSON helpers over a plain text column on PostgreSQL', () => {
+  it('casts the column to jsonb before extracting text', () => {
+    const rendered = renderPg(jsonExtractText(a2aTasksLike.data, ['scope', 'tenant']))
+
+    // Without the cast this is `"a2a_tasks"."data" -> $1 ->> $2`, which
+    // PostgreSQL rejects outright with 42883.
+    expect(rendered).toBe('("a2a_tasks"."data")::jsonb -> $1 ->> $2')
+  })
+
+  it('casts before a single-segment text extraction', () => {
+    expect(renderPg(jsonExtractText(a2aTasksLike.data, ['contextId']))).toBe(
+      '("a2a_tasks"."data")::jsonb ->> $1',
+    )
+  })
+
+  it('casts before extracting a number', () => {
+    expect(renderPg(jsonExtractNumber(a2aTasksLike.data, ['persistenceVersion']))).toBe(
+      '(("a2a_tasks"."data")::jsonb ->> $1)::numeric',
+    )
+  })
+
+  it('casts every parent segment chain from the same cast root', () => {
+    // The cast applies once, at the column, and the `->` chain then walks the
+    // resulting jsonb — not one cast per segment.
+    const rendered = renderPg(jsonExtractText(a2aTasksLike.data, ['task', 'status', 'state']))
+    expect(rendered).toBe('("a2a_tasks"."data")::jsonb -> $1 -> $2 ->> $3')
+    expect(rendered.match(/::jsonb/g)).toHaveLength(1)
+  })
+
+  it('casts before an array containment probe', () => {
+    const rendered = renderPg(
+      jsonArrayContainsKeyValue(a2aTasksLike.data, ['chain'], 'providerId', 'prv_1'),
+    )
+    expect(rendered).toContain('("a2a_tasks"."data")::jsonb')
+    expect(rendered).toContain('@>')
+  })
+
+  it('casts before a key-presence check', () => {
+    const rendered = renderPg(jsonPathIsAbsent(a2aTasksLike.data, ['usage']))
+    // `?` is a jsonb operator too, so the same cast is required.
+    expect(rendered).toContain('("a2a_tasks"."data")::jsonb')
+  })
+
+  it('casts before jsonb_set', () => {
+    const rendered = renderPg(jsonSet(a2aTasksLike.data, ['scope'], { tenant: 't' }))
+    expect(rendered).toContain('("a2a_tasks"."data")::jsonb')
+    expect(rendered).toContain('jsonb_set')
+  })
+
+  it('leaves a real jsonb column uncast, so no redundant work is added', () => {
+    // The cast must be driven by the column's declared type, not applied
+    // blanket-fashion: every other call site already passes a jsonb column.
+    const rendered = renderPg(jsonExtractText(runStepsLike.output, ['usage', 'inputTokens']))
+
+    expect(rendered).toBe('"run_steps"."output" -> $1 ->> $2')
+    expect(rendered).not.toContain('::jsonb')
+  })
+
+  it('leaves a jsonb column uncast for every other helper', () => {
+    expect(renderPg(jsonExtractNumber(runStepsLike.output, ['usage', 'n']))).not.toContain(
+      '::jsonb',
+    )
+    expect(renderPg(jsonPathIsAbsent(runStepsLike.output, ['usage']))).not.toContain(
+      '"run_steps"."output")::jsonb',
+    )
+    expect(
+      renderPg(jsonArrayContainsKeyValue(runStepsLike.output, ['chain'], 'k', 'v')),
+    ).not.toContain('"run_steps"."output")::jsonb')
+  })
+})

--- a/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-pg-text-column.test.ts
@@ -52,6 +52,18 @@ function renderPg(fragment: Parameters<PgDialect['sqlToQuery']>[0]): string {
   return dialect.sqlToQuery(fragment).sql
 }
 
+/**
+ * The bound parameters alongside the SQL.
+ *
+ * Asserting the SQL alone cannot distinguish two paths that differ only in
+ * their values: `['scope','tenant']` and `['scope','scope']` both render as
+ * `... -> $1 ->> $2`. Anything claiming a *particular* segment reached the
+ * query has to check here, or it is only testing the shape.
+ */
+function renderPgParams(fragment: Parameters<PgDialect['sqlToQuery']>[0]): unknown[] {
+  return dialect.sqlToQuery(fragment).params
+}
+
 describe('JSON helpers over a plain text column on PostgreSQL', () => {
   it('pins the schema premise the rest of this file depends on', () => {
     // Stated explicitly so that changing either declaration fails HERE, with a
@@ -162,15 +174,24 @@ describe('JSON helpers over a plain text column on PostgreSQL', () => {
   })
 
   it('binds the jsonSet segment instead of building a path literal', () => {
-    // A key containing a comma is the case a `'{a,b}'` string literal gets
-    // wrong: PostgreSQL parses it as the nested path a->b and (verified on 14)
-    // returns `{}` unchanged, while SQLite writes the single key "a,b". Binding
-    // a one-element ARRAY makes the segment a parameter, so the value can no
-    // longer be reinterpreted as path structure.
-    const rendered = renderPg(jsonSet(runSteps.output, ['a,b'], 1))
+    // A `'{seg}'` text literal makes the segment's content structural. Binding
+    // a one-element ARRAY keeps it a value.
+    const fragment = jsonSet(runSteps.output, ['usage'], 1)
 
-    expect(rendered).toContain('ARRAY[')
-    expect(rendered).not.toContain("'{a,b}'")
+    expect(renderPg(fragment)).toContain('ARRAY[$1]')
+    expect(renderPg(fragment)).not.toContain("'{usage}'")
+    // The SQL text alone cannot show *which* segment was bound — `ARRAY[$1]`
+    // renders identically for every key — so assert the parameter itself.
+    expect(renderPgParams(fragment)[0]).toBe('usage')
+  })
+
+  it('binds each extraction segment as a parameter, not into the SQL text', () => {
+    // Guards the same blind spot on the read path: two different paths render
+    // to identical SQL, so only the params distinguish them.
+    const fragment = jsonExtractText(a2aTasks.data, ['scope', 'tenant'])
+
+    expect(renderPgParams(fragment)).toEqual(['scope', 'tenant'])
+    expect(renderPg(fragment)).not.toContain('tenant')
   })
 
   it('still refuses an aliased non-JSON column', () => {

--- a/apps/api/src/lib/__tests__/json-sql.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql.test.ts
@@ -32,6 +32,40 @@ function makeDb() {
   return { db: drizzle(sqlite, { schema: { rows } }), sqlite }
 }
 
+/**
+ * The column-type invariant holds on SQLite too — the point of enforcing it in
+ * the helper rather than only in the static call-site analyzer.
+ *
+ * It used to live inside `pgJsonSource`, behind `isPostgresRuntime()`. On the
+ * default backend `json_extract` on a non-JSON column returns NULL instead of
+ * raising, so the mistake was invisible exactly where most development happens,
+ * and only a static analyzer stood between it and production. Static analysis of
+ * a JS call site is leaky by nature (aliasing, destructuring, dynamic import),
+ * which is why that analyzer needed six review rounds; the function itself sees
+ * every call however it was spelled.
+ */
+describe('a non-JSON column is rejected on SQLite, not just on PostgreSQL', () => {
+  it('throws for a column that holds no JSON, naming the column', () => {
+    expect(() => jsonExtractText(rows.n, ['anything'])).toThrow(/rows\.n/)
+    expect(() => jsonExtractNumber(rows.n, ['anything'])).toThrow(
+      /neither a mode:'json' column nor a known plain-text JSON column/,
+    )
+  })
+
+  it('still accepts a mode:json column', () => {
+    expect(() => jsonExtractText(rows.output, ['usage'])).not.toThrow()
+  })
+
+  it('ignores a value that is not a drizzle column, so schema mocks still work', () => {
+    // routes/__tests__/internal-admin.test.ts substitutes a table of plain
+    // strings for the schema. Such a stub carries no dataType to judge, so there
+    // is no defect to report — failing here would break that suite over the
+    // mock's shape. The static call-site analyzer covers those sites instead.
+    const notAColumn = 'runs.result' as unknown as typeof rows.output
+    expect(() => jsonExtractNumber(notAColumn, ['durationMs'])).not.toThrow()
+  })
+})
+
 describe('jsonExtractNumber on SQLite', () => {
   it('reads a nested numeric path', async () => {
     const { db, sqlite } = makeDb()

--- a/apps/api/src/lib/__tests__/zz-probe.test.ts
+++ b/apps/api/src/lib/__tests__/zz-probe.test.ts
@@ -1,0 +1,28 @@
+import { getTableName } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/sqlite-core'
+import { describe, expect, it } from 'vitest'
+import { a2aTasks, runSteps, runs } from '../../db/schema.sqlite.js'
+
+describe('alias probe', () => {
+  it('reports original name', () => {
+    const a = alias(a2aTasks, 'task_alias')
+    console.log('getTableName(alias)=', getTableName(a))
+    console.log(
+      'OriginalName on table=',
+      (a as unknown as Record<symbol, unknown>)[Symbol.for('drizzle:OriginalName')],
+    )
+    console.log(
+      'OriginalName on col.table=',
+      (a.data.table as unknown as Record<symbol, unknown>)[Symbol.for('drizzle:OriginalName')],
+    )
+    console.log(
+      'non-alias a2aTasks OriginalName=',
+      (a2aTasks as unknown as Record<symbol, unknown>)[Symbol.for('drizzle:OriginalName')],
+    )
+    console.log('runs.result dataType=', runs.result.dataType, 'name=', runs.result.name)
+    console.log('a2aTasks.data dataType=', a2aTasks.data.dataType, 'name=', a2aTasks.data.name)
+    console.log('runSteps.output dataType=', runSteps.output.dataType)
+    console.log('syms=', Object.getOwnPropertySymbols(a).map(String))
+    expect(1).toBe(1)
+  })
+})

--- a/apps/api/src/lib/json-sql.ts
+++ b/apps/api/src/lib/json-sql.ts
@@ -22,6 +22,23 @@ import { isPostgresRuntime } from '../db/dialect-runtime.js'
 type JsonPath = readonly [string, ...string[]]
 
 /**
+ * The PostgreSQL operators below (`->`, `->>`, `?`, `@>`, `jsonb_set`) are
+ * defined for json/jsonb only. Columns declared `text(..., { mode: 'json' })`
+ * become `jsonb` via db/schema-transform.ts and need nothing extra — but a
+ * column holding JSON while declared as plain `text` does, or PostgreSQL fails
+ * the statement outright with `42883 operator does not exist: text -> unknown`.
+ *
+ * `a2a_tasks.data` is that column: a2a/sqlite-task-store.ts serialises and
+ * parses the envelope by hand instead of through drizzle, so it is plain text
+ * on both dialects while `list()` still filters on `scope`/`task` paths inside
+ * it. Keying the cast off the column's declared `dataType` fixes that without
+ * adding a redundant cast to the jsonb columns every other call site passes.
+ */
+function pgJsonSource(column: SQLiteColumn): SQL {
+  return column.dataType === 'json' ? sql`${column}` : sql`(${column})::jsonb`
+}
+
+/**
  * Build the PostgreSQL accessor chain: every segment but the last uses `->`
  * (which yields jsonb, so it can be chained), and the final one uses `->>`
  * (which yields text, so it can be cast or compared).
@@ -29,7 +46,7 @@ type JsonPath = readonly [string, ...string[]]
 function pgAccessor(column: SQLiteColumn, path: JsonPath): SQL {
   const parents = path.slice(0, -1)
   const leaf = path[path.length - 1]
-  let expr = sql`${column}`
+  let expr = pgJsonSource(column)
   for (const segment of parents) {
     expr = sql`${expr} -> ${segment}`
   }
@@ -81,7 +98,7 @@ export function jsonArrayContainsKeyValue(
   value: string,
 ): SQL {
   if (isPostgresRuntime()) {
-    let target = sql`${column}`
+    let target = pgJsonSource(column)
     for (const segment of arrayPath) {
       target = sql`${target} -> ${segment}`
     }
@@ -105,7 +122,7 @@ export function jsonArrayContainsKeyValue(
 export function jsonSet(column: SQLiteColumn, path: JsonPath, value: unknown): SQL {
   const serialized = JSON.stringify(value)
   if (isPostgresRuntime()) {
-    return sql`jsonb_set(COALESCE(${column}, '{}'::jsonb), ${`{${path.join(',')}}`}, ${serialized}::jsonb, true)`
+    return sql`jsonb_set(COALESCE(${pgJsonSource(column)}, '{}'::jsonb), ${`{${path.join(',')}}`}, ${serialized}::jsonb, true)`
   }
   return sql`json_set(COALESCE(${column}, '{}'), ${sqlitePath(path)}, json(${serialized}))`
 }
@@ -120,7 +137,7 @@ export function jsonSet(column: SQLiteColumn, path: JsonPath, value: unknown): S
 export function jsonPathIsAbsent(column: SQLiteColumn, path: JsonPath): SQL {
   if (isPostgresRuntime()) {
     const leaf = path[path.length - 1]
-    let parent = sql`${column}`
+    let parent = pgJsonSource(column)
     for (const segment of path.slice(0, -1)) {
       parent = sql`${parent} -> ${segment}`
     }

--- a/apps/api/src/lib/json-sql.ts
+++ b/apps/api/src/lib/json-sql.ts
@@ -49,14 +49,20 @@ type JsonPath = readonly [string, ...string[]]
  *   contains '['   `$.a[0]` indexes an array    (PG: the literal key "a[0]")
  *   leading '"'    `$."ab`  "bad JSON path"     (PG: the literal key '"ab')
  *   empty          `$.`     "bad JSON path"     (PG: the empty key)
- *   contains NUL   `$.a\0b` reads the key "a"   (PG: the literal key "a\0b")
+ *   contains NUL   `$.a\0b` reads the key "a"   (PG: cannot represent the key)
  *
  * The NUL case is the quietest of the five and the only one that returns a
  * *wrong row* rather than an error. SQLite's path is a C string, so it truncates
  * at the first NUL: verified against the bundled better-sqlite3, `$.a\0b` on
- * `{"a":1,"a\0b":3}` returns `1` — the value of a different key — while
- * PostgreSQL binds the whole segment and reads `3`. A trailing NUL degrades the
- * same way (`ab\0` reads `ab`), and a leading one throws "bad JSON path".
+ * `{"a":1,"a\0b":3}` returns `1` — the value of a different key. A trailing NUL
+ * degrades the same way (`ab\0` reads `ab`), and a leading one throws.
+ *
+ * PostgreSQL does not read that key either: jsonb stores unescaped text, and
+ * a NUL has no text representation, so a key containing one fails to cast with
+ * `22P05 unsupported Unicode escape sequence` (verified on PostgreSQL 14).
+ * Rejecting the segment is therefore right on both backends — an earlier
+ * revision of this comment claimed PostgreSQL bound it as a literal key, which
+ * is wrong.
  *
  * Everything else — commas, spaces, unicode, leading digits, hyphens, colons,
  * `$`, `#`, `]`, backslashes, interior or trailing quotes — round-trips as the

--- a/apps/api/src/lib/json-sql.ts
+++ b/apps/api/src/lib/json-sql.ts
@@ -49,6 +49,14 @@ type JsonPath = readonly [string, ...string[]]
  *   contains '['   `$.a[0]` indexes an array    (PG: the literal key "a[0]")
  *   leading '"'    `$."ab`  "bad JSON path"     (PG: the literal key '"ab')
  *   empty          `$.`     "bad JSON path"     (PG: the empty key)
+ *   contains NUL   `$.a\0b` reads the key "a"   (PG: the literal key "a\0b")
+ *
+ * The NUL case is the quietest of the five and the only one that returns a
+ * *wrong row* rather than an error. SQLite's path is a C string, so it truncates
+ * at the first NUL: verified against the bundled better-sqlite3, `$.a\0b` on
+ * `{"a":1,"a\0b":3}` returns `1` — the value of a different key — while
+ * PostgreSQL binds the whole segment and reads `3`. A trailing NUL degrades the
+ * same way (`ab\0` reads `ab`), and a leading one throws "bad JSON path".
  *
  * Everything else — commas, spaces, unicode, leading digits, hyphens, colons,
  * `$`, `#`, `]`, backslashes, interior or trailing quotes — round-trips as the
@@ -61,6 +69,7 @@ function isDialectDivergentSegment(segment: string): boolean {
     segment.length === 0 ||
     segment.includes('.') ||
     segment.includes('[') ||
+    segment.includes('\0') ||
     segment.startsWith('"')
   )
 }
@@ -69,7 +78,7 @@ function assertSafePath(path: readonly string[], helper: string): void {
   for (const segment of path) {
     if (isDialectDivergentSegment(segment)) {
       throw new Error(
-        `json-sql: ${helper} received the path segment ${JSON.stringify(segment)}, which SQLite reads as path syntax ('.'/'[' descend, a leading '"' opens a quoted label, an empty label is invalid) while PostgreSQL binds it as a literal key — the two backends would address different data.`,
+        `json-sql: ${helper} received the path segment ${JSON.stringify(segment)}, which SQLite reads as path syntax ('.'/'[' descend, a leading '"' opens a quoted label, a NUL truncates the key, an empty label is invalid) while PostgreSQL binds it as a literal key — the two backends would address different data.`,
       )
     }
   }
@@ -134,26 +143,57 @@ function physicalTableName(column: SQLiteColumn): string {
 }
 
 /**
- * The PostgreSQL operators used below (`->`, `->>`, `?`, `@>`, `jsonb_set`) are
- * defined for json/jsonb only. A `mode: 'json'` column is already `jsonb` via
+ * Reject a column that does not hold JSON — on **both** dialects.
+ *
+ * This check is dialect-independent on purpose. It used to live only inside
+ * `pgJsonSource`, i.e. behind `isPostgresRuntime()`, which made the invariant
+ * true on PostgreSQL and merely *hoped for* on SQLite: `json_extract` on a
+ * non-JSON column returns NULL instead of raising, so a developer running the
+ * default backend saw a silently empty result and shipped it.
+ *
+ * Closing that gap in the compiler was what the call-site analyzer existed for,
+ * and why it needed six rounds of review — a static checker has to recognise
+ * every syntactic route to a call, while the function itself sees every call by
+ * construction. Enforcing it here makes the analyzer a second line of defence
+ * (it reports the mistake at `pnpm test` rather than at query-build time)
+ * instead of the only one.
+ *
+ * A value that is not a drizzle column carries no `dataType` to judge, so there
+ * is nothing to validate and it passes. That is what unit tests substituting a
+ * table of plain strings for the schema (routes/__tests__/internal-admin.test.ts)
+ * pass in; rejecting those would fail the suite over the *mock's* shape rather
+ * than over a real defect. Those call sites are not left unchecked — the
+ * call-site analyzer resolves them against the true schema, which is precisely
+ * the split of duties: the runtime guard catches what reaches it, the analyzer
+ * catches what the types say.
+ */
+function assertJsonBearingColumn(column: SQLiteColumn, helper: string): void {
+  if (typeof column?.dataType !== 'string') return
+  if (column.dataType === 'json') return
+  if (PLAIN_TEXT_JSON_COLUMNS.has(`${physicalTableName(column)}.${column.name}`)) return
+
+  throw new Error(
+    `json-sql: ${helper} received ${physicalTableName(column)}.${column.name}, which is neither a mode:'json' column nor a known plain-text JSON column. Declare it as text(..., { mode: 'json' }), or add it to PLAIN_TEXT_JSON_COLUMNS if it holds hand-serialised JSON.`,
+  )
+}
+
+/**
+ * The jsonb left-hand side for the PostgreSQL branch.
+ *
+ * The operators used below (`->`, `->>`, `?`, `@>`, `jsonb_set`) are defined for
+ * json/jsonb only. A `mode: 'json'` column is already `jsonb` via
  * db/schema-transform.ts and needs nothing; a plain-text JSON column must be
  * cast, or the statement dies with `42883 operator does not exist: text ->
  * unknown` — which is exactly how every A2A `tasks/list` call failed on
  * PostgreSQL.
  *
- * Throws for a column that is neither, since that is a call-site error no cast
- * can rescue: it fails at query-build time, in-process and with the column
- * named, rather than reaching the server as a confusing per-row data error.
+ * The cast here is unconditional because `assertJsonBearingColumn` has already
+ * run: anything reaching this point is either jsonb or an allowlisted plain-text
+ * JSON column, so there is no third case left to reject.
  */
 function pgJsonSource(column: SQLiteColumn): SQL {
   if (column.dataType === 'json') return sql`${column}`
-
-  const qualifiedName = `${physicalTableName(column)}.${column.name}`
-  if (PLAIN_TEXT_JSON_COLUMNS.has(qualifiedName)) return sql`(${column})::jsonb`
-
-  throw new Error(
-    `json-sql: ${qualifiedName} is neither a mode:'json' column nor a known plain-text JSON column. Declare it as text(..., { mode: 'json' }), or add it to PLAIN_TEXT_JSON_COLUMNS if it holds hand-serialised JSON.`,
-  )
+  return sql`(${column})::jsonb`
 }
 
 /**
@@ -185,6 +225,7 @@ function sqlitePath(path: JsonPath): string {
  * absent figure as "not recorded" instead of zero.
  */
 export function jsonExtractNumber(column: SQLiteColumn, path: JsonPath): SQL<number | null> {
+  assertJsonBearingColumn(column, 'jsonExtractNumber')
   assertSafePath(path, 'jsonExtractNumber')
   if (isPostgresRuntime()) {
     return sql<number | null>`(${pgAccessor(column, path)})::numeric`
@@ -194,6 +235,7 @@ export function jsonExtractNumber(column: SQLiteColumn, path: JsonPath): SQL<num
 
 /** Extract a JSON value as **text**, for equality comparisons against an id. */
 export function jsonExtractText(column: SQLiteColumn, path: JsonPath): SQL<string | null> {
+  assertJsonBearingColumn(column, 'jsonExtractText')
   assertSafePath(path, 'jsonExtractText')
   if (isPostgresRuntime()) {
     return sql<string | null>`${pgAccessor(column, path)}`
@@ -217,6 +259,7 @@ export function jsonArrayContainsKeyValue(
   elementKey: string,
   value: string,
 ): SQL {
+  assertJsonBearingColumn(column, 'jsonArrayContainsKeyValue')
   assertSafePath(arrayPath, 'jsonArrayContainsKeyValue')
   // `elementKey` is interpolated into SQLite's `$.${elementKey}` path exactly
   // like a segment, so it carries the same ambiguity and gets the same check.
@@ -253,6 +296,7 @@ export function jsonSet(column: SQLiteColumn, path: JsonSetPath, value: unknown)
       `json-sql: jsonSet takes a single-segment path, got [${path.join(', ')}]. PostgreSQL's jsonb_set will not create a missing intermediate parent, so a nested write silently no-ops there while succeeding on SQLite.`,
     )
   }
+  assertJsonBearingColumn(column, 'jsonSet')
   assertSafePath(path, 'jsonSet')
   const serialized = JSON.stringify(value)
   if (isPostgresRuntime()) {
@@ -274,6 +318,7 @@ export function jsonSet(column: SQLiteColumn, path: JsonSetPath, value: unknown)
  * check on the key. Both distinguish "key missing" from "key present but null".
  */
 export function jsonPathIsAbsent(column: SQLiteColumn, path: JsonPath): SQL {
+  assertJsonBearingColumn(column, 'jsonPathIsAbsent')
   assertSafePath(path, 'jsonPathIsAbsent')
   if (isPostgresRuntime()) {
     const leaf = path[path.length - 1]

--- a/apps/api/src/lib/json-sql.ts
+++ b/apps/api/src/lib/json-sql.ts
@@ -35,31 +35,41 @@ import { isPostgresRuntime } from '../db/dialect-runtime.js'
 type JsonPath = readonly [string, ...string[]]
 
 /**
- * Segments must be plain keys, because the two dialects disagree on what a
- * special character inside one *means*.
+ * A segment is rejected only when SQLite would read it as something other than
+ * a literal key — the set is defined by SQLite's path grammar, not by a
+ * conservative allowlist.
  *
- * PostgreSQL takes each segment as a bound parameter, so it is always a literal
- * key. SQLite takes the whole path as one `$.a.b` string, where `.` and `[]`
- * are path syntax. The same single segment therefore addresses two different
- * things — verified against both engines:
+ * PostgreSQL binds every segment as a parameter, so it is always literal. On
+ * SQLite the path arrives as one `$.a.b` string, where an unquoted label runs
+ * until the next `.` or `[`, a *leading* `"` opens a quoted label, and an empty
+ * label is invalid. Exactly four shapes therefore diverge — each verified
+ * against the bundled better-sqlite3:
  *
- *   ['a.b']   PG writes/reads the key "a.b";  SQLite descends into a -> b
- *   ['a[0]']  PG writes/reads the key "a[0]"; SQLite indexes into the array a
- *   ['']      PG accepts the empty key;       SQLite raises "bad JSON path"
+ *   contains '.'   `$.a.b`  descends a -> b     (PG: the literal key "a.b")
+ *   contains '['   `$.a[0]` indexes an array    (PG: the literal key "a[0]")
+ *   leading '"'    `$."ab`  "bad JSON path"     (PG: the literal key '"ab')
+ *   empty          `$.`     "bad JSON path"     (PG: the empty key)
  *
- * Escaping SQLite's path form would close the write side but still leave the
- * two engines' quoting rules to keep in sync forever. Every real segment here
- * is an object key from a TypeScript interface (`usage`, `scope`, `contextId`),
- * so rejecting the ambiguous shapes outright costs nothing today and removes
- * the divergence class rather than tracking it.
+ * Everything else — commas, spaces, unicode, leading digits, hyphens, colons,
+ * `$`, `#`, `]`, backslashes, interior or trailing quotes — round-trips as the
+ * same literal key on both engines, so it is allowed. An earlier revision
+ * rejected all of those too; that mislabelled dialect-consistent keys as
+ * divergent and made the helpers refuse paths both backends agree on.
  */
-const SAFE_SEGMENT = /^[A-Za-z_][A-Za-z0-9_]*$/
+function isDialectDivergentSegment(segment: string): boolean {
+  return (
+    segment.length === 0 ||
+    segment.includes('.') ||
+    segment.includes('[') ||
+    segment.startsWith('"')
+  )
+}
 
 function assertSafePath(path: readonly string[], helper: string): void {
   for (const segment of path) {
-    if (!SAFE_SEGMENT.test(segment)) {
+    if (isDialectDivergentSegment(segment)) {
       throw new Error(
-        `json-sql: ${helper} received the path segment ${JSON.stringify(segment)}, which is not a plain key. SQLite reads '.' and '[]' as path syntax while PostgreSQL binds the segment literally, so the two backends would address different data. Use a segment matching ${SAFE_SEGMENT}.`,
+        `json-sql: ${helper} received the path segment ${JSON.stringify(segment)}, which SQLite reads as path syntax ('.'/'[' descend, a leading '"' opens a quoted label, an empty label is invalid) while PostgreSQL binds it as a literal key — the two backends would address different data.`,
       )
     }
   }

--- a/apps/api/src/lib/json-sql.ts
+++ b/apps/api/src/lib/json-sql.ts
@@ -208,7 +208,12 @@ export function jsonSet(column: SQLiteColumn, path: JsonSetPath, value: unknown)
   }
   const serialized = JSON.stringify(value)
   if (isPostgresRuntime()) {
-    return sql`jsonb_set(COALESCE(${pgJsonSource(column)}, '{}'::jsonb), ${`{${path.join(',')}}`}, ${serialized}::jsonb, true)`
+    // `ARRAY[$n]`, not a `'{seg}'` literal. Building the path as text makes the
+    // segment's *content* structural: a key containing a comma — `['a,b']` —
+    // parses as the nested path a->b, which jsonb_set then no-ops on because
+    // `a` is absent (verified on PostgreSQL 14), while SQLite writes the single
+    // key "a,b". Binding a one-element array keeps the segment a value.
+    return sql`jsonb_set(COALESCE(${pgJsonSource(column)}, '{}'::jsonb), ARRAY[${path[0]}], ${serialized}::jsonb, true)`
   }
   return sql`json_set(COALESCE(${column}, '{}'), ${sqlitePath(path)}, json(${serialized}))`
 }

--- a/apps/api/src/lib/json-sql.ts
+++ b/apps/api/src/lib/json-sql.ts
@@ -1,4 +1,4 @@
-import { type SQL, sql } from 'drizzle-orm'
+import { type SQL, getTableName, sql } from 'drizzle-orm'
 import type { SQLiteColumn } from 'drizzle-orm/sqlite-core'
 import { isPostgresRuntime } from '../db/dialect-runtime.js'
 
@@ -10,9 +10,22 @@ import { isPostgresRuntime } from '../db/dialect-runtime.js'
  * Every JSON-reading query therefore has to be built through these helpers
  * rather than written inline, or it silently works on one backend only.
  *
- * A note on storage: these columns are `text` under SQLite but `jsonb` under
- * PostgreSQL (see db/schema-transform.ts). The PostgreSQL operators below are
- * the jsonb ones, which is exactly why that mapping was chosen.
+ * A note on storage: a column declared `text(..., { mode: 'json' })` is `text`
+ * under SQLite and `jsonb` under PostgreSQL (see db/schema-transform.ts). The
+ * PostgreSQL operators below are the jsonb ones, which is exactly why that
+ * mapping was chosen.
+ *
+ * That mapping keys off `mode: 'json'` and nothing else, so it is **not** true
+ * that every JSON-holding column is jsonb on PostgreSQL. A column whose JSON is
+ * serialised by hand is declared plain `text` and stays `text` on both dialects
+ * — `a2a_tasks.data` is exactly that (a2a/sqlite-task-store.ts does its own
+ * JSON.stringify/JSON.parse). Assuming otherwise is what made `tasks/list` fail
+ * with `42883 operator does not exist: text -> unknown` on every PostgreSQL
+ * deployment. The helpers below handle it via `pgJsonSource`; an inline
+ * `->`/`->>` written at a call site would not, and no gate catches that
+ * (no-raw-sqlite-json-sql.test.ts scans for the SQLite-only functions only).
+ * So: route JSON access through these helpers, and do not assume the column
+ * arrived as jsonb.
  *
  * All operators used here predate PostgreSQL 9.6 (`->`/`->>` arrived in 9.3),
  * so nothing here breaks the supported floor.
@@ -22,20 +35,50 @@ import { isPostgresRuntime } from '../db/dialect-runtime.js'
 type JsonPath = readonly [string, ...string[]]
 
 /**
- * The PostgreSQL operators below (`->`, `->>`, `?`, `@>`, `jsonb_set`) are
- * defined for json/jsonb only. Columns declared `text(..., { mode: 'json' })`
- * become `jsonb` via db/schema-transform.ts and need nothing extra — but a
- * column holding JSON while declared as plain `text` does, or PostgreSQL fails
- * the statement outright with `42883 operator does not exist: text -> unknown`.
+ * Plain-text columns that legitimately hold JSON, as `table.column`.
  *
- * `a2a_tasks.data` is that column: a2a/sqlite-task-store.ts serialises and
- * parses the envelope by hand instead of through drizzle, so it is plain text
- * on both dialects while `list()` still filters on `scope`/`task` paths inside
- * it. Keying the cast off the column's declared `dataType` fixes that without
- * adding a redundant cast to the jsonb columns every other call site passes.
+ * Deliberately an allowlist rather than "cast anything that is not json". A
+ * blanket cast also swallows the case these helpers should never see — a
+ * genuinely non-JSON column passed by mistake, say `runs.status`. Pre-cast that
+ * failed at PostgreSQL's parse stage with `42883 operator does not exist`,
+ * naming the operator before a single row was read. Cast blindly it instead
+ * plans fine and fails per-row with `22P02 invalid input syntax for type json`,
+ * pointing at the value rather than the mistake — and on an empty table it does
+ * not fail at all, silently returning no rows so a mis-wired predicate reads as
+ * "nothing matched" instead of a bug.
+ *
+ * Naming the columns keeps the loud, early failure for a real mistake while
+ * still fixing the columns that need it.
+ */
+const PLAIN_TEXT_JSON_COLUMNS: ReadonlySet<string> = new Set([
+  // a2a/sqlite-task-store.ts serialises and parses this envelope by hand
+  // (`encodeTask` returns a string, `JSON.parse(row.data)` reads one back)
+  // instead of letting drizzle do it, so it carries no `mode: 'json'` and stays
+  // `text` on both dialects while `list()` filters on paths inside it.
+  'a2a_tasks.data',
+])
+
+/**
+ * The PostgreSQL operators used below (`->`, `->>`, `?`, `@>`, `jsonb_set`) are
+ * defined for json/jsonb only. A `mode: 'json'` column is already `jsonb` via
+ * db/schema-transform.ts and needs nothing; a plain-text JSON column must be
+ * cast, or the statement dies with `42883 operator does not exist: text ->
+ * unknown` — which is exactly how every A2A `tasks/list` call failed on
+ * PostgreSQL.
+ *
+ * Throws for a column that is neither, since that is a call-site error no cast
+ * can rescue: it fails at query-build time, in-process and with the column
+ * named, rather than reaching the server as a confusing per-row data error.
  */
 function pgJsonSource(column: SQLiteColumn): SQL {
-  return column.dataType === 'json' ? sql`${column}` : sql`(${column})::jsonb`
+  if (column.dataType === 'json') return sql`${column}`
+
+  const qualifiedName = `${getTableName(column.table)}.${column.name}`
+  if (PLAIN_TEXT_JSON_COLUMNS.has(qualifiedName)) return sql`(${column})::jsonb`
+
+  throw new Error(
+    `json-sql: ${qualifiedName} is neither a mode:'json' column nor a known plain-text JSON column. Declare it as text(..., { mode: 'json' }), or add it to PLAIN_TEXT_JSON_COLUMNS if it holds hand-serialised JSON.`,
+  )
 }
 
 /**

--- a/apps/api/src/lib/json-sql.ts
+++ b/apps/api/src/lib/json-sql.ts
@@ -35,6 +35,37 @@ import { isPostgresRuntime } from '../db/dialect-runtime.js'
 type JsonPath = readonly [string, ...string[]]
 
 /**
+ * Segments must be plain keys, because the two dialects disagree on what a
+ * special character inside one *means*.
+ *
+ * PostgreSQL takes each segment as a bound parameter, so it is always a literal
+ * key. SQLite takes the whole path as one `$.a.b` string, where `.` and `[]`
+ * are path syntax. The same single segment therefore addresses two different
+ * things — verified against both engines:
+ *
+ *   ['a.b']   PG writes/reads the key "a.b";  SQLite descends into a -> b
+ *   ['a[0]']  PG writes/reads the key "a[0]"; SQLite indexes into the array a
+ *   ['']      PG accepts the empty key;       SQLite raises "bad JSON path"
+ *
+ * Escaping SQLite's path form would close the write side but still leave the
+ * two engines' quoting rules to keep in sync forever. Every real segment here
+ * is an object key from a TypeScript interface (`usage`, `scope`, `contextId`),
+ * so rejecting the ambiguous shapes outright costs nothing today and removes
+ * the divergence class rather than tracking it.
+ */
+const SAFE_SEGMENT = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+function assertSafePath(path: readonly string[], helper: string): void {
+  for (const segment of path) {
+    if (!SAFE_SEGMENT.test(segment)) {
+      throw new Error(
+        `json-sql: ${helper} received the path segment ${JSON.stringify(segment)}, which is not a plain key. SQLite reads '.' and '[]' as path syntax while PostgreSQL binds the segment literally, so the two backends would address different data. Use a segment matching ${SAFE_SEGMENT}.`,
+      )
+    }
+  }
+}
+
+/**
  * `jsonSet` accepts a **single** segment only — the two dialects disagree on
  * anything deeper. Verified on PostgreSQL 14 against SQLite:
  *
@@ -144,6 +175,7 @@ function sqlitePath(path: JsonPath): string {
  * absent figure as "not recorded" instead of zero.
  */
 export function jsonExtractNumber(column: SQLiteColumn, path: JsonPath): SQL<number | null> {
+  assertSafePath(path, 'jsonExtractNumber')
   if (isPostgresRuntime()) {
     return sql<number | null>`(${pgAccessor(column, path)})::numeric`
   }
@@ -152,6 +184,7 @@ export function jsonExtractNumber(column: SQLiteColumn, path: JsonPath): SQL<num
 
 /** Extract a JSON value as **text**, for equality comparisons against an id. */
 export function jsonExtractText(column: SQLiteColumn, path: JsonPath): SQL<string | null> {
+  assertSafePath(path, 'jsonExtractText')
   if (isPostgresRuntime()) {
     return sql<string | null>`${pgAccessor(column, path)}`
   }
@@ -174,6 +207,10 @@ export function jsonArrayContainsKeyValue(
   elementKey: string,
   value: string,
 ): SQL {
+  assertSafePath(arrayPath, 'jsonArrayContainsKeyValue')
+  // `elementKey` is interpolated into SQLite's `$.${elementKey}` path exactly
+  // like a segment, so it carries the same ambiguity and gets the same check.
+  assertSafePath([elementKey], 'jsonArrayContainsKeyValue')
   if (isPostgresRuntime()) {
     let target = pgJsonSource(column)
     for (const segment of arrayPath) {
@@ -206,6 +243,7 @@ export function jsonSet(column: SQLiteColumn, path: JsonSetPath, value: unknown)
       `json-sql: jsonSet takes a single-segment path, got [${path.join(', ')}]. PostgreSQL's jsonb_set will not create a missing intermediate parent, so a nested write silently no-ops there while succeeding on SQLite.`,
     )
   }
+  assertSafePath(path, 'jsonSet')
   const serialized = JSON.stringify(value)
   if (isPostgresRuntime()) {
     // `ARRAY[$n]`, not a `'{seg}'` literal. Building the path as text makes the
@@ -226,6 +264,7 @@ export function jsonSet(column: SQLiteColumn, path: JsonSetPath, value: unknown)
  * check on the key. Both distinguish "key missing" from "key present but null".
  */
 export function jsonPathIsAbsent(column: SQLiteColumn, path: JsonPath): SQL {
+  assertSafePath(path, 'jsonPathIsAbsent')
   if (isPostgresRuntime()) {
     const leaf = path[path.length - 1]
     let parent = pgJsonSource(column)

--- a/apps/api/src/lib/json-sql.ts
+++ b/apps/api/src/lib/json-sql.ts
@@ -35,6 +35,21 @@ import { isPostgresRuntime } from '../db/dialect-runtime.js'
 type JsonPath = readonly [string, ...string[]]
 
 /**
+ * `jsonSet` accepts a **single** segment only — the two dialects disagree on
+ * anything deeper. Verified on PostgreSQL 14 against SQLite:
+ *
+ *   PG      jsonb_set('{}', '{a,b}', '1', true)  ->  {}
+ *   SQLite  json_set('{}', '$.a.b', json('1'))   ->  {"a":{"b":1}}
+ *
+ * `jsonb_set` refuses to create a missing intermediate parent and returns the
+ * document untouched, so a nested write would silently no-op on PostgreSQL
+ * while succeeding on SQLite — the same "works on the backend you run locally"
+ * trap this module exists to close. Narrowing the type makes the divergence
+ * unreachable rather than merely documented.
+ */
+type JsonSetPath = readonly [string]
+
+/**
  * Plain-text columns that legitimately hold JSON, as `table.column`.
  *
  * Deliberately an allowlist rather than "cast anything that is not json". A
@@ -59,6 +74,25 @@ const PLAIN_TEXT_JSON_COLUMNS: ReadonlySet<string> = new Set([
 ])
 
 /**
+ * The physical table a column belongs to, seeing through `alias()`.
+ *
+ * `getTableName` reports the *alias* — `alias(a2aTasks, 'task_alias')` yields
+ * `task_alias` — which would miss the allowlist above and reject the very
+ * column it exists to permit. `alias()` is already used in this codebase
+ * (lib/agent-access.ts), so a self-join or subquery over a2a_tasks is a live
+ * shape rather than a hypothetical one. drizzle keeps the underlying name on
+ * the table under a globally-registered symbol; fall back to the alias if a
+ * future version stops populating it, since a wrong-but-present name only
+ * costs a clearer error while a crash here would break query building.
+ */
+function physicalTableName(column: SQLiteColumn): string {
+  const original = (column.table as unknown as Record<symbol, unknown>)[
+    Symbol.for('drizzle:OriginalName')
+  ]
+  return typeof original === 'string' ? original : getTableName(column.table)
+}
+
+/**
  * The PostgreSQL operators used below (`->`, `->>`, `?`, `@>`, `jsonb_set`) are
  * defined for json/jsonb only. A `mode: 'json'` column is already `jsonb` via
  * db/schema-transform.ts and needs nothing; a plain-text JSON column must be
@@ -73,7 +107,7 @@ const PLAIN_TEXT_JSON_COLUMNS: ReadonlySet<string> = new Set([
 function pgJsonSource(column: SQLiteColumn): SQL {
   if (column.dataType === 'json') return sql`${column}`
 
-  const qualifiedName = `${getTableName(column.table)}.${column.name}`
+  const qualifiedName = `${physicalTableName(column)}.${column.name}`
   if (PLAIN_TEXT_JSON_COLUMNS.has(qualifiedName)) return sql`(${column})::jsonb`
 
   throw new Error(
@@ -156,13 +190,22 @@ export function jsonArrayContainsKeyValue(
 }
 
 /**
- * Set a JSON path to `value`, treating a NULL column as an empty object.
+ * Set a top-level JSON key to `value`, treating a NULL column as an empty
+ * object. Single-segment only — see `JsonSetPath` for why anything deeper is a
+ * dialect divergence rather than a feature.
  *
  * `jsonb_set` predates the 9.6 floor (it arrived in 9.5). Both branches take the
  * value as a bound parameter rather than interpolating it, so a string inside
  * the payload cannot terminate the literal.
  */
-export function jsonSet(column: SQLiteColumn, path: JsonPath, value: unknown): SQL {
+export function jsonSet(column: SQLiteColumn, path: JsonSetPath, value: unknown): SQL {
+  // The type already forbids this; the runtime check covers a path built
+  // dynamically (`string[]` widened at a call site), where the compiler cannot.
+  if (path.length !== 1) {
+    throw new Error(
+      `json-sql: jsonSet takes a single-segment path, got [${path.join(', ')}]. PostgreSQL's jsonb_set will not create a missing intermediate parent, so a nested write silently no-ops there while succeeding on SQLite.`,
+    )
+  }
   const serialized = JSON.stringify(value)
   if (isPostgresRuntime()) {
     return sql`jsonb_set(COALESCE(${pgJsonSource(column)}, '{}'::jsonb), ${`{${path.join(',')}}`}, ${serialized}::jsonb, true)`


### PR DESCRIPTION
## Problem

`a2a_tasks.data` holds a JSON envelope but is declared as plain `text`, because `a2a/sqlite-task-store.ts` serialises and parses it by hand (`encodeTask` returns a string, `JSON.parse(row.data)` reads one back) rather than letting drizzle do it.

`db/schema-transform.ts` maps a column to `jsonb` based on `mode: 'json'` and nothing else, so this column stays `text` in the PostgreSQL lineage — while `SqliteTaskStore.list()` still builds `data -> 'scope' ->> 'tenant'` over it.

PostgreSQL defines `->` / `->>` for json/jsonb only, so this does not degrade — it fails the statement outright. **Every A2A `tasks/list` call 500s on a PostgreSQL deployment.** Verified against a real PostgreSQL 14 server:

```
SELECT "data" -> 'scope' ->> 'tenant' FROM a2a_tasks;
  ERROR:  operator does not exist: text -> unknown        ← 42883

SELECT ("data")::jsonb -> 'scope' ->> 'tenant' FROM a2a_tasks;
  acme  (1 row)
```

`a2a_tasks.data` is the only such column today — every other JSON-queried column (`runs.result`, `run_steps.output`, `agents.config`, …) is `mode: 'json'` and unaffected.

## Approach

Cast at the column inside the PostgreSQL branch, keyed off the column's declared type, rather than changing the column to `mode: 'json'`. The latter would make drizzle return a parsed object, rippling through `save`/`load`/`list`/`markTaskFailed` and changing the SQLite storage path too — a large change to the storage layer for a query-layer bug.

The cast is an **allowlist**, not "cast anything non-json". A blanket cast would also swallow a genuinely non-JSON column passed by mistake: pre-cast that failed at parse time with `42883` naming the operator, but cast blindly it plans fine and fails per-row with `22P02` — and on an empty table does not fail at all, silently returning no rows. The guard keeps that mistake loud and names the column at query-build time.

## Why this took many review rounds — and what finally ended it

Six review rounds each found a new way past the static call-site gate: aliased import, local rebind, namespace destructure, type-annotated rebind, quoted ES2022 specifier, then shorthand/computed destructure and `as const` / `satisfies` / concatenated dynamic-import specifiers. Fixing them one at a time was never going to converge.

**Root cause:** the column-type invariant lived inside `pgJsonSource`, i.e. behind `isPostgresRuntime()`. It was therefore enforced on PostgreSQL and merely *hoped for* on SQLite, where `json_extract` on a non-JSON column returns NULL instead of raising. A static analyzer was the only thing standing between that mistake and production **on the default backend** — and static analysis of a JS call site is leaky by nature, because a checker must recognise every syntactic route to a call while the function itself sees every call by construction.

Note the contrast inside the same file: `assertSafePath` was always called unconditionally, and nobody ever found a way past it.

**The fix is structural, not another pattern:**

1. **`assertJsonBearingColumn` runs unconditionally in all five helpers**, on both dialects. No aliasing or destructuring can evade it. A value that is not a drizzle column carries no `dataType` to judge and passes — that is what unit tests substituting a table of plain strings for the schema (`routes/__tests__/internal-admin.test.ts`) pass in.

2. **The analyzer is kept as a second line of defence**, not deleted. A runtime guard only fires on a path that executes, and api coverage is ~82% — a mistyped column on an untested branch would still ship. The analyzer reads code instead of running it.

3. **Its resolution strategy is inverted.** Ask what a binding *is* (`getTypeAtLocation`) rather than which syntax produced it; read string-literal *types* rather than pattern-matching specifier expressions; and **fail closed** when identity cannot be established. Silence previously meant "the analyzer failed", which read identically to "the code is safe".

## Review rounds

Reviewed with `/code-review high` and several `codex` passes; findings were verified against a live PostgreSQL 14 or better-sqlite3 rather than accepted on argument.

| Finding | Resolution |
|---|---|
| Blanket cast degrades error reporting | Allowlist + build-time throw |
| Module header asserted the disproved invariant | Rewritten |
| Tests used local fixtures, not the real schema | Import real tables + premise assertion |
| Runtime guard only fires on PostgreSQL | Added dialect-independent call-site gate |
| Allowlist rejected `alias()`-wrapped tables | Resolve via drizzle's `OriginalName` |
| `jsonSet` multi-segment path diverges by dialect | Type narrowed to single segment + runtime check |
| Call-site gate had false negatives | Detect aliased imports, local rebinds, unresolved args |
| `jsonSet` segment *content* could still carry a comma | Bind `ARRAY[$n]` instead of a `'{seg}'` literal |
| Gate still missed shorthand/computed destructure | **Root-caused:** invariant moved to runtime; analyzer resolves by type identity |
| `as const` / `satisfies` / concatenated specifiers invisible | `staticStringValue` reads literal *types*; unprovable specifier now fails closed |
| Suffix-based exemption passed `` `../lib/${part}.js` `` | Only an interpolation-free absolute-URL/path head is exempt — proving a suffix never proves the module |
| Contextual annotation hid a destructured helper | Third resolution layer: provenance (which object was it destructured from?) |
| Aliased schema table recorded under its local spelling | Record the canonical export name; new test resolves it against the real schema |
| NUL in a path segment silently read a different key | Rejected; covered in leading/middle/trailing positions |
| **NUL in caller task text broke `tasks/list` for a whole scope on PostgreSQL** | Sanitised at the a2a write path |
| A lone surrogate did the same, and arrives far more easily | Same sanitiser, generalised to every jsonb-unrepresentable code point |
| A helper reached through a typed parameter became invisible | Type-identity exclusion narrowed to declarations that assign their own value |
| A mapped-type copy of the namespace evaded the element-access check | Property matched by type, via `getTypeOfSymbol` |
| Assignment-pattern destructure resolved to nothing | Covered by the same provenance path |
| The dynamic-import allowlist was keyed by file, so it could widen silently | Keyed by file **and** specifier text |

### Findings rejected after verification

Two review claims were **disproved on a real server** rather than accepted:

- `jsonSet` "fails with `42804` because pg_cast defines jsonb→text as explicit-only" — that `pg_cast` row does not exist; PostgreSQL falls back to I/O conversion, permitted for assignment to a text target.
- A later pass re-raised the same shape: "`UPDATE ... SET data = jsonSet(...)` fails because PostgreSQL will not assign `jsonb` to `text`". Re-verified on PostgreSQL 14 — the `UPDATE` **succeeds** (`UPDATE 1`) and round-trips correctly (`data::jsonb->>'k'` = the written value). No change made. The only `jsonSet` call site is `runSteps.output` (`mode:'json'` → `jsonb`) in any case; `a2a_tasks.data` is read-only through these helpers.

Two dialect divergences found and closed along the way, both verified on real engines:

```
PG      jsonb_set('{}', '{a,b}', '1', true)  ->  {}            (silent no-op)
SQLite  json_set('{}', '$.a.b', json('1'))   ->  {"a":{"b":1}}

SQLite  json_extract('{"a":1,"a\0b":3}', '$.a\0b')  ->  1      (truncates at NUL,
PG      binds the whole segment                     ->  3       reads a DIFFERENT key)
```

The NUL case was the only divergent shape that returned a **wrong row** rather than an error.

### The last round, and why it mattered

A high-effort multi-agent review of this branch confirmed seven further defects; all seven are fixed above, each starting from a failing test.

Two are worth calling out because they are **production** bugs rather than gate gaps:

```
PG   '{"t":"<NUL escape>"}'::jsonb      ERROR 22P05 unsupported Unicode escape sequence
PG   '{"t":"<lone surrogate>"}'::jsonb  ERROR 22P02 Unicode low surrogate must follow a high surrogate
PG   '{"t":"<emoji>"}'::jsonb           OK  (a paired surrogate is an ordinary astral character)
SQLite, same envelope                   returns the row
```

A2A message content is caller-supplied, and `list()` casts the **whole** envelope to filter on `scope.tenant` — so one bad code point in one task's text, in a field the query never reads, made `tasks/list` fail for **every** task in that scope. A lone surrogate is what an ordinary client produces by truncating a UTF-16 string mid-emoji.

The sanitiser runs on the string **values** during serialisation, not on the JSON text afterwards. An escape-level regex worked for NUL but had to reason about backslash parity to avoid corrupting a user who typed the escape literally, and it did not generalise. Sanitising the data is the level the problem lives at.

Two of the seven were regressions introduced by the *previous* round's fix — a type-identity check that silenced typed parameters, and a shape exemption that proved a fragment of an import specifier rather than the module. Both are recorded in the table above rather than quietly amended.

## Testing

TDD throughout — every fix started from a failing test, including all fourteen evasion shapes, each pinned as a fixture.

- `json-sql.test.ts` — SQLite branch against a real in-memory database, incl. the column guard firing on the default backend
- `json-sql-pg-text-column.test.ts` — cast behaviour, guard, aliasing, `jsonSet` shape
- `json-sql-path-segments.test.ts` — every divergent segment classification checked against the **real SQLite engine**, so an allow/reject decision is proven, not asserted
- `json-sql-call-sites.test.ts` — resolves every column argument at every call site against the schema, dialect-independently

Both gates were confirmed to actually catch what they claim: planting a mistyped call site, an aliased import, a local rebind, and flipping the schema to `mode: 'json'` each produce a precise failure.

**Gates:** lint 0 errors (426 pre-existing warnings, none added) · typecheck fully green · **api 5602 tests pass** (353 files), web 852, scripts 180.

## Notes

- Manual update not needed — internal DB helpers and tests only; no pages, routes, or user-visible copy.
- Not addressed: a malformed-JSON row fails the whole statement, on both dialects alike (`::jsonb` and `json_extract` both raise). Pre-existing and dialect-neutral, so out of scope here.
- Per the repo trust model, none of these gates attempt to contain a hostile authenticated author — a deliberate `as any` still bypasses them by design. They exist to catch accidents and force review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

