### PR TITLE
fix: allow follow-ups in restored chats

### DIFF
--- a/apps/web/src/hooks/__tests__/use-agent-chat-behaviour.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-agent-chat-behaviour.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Behavioural tests for `useAgentChat`'s transcript-adoption effect.
  *
- * Seven review rounds produced defects in this effect and every one of them was a
+ * Eight review rounds produced defects in this effect and every one of them was a
  * BEHAVIOURAL bug that a pure-function test could not have caught: a transcript
  * blanked, a composer frozen, a placeholder deleted, thumbnails revoked. These
  * tests drive the real hook against a controllable query result so those states
@@ -81,6 +81,31 @@ describe('useAgentChat — restoring a conversation', () => {
     // composer). It MUST be released once the run has settled, or every restored
     // conversation would come back read-only.
     await waitFor(() => expect(result.current.isStreaming).toBe(false))
+  })
+
+  it('can send a follow-up after reopening a settled conversation', async () => {
+    agentChats = [{ id: 'run_1' }]
+    chatHistory = {
+      run: { id: 'run_1', status: 'completed' },
+      messages: [
+        { role: 'user', content: 'hi' },
+        { role: 'agent', content: 'hello' },
+      ],
+    }
+    const { result } = renderChat()
+    await waitFor(() => expect(result.current.messages).toHaveLength(2))
+    await waitFor(() => expect(result.current.isStreaming).toBe(false))
+
+    act(() => result.current.refreshHistory())
+    await waitFor(() => expect(result.current.isStreaming).toBe(false))
+
+    act(() => result.current.setChatInput('follow-up'))
+    await waitFor(() => expect(result.current.canSend).toBe(true))
+    await act(async () => {
+      await result.current.sendMessage()
+    })
+
+    expect(result.current.chatInput).toBe('')
   })
 
   it('keeps the composer disabled while the restored run is still executing', async () => {

--- a/apps/web/src/hooks/use-agent-chat.ts
+++ b/apps/web/src/hooks/use-agent-chat.ts
@@ -275,17 +275,13 @@ export function useAgentChat({
   // `isStreaming` directly re-created the callback on every stream transition,
   // re-firing the drawer's `useEffect([open, refreshHistory])` at the end of each
   // turn and force-resuming whatever conversation was newest.
-  const isStreamingRef = useRef(false)
+  const isTurnActiveRef = useRef(false)
   // Mirrors "a turn is in progress", which includes a queued run whose stream has
   // already closed — refusing on raw `isStreaming` alone would let a drawer reopen
   // replace the conversation the user is still waiting on.
   useEffect(() => {
     messagesRef.current = messages
   }, [messages])
-
-  useEffect(() => {
-    isStreamingRef.current = isStreaming || !!followedRunId
-  }, [isStreaming, followedRunId])
 
   /**
    * Re-read the session list and resume whatever is newest now.
@@ -302,7 +298,7 @@ export function useAgentChat({
    */
   const refreshHistory = useCallback(() => {
     if (!loadHistory) return
-    if (isStreamingRef.current || userStartedFreshRef.current) return
+    if (isTurnActiveRef.current || userStartedFreshRef.current) return
     // Re-arm the resume effect only AFTER the refetch lands. Releasing the latch
     // first would let the effect run synchronously against the still-cached list
     // and re-latch on the stale newest session — the exact staleness this exists
@@ -655,11 +651,11 @@ export function useAgentChat({
   const sendMessage = useCallback(
     async (rawMessage?: string) => {
       const trimmed = (rawMessage ?? chatInput).trim()
-      // `isStreamingRef` mirrors "a turn is in progress", which includes a queued
+      // `isTurnActiveRef` mirrors "a turn is in progress", which includes a queued
       // run whose stream already closed — raw `isStreaming` is false there. The UI
       // already blocks this via `canSend`, but a programmatic caller (the chat
       // page's suggested-question chips) reaches this directly.
-      if (!trimmed || !id || isStreamingRef.current) return
+      if (!trimmed || !id || isTurnActiveRef.current) return
 
       if (!canChat) {
         setChatError(disabledReason ?? null)
@@ -677,6 +673,10 @@ export function useAgentChat({
         setChatError(t('agentDetail.attachmentHasFailed'))
         return
       }
+
+      // Close the gap before React commits `isStreaming`: a rapid second click or
+      // programmatic call must not start another turn against the same chat.
+      isTurnActiveRef.current = true
 
       const readyAttachments = pendingAttachments.filter((a) => a.token)
       const attachmentRefs = readyAttachments.map((a) => ({
@@ -1008,6 +1008,13 @@ export function useAgentChat({
     !isRunPending &&
     !chatHistoryFetching
   const isTurnActive = isStreaming || (!!followedRunId && !followedRunSettled)
+
+  // Keep imperative guards aligned with the exact state exposed to the composer.
+  // A completed restored run still has a followed id briefly; treating that id by
+  // itself as active made the enabled Send button silently ignore clicks.
+  useEffect(() => {
+    isTurnActiveRef.current = isTurnActive
+  }, [isTurnActive])
 
   const canSend =
     chatInput.trim().length > 0 &&


### PR DESCRIPTION
## Summary

- keep the imperative turn guard aligned with the composer-visible state
- allow a new instruction after reopening a completed conversation
- close the rapid double-send window before React commits streaming state

## Tests

- `pnpm run test -- src/hooks/__tests__/use-agent-chat-behaviour.test.tsx` (12 passed)
- `pnpm -r typecheck`