### PR TITLE
fix: 统一 Run 启动生命周期与状态刷新

### DIFF
--- a/apps/api/src/a2a/run-recording.ts
+++ b/apps/api/src/a2a/run-recording.ts
@@ -1,10 +1,10 @@
 import { and, desc, eq } from 'drizzle-orm'
 import type { Context } from 'hono'
 import { db } from '../db/client.js'
-import { agents, chatMessages, runSteps, runs } from '../db/schema.js'
+import { agents, runSteps, runs } from '../db/schema.js'
 import { allTaskIdVariants } from '../engine/task-id.js'
-import { taskQueueDb } from '../engine/task-queue-db.js'
 import { tryAcquireSlot } from '../engine/task-queue.js'
+import { taskQueueDb } from '../engine/task-queue-db.js'
 import { cleanupMaterializedRoot, materializeForRun } from '../lib/attachment-materializer.js'
 import { logAudit } from '../lib/audit.js'
 import { executeWithRetry } from '../lib/execute-with-retry.js'
@@ -13,13 +13,14 @@ import { logger } from '../lib/logger.js'
 import { cancelRunningTasksInBackground, claimRunCancellation } from '../lib/run-cancellation.js'
 import { buildGatewayChannel } from '../lib/run-channel.js'
 import {
-  type IdempotentRun,
   findIdempotentRun,
+  type IdempotentRun,
   isActiveOrCompletedRun,
   isRunIdempotencyConflict,
 } from '../lib/run-idempotency.js'
 import { finishRunError, finishRunSuccess } from '../lib/run-lifecycle.js'
 import { stopLogCollector } from '../lib/run-log-registry.js'
+import { persistRunTurn } from '../lib/run-startup.js'
 import {
   type GatewayCaller,
   normalizeAuthType,
@@ -306,21 +307,22 @@ export async function createRecordedA2AExecuteFn(c: Context, agent: AgentRow): P
         context: { ...(payload.context ?? {}), channel },
       }
 
-      await db.insert(runSteps).values({
-        id: stepId,
-        runId,
-        agentId: agent.id,
-        order: 1,
-        input: stepInput,
-        status: 'running',
-      })
-
-      await db.insert(chatMessages).values({
-        id: createId('msg'),
-        runId,
-        role: 'user',
-        // 存用户原文（payload.prompt，合并前），不存注入了附件路径的 mergedPrompt。
-        content: payload.prompt,
+      await persistRunTurn({
+        step: {
+          id: stepId,
+          runId,
+          agentId: agent.id,
+          order: 1,
+          input: stepInput,
+          status: 'running',
+        },
+        message: {
+          id: createId('msg'),
+          runId,
+          role: 'user',
+          // 存用户原文（payload.prompt，合并前），不存注入了附件路径的 mergedPrompt。
+          content: payload.prompt,
+        },
       })
 
       const { provenance: _provenance, ...executeOptions } = options ?? {}

--- a/apps/api/src/lib/__tests__/run-startup.test.ts
+++ b/apps/api/src/lib/__tests__/run-startup.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest'
+import { persistRunTurn, recoverRunStartup } from '../run-startup.js'
+
+describe('persistRunTurn', () => {
+  it('persists the step and user message inside one transaction', async () => {
+    const values = vi.fn().mockResolvedValue(undefined)
+    const tx = { insert: vi.fn(() => ({ values })) }
+    const transaction = vi.fn(async (callback) => await callback(tx))
+
+    await persistRunTurn(
+      {
+        step: {
+          id: 'rst_test',
+          runId: 'run_test',
+          agentId: 'agt_test',
+          order: 1,
+          input: { message: 'hello' },
+          status: 'running',
+        },
+        message: {
+          id: 'msg_test',
+          runId: 'run_test',
+          role: 'user',
+          content: 'hello',
+        },
+      },
+      { transaction },
+    )
+
+    expect(transaction).toHaveBeenCalledOnce()
+    expect(tx.insert).toHaveBeenCalledTimes(2)
+    expect(values).toHaveBeenNthCalledWith(1, expect.objectContaining({ id: 'rst_test', order: 1 }))
+    expect(values).toHaveBeenNthCalledWith(2, expect.objectContaining({ id: 'msg_test' }))
+  })
+
+  it('computes the next step order inside the same transaction', async () => {
+    const values = vi.fn().mockResolvedValue(undefined)
+    const limit = vi.fn().mockResolvedValue([{ maxOrder: 4 }])
+    const tx = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({ where: vi.fn(() => ({ limit })) })),
+      })),
+      insert: vi.fn(() => ({ values })),
+    }
+    const transaction = vi.fn(async (callback) => await callback(tx))
+
+    await persistRunTurn(
+      {
+        step: {
+          id: 'rst_next',
+          runId: 'run_test',
+          agentId: 'agt_test',
+          input: { message: 'follow up' },
+          status: 'running',
+        },
+        message: {
+          id: 'msg_next',
+          runId: 'run_test',
+          role: 'user',
+          content: 'follow up',
+        },
+      },
+      { transaction },
+    )
+
+    expect(limit).toHaveBeenCalledWith(1)
+    expect(values).toHaveBeenNthCalledWith(1, expect.objectContaining({ id: 'rst_next', order: 5 }))
+  })
+
+  it('propagates a write failure so the transaction can roll back both records', async () => {
+    let writeCount = 0
+    const tx = {
+      insert: vi.fn(() => ({
+        values: vi.fn(async () => {
+          writeCount++
+          if (writeCount === 2) throw new Error('message write failed')
+        }),
+      })),
+    }
+    const transaction = vi.fn(async (callback) => await callback(tx))
+
+    await expect(
+      persistRunTurn(
+        {
+          step: {
+            id: 'rst_test',
+            runId: 'run_test',
+            agentId: 'agt_test',
+            order: 1,
+            input: { message: 'hello' },
+            status: 'running',
+          },
+          message: {
+            id: 'msg_test',
+            runId: 'run_test',
+            role: 'user',
+            content: 'hello',
+          },
+        },
+        { transaction },
+      ),
+    ).rejects.toThrow('message write failed')
+  })
+})
+
+describe('recoverRunStartup', () => {
+  it('settles persisted state before releasing the lease and advancing the queue', async () => {
+    const calls: string[] = []
+
+    await recoverRunStartup(
+      {
+        runId: 'run_test',
+        agentId: 'agt_test',
+        cleanup: async () => calls.push('cleanup'),
+        settleRun: async () => calls.push('settle-run'),
+      },
+      {
+        failRunSteps: async () => calls.push('fail-steps'),
+        releaseLease: () => calls.push('release-lease'),
+        scheduleNext: async () => {
+          calls.push('schedule-next')
+        },
+        reportError: vi.fn(),
+      },
+    )
+
+    expect(calls).toEqual(['cleanup', 'fail-steps', 'settle-run', 'release-lease', 'schedule-next'])
+  })
+
+  it('continues releasing and scheduling when an earlier recovery phase fails', async () => {
+    const releaseLease = vi.fn()
+    const scheduleNext = vi.fn().mockResolvedValue(undefined)
+    const reportError = vi.fn()
+
+    await recoverRunStartup(
+      {
+        runId: 'run_test',
+        agentId: 'agt_test',
+        cleanup: vi.fn().mockRejectedValue(new Error('cleanup failed')),
+        settleRun: vi.fn().mockRejectedValue(new Error('settle failed')),
+      },
+      {
+        failRunSteps: vi.fn().mockRejectedValue(new Error('step update failed')),
+        releaseLease,
+        scheduleNext,
+        reportError,
+      },
+    )
+
+    expect(reportError).toHaveBeenCalledTimes(3)
+    expect(releaseLease).toHaveBeenCalledWith('run_test')
+    expect(scheduleNext).toHaveBeenCalledWith('agt_test')
+  })
+})

--- a/apps/api/src/lib/feishu-service.ts
+++ b/apps/api/src/lib/feishu-service.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { once } from 'node:events'
-import { promises as fs, createWriteStream, readFileSync, statSync } from 'node:fs'
+import { createWriteStream, promises as fs, readFileSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
 import { finished } from 'node:stream/promises'
@@ -9,42 +9,34 @@ import * as lark from '@larksuiteoapi/node-sdk'
 import { and, desc, eq, isNull, lt, or } from 'drizzle-orm'
 import WebSocket from 'ws'
 import { db } from '../db/client.js'
-import {
-  agents,
-  chatMessages,
-  feishuCardCallbacks,
-  feishuPendingMessages,
-  runSteps,
-  runs,
-} from '../db/schema.js'
+import { agents, feishuCardCallbacks, feishuPendingMessages, runSteps, runs } from '../db/schema.js'
 import { withTransaction } from '../db/transaction.js'
-import { completeExecutionLease } from '../engine/execution-lease-registry.js'
 import { resolveAgentRuntimeTmpDir } from '../engine/runtime-context.js'
 import { buildTaskId } from '../engine/task-id.js'
+import { tryAcquireSlot } from '../engine/task-queue.js'
 import { taskQueueDb } from '../engine/task-queue-db.js'
-import { scheduleNext, tryAcquireSlot } from '../engine/task-queue.js'
 import { env } from '../env.js'
 import type { WorkerTaskPayload } from '../worker/index.js'
 import { buildAgentConfig, resolveEngineType, resolveWorkDir } from './agent-helpers.js'
 import { buildFeishuArtifactSection } from './artifact-links.js'
 import {
+  getDirectorySourceSize,
   MAX_ZIP_SOURCE_BYTES,
   type RegisteredArtifact,
-  getDirectorySourceSize,
   zipDirectoryToBuffer,
 } from './artifact-storage.js'
 import { ProviderConfigurationError } from './errors.js'
 import { FeishuStreamingCard } from './feishu-card-streaming.js'
 import { type NormalizedFeishuConfig, normalizeFeishuConfig } from './feishu-config.js'
 import {
-  type CardCallbackValue,
-  type CardStyle,
-  INTERACTIVE_CARD_PROMPT,
-  type InteractiveCardSpec,
   buildInteractiveCardJson,
   buildPlainCardJson,
   buildResolvedCardJson,
+  type CardCallbackValue,
+  type CardStyle,
   decideCardAction,
+  INTERACTIVE_CARD_PROMPT,
+  type InteractiveCardSpec,
   parseInteractiveCardSpec,
   summarizeCardAction,
 } from './feishu-interactive-card.js'
@@ -85,17 +77,16 @@ import { buildFeishuChannel } from './run-channel.js'
 import { FAILURE_REASONS } from './run-failure-reasons.js'
 import { runWithLifecycle } from './run-launcher.js'
 import { finishRunAborted, finishRunError } from './run-lifecycle.js'
+import { persistRunTurn, recoverRunStartup } from './run-startup.js'
 import {
   registerStreamingCard,
   touchStreamingCard,
   unregisterStreamingCard,
 } from './streaming-card-registry.js'
 
-export type { FeishuConfig }
 export { normalizeFeishuConfig } from './feishu-config.js'
 export { buildTriggerSessionId, quoteAnchorId } from './feishu-message-context.js'
-
-export type { FeishuMessagePayload, FeishuSenderPayload }
+export type { FeishuConfig, FeishuMessagePayload, FeishuSenderPayload }
 
 /** The `im.message.receive_v1` event body delivered over the long connection. */
 interface FeishuMessageEvent {
@@ -174,6 +165,7 @@ export function buildFeishuReplyContent(
 // Re-export from feishu-fallback.ts (dependency-free module) so both this file
 // and run-lifecycle.ts can use it without forming a cycle.
 import { buildFeishuFallbackText, buildFeishuProviderConfigErrorText } from './feishu-fallback.js'
+
 export { buildFeishuFallbackText }
 
 // ── Pure helpers (exported for testing) ──────────────────────────
@@ -2080,16 +2072,15 @@ class FeishuConnectionManager {
 
     /** Fail the run and release the concurrency slot so queued runs can proceed. */
     const failRunAndReleaseSlot = async (error: string) => {
-      await db
-        .update(runs)
-        .set({ status: 'failed', result: { error }, updatedAt: new Date() })
-        .where(eq(runs.id, runId))
-      completeExecutionLease(runId)
-      void scheduleNext(
-        taskQueueDb,
+      await recoverRunStartup({
+        runId,
         agentId,
-        (rid, aid) => void import('./execute-chat-run.js').then((m) => m.executeChatRun(aid, rid)),
-      )
+        settleRun: () =>
+          db
+            .update(runs)
+            .set({ status: 'failed', result: { error }, updatedAt: new Date() })
+            .where(eq(runs.id, runId)),
+      })
     }
 
     // ── Streaming card: create before queue decision so queued jobs show "排队中..." ──
@@ -2420,17 +2411,17 @@ class FeishuConnectionManager {
         }
 
         const stepId = createId('rst')
-        await db.insert(runSteps).values({
-          id: stepId,
-          runId,
-          agentId,
-          order: 1,
-          input: { message: fullPrompt, context: feishuContext },
-          status: 'running',
+        await persistRunTurn({
+          step: {
+            id: stepId,
+            runId,
+            agentId,
+            order: 1,
+            input: { message: fullPrompt, context: feishuContext },
+            status: 'running',
+          },
+          message: { id: createId('msg'), runId, role: 'user', content: fullPrompt },
         })
-        await db
-          .insert(chatMessages)
-          .values({ id: createId('msg'), runId, role: 'user', content: fullPrompt })
 
         // 不在此创建 collector：runWithLifecycle 内部已 createPersistingLogCollector +
         // registerLogCollector，Web UI 通过该 collector 看到流式日志；feishu 本地无需另起一份。

--- a/apps/api/src/lib/run-startup.ts
+++ b/apps/api/src/lib/run-startup.ts
@@ -1,0 +1,112 @@
+import { eq, sql } from 'drizzle-orm'
+import { chatMessages, runSteps } from '../db/schema.js'
+import { type TransactionHandle, withTransaction } from '../db/transaction.js'
+import { completeExecutionLease } from '../engine/execution-lease-registry.js'
+import { scheduleNext } from '../engine/task-queue.js'
+import { taskQueueDb } from '../engine/task-queue-db.js'
+import { logger } from './logger.js'
+
+type TransactionRunner = <T>(callback: (tx: TransactionHandle) => Promise<T>) => Promise<T>
+
+interface PersistRunTurnDeps {
+  transaction: TransactionRunner
+}
+
+interface PersistRunTurnInput {
+  step: Omit<typeof runSteps.$inferInsert, 'order'> & { order?: number }
+  message: typeof chatMessages.$inferInsert
+}
+
+const defaultPersistDeps: PersistRunTurnDeps = {
+  transaction: withTransaction,
+}
+
+/** Persist one user turn atomically so history never contains a step without its message. */
+export async function persistRunTurn(
+  input: PersistRunTurnInput,
+  deps: PersistRunTurnDeps = defaultPersistDeps,
+): Promise<void> {
+  await deps.transaction(async (tx) => {
+    let order = input.step.order
+    if (order === undefined) {
+      const [lastStep] = await tx
+        .select({ maxOrder: sql<number>`MAX(${runSteps.order})` })
+        .from(runSteps)
+        .where(eq(runSteps.runId, input.step.runId))
+        .limit(1)
+      order = (lastStep?.maxOrder ?? 0) + 1
+    }
+
+    await tx.insert(runSteps).values({ ...input.step, order })
+    await tx.insert(chatMessages).values(input.message)
+  })
+}
+
+export type RunStartupRecoveryPhase =
+  | 'cleanup'
+  | 'fail-steps'
+  | 'settle-run'
+  | 'release-lease'
+  | 'schedule-next'
+
+interface RecoverRunStartupInput {
+  runId: string
+  agentId: string
+  cleanup?: () => Promise<unknown>
+  settleRun: () => Promise<unknown>
+}
+
+interface RecoverRunStartupDeps {
+  failRunSteps: (runId: string) => Promise<unknown>
+  releaseLease: (runId: string) => unknown
+  scheduleNext: (agentId: string) => Promise<unknown>
+  reportError: (
+    phase: RunStartupRecoveryPhase,
+    error: unknown,
+    context: { runId: string; agentId: string },
+  ) => void
+}
+
+const defaultRecoveryDeps: RecoverRunStartupDeps = {
+  failRunSteps: (runId) => taskQueueDb.failRunSteps(runId),
+  releaseLease: completeExecutionLease,
+  scheduleNext: async (agentId) => {
+    await scheduleNext(taskQueueDb, agentId, (runId, scheduledAgentId) => {
+      void import('./execute-chat-run.js').then(({ executeChatRun }) =>
+        executeChatRun(scheduledAgentId, runId),
+      )
+    })
+  },
+  reportError: (phase, error, context) => {
+    logger.error({ err: error, phase, ...context }, 'Run startup recovery phase failed')
+  },
+}
+
+/**
+ * Converge a run that failed after acquiring a concurrency slot.
+ *
+ * Every phase is best-effort and isolated: a cleanup or database failure must
+ * never prevent releasing the in-memory lease or waking the persisted queue.
+ */
+export async function recoverRunStartup(
+  input: RecoverRunStartupInput,
+  deps: RecoverRunStartupDeps = defaultRecoveryDeps,
+): Promise<void> {
+  const context = { runId: input.runId, agentId: input.agentId }
+  const runPhase = async (
+    phase: RunStartupRecoveryPhase,
+    action: () => Promise<unknown> | unknown,
+  ) => {
+    try {
+      await action()
+    } catch (error) {
+      deps.reportError(phase, error, context)
+    }
+  }
+
+  if (input.cleanup) await runPhase('cleanup', input.cleanup)
+  await runPhase('fail-steps', () => deps.failRunSteps(input.runId))
+  await runPhase('settle-run', input.settleRun)
+  await runPhase('release-lease', () => deps.releaseLease(input.runId))
+  await runPhase('schedule-next', () => deps.scheduleNext(input.agentId))
+}

--- a/apps/api/src/routes/__tests__/agents.test.ts
+++ b/apps/api/src/routes/__tests__/agents.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Hono } from 'hono'
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { z } from 'zod'
 import { registerAgentEnvMaskingTests } from './agents-env-masking-cases.js'
 import { registerOauthPublishTests } from './agents-oauth-publish-cases.js'
@@ -292,16 +292,15 @@ function makeDeleteChain() {
 import { db } from '../../db/client.js'
 import { scheduleNext, tryAcquireSlot } from '../../engine/task-queue.js'
 import {
-  WorktreeOccupiedError,
   resolveCleanupWorkDirs,
   resolveWorkDir,
+  WorktreeOccupiedError,
 } from '../../lib/agent-helpers.js'
 import { AppError, ProviderMcpUnsupportedError } from '../../lib/errors.js'
 import { WorktreeBranchLockedError } from '../../lib/git-workspace.js'
 import { MEMORY_OVERRIDE_MARKER } from '../../lib/memory-storage.js'
-import { executeInWorker } from '../../worker/index.js'
-
 import { asyncQuery } from '../../test/async-query.js'
+import { executeInWorker } from '../../worker/index.js'
 
 /**
  * Build the test app with the same global onError shape as `apps/api/src/index.ts`
@@ -1976,6 +1975,31 @@ describe('POST /agents/:id/chat — sync execution', () => {
 
     const res = await chatRequest({ message: 'hi' })
     expect(res.status).toBe(500)
+  })
+
+  it('restores the run and advances the queue when turn persistence fails', async () => {
+    mockDb.select.mockReturnValue(makeSelectChain(CHAT_AGENT))
+    mockDb.update.mockReturnValue(makeUpdateChain())
+    mockDb.delete.mockReturnValue(makeDeleteChain())
+    mockDb.insert
+      .mockReturnValueOnce(makeInsertChain())
+      .mockReturnValueOnce(makeInsertChain())
+      .mockReturnValueOnce({
+        values: vi.fn().mockReturnValue(
+          asyncQuery({
+            run: vi.fn(() => {
+              throw new Error('message insert failed')
+            }),
+          }),
+        ),
+      })
+
+    const res = await chatRequest({ message: 'hi' })
+
+    expect(res.status).toBe(500)
+    expect(mockDb.delete).toHaveBeenCalled()
+    expect(mockScheduleNext).toHaveBeenCalled()
+    expect(mockExecuteInWorker).not.toHaveBeenCalled()
   })
 
   it('returns 404 when agent does not exist', async () => {

--- a/apps/api/src/routes/__tests__/gateway.test.ts
+++ b/apps/api/src/routes/__tests__/gateway.test.ts
@@ -1,6 +1,6 @@
 import { GatewayErrorCode } from '@a2wave/shared'
 import { Hono } from 'hono'
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 
 type Json = Record<string, unknown>
 type ErrorJson = { error: { code: string; message: string; details?: unknown } }
@@ -155,7 +155,7 @@ function makeUpdateChain() {
 import { db } from '../../db/client.js'
 import { engineRegistry } from '../../engine/index.js'
 import { scheduleNext, tryAcquireSlot } from '../../engine/task-queue.js'
-import { WorktreeOccupiedError, buildAgentConfig, resolveWorkDir } from '../../lib/agent-helpers.js'
+import { buildAgentConfig, resolveWorkDir, WorktreeOccupiedError } from '../../lib/agent-helpers.js'
 import { ProviderConfigurationError } from '../../lib/errors.js'
 import { WorktreeBranchLockedError } from '../../lib/git-workspace.js'
 import { validateGatewayAuth } from '../../middleware/gateway-auth.js'
@@ -392,6 +392,29 @@ describe('Gateway routes', () => {
       const json = (await res.json()) as ErrorJson
       expect(json.error.code).toBe(GatewayErrorCode.EXECUTION_ERROR)
       expect(json.error.message).toBe('Execution failed. Check server logs for details.')
+    })
+
+    it('reclaims the run and advances the queue when turn persistence fails', async () => {
+      ;(db.select as Mock).mockReturnValue(makeDbChain(publishedAgent))
+      ;(db.insert as Mock)
+        .mockReturnValueOnce(makeInsertChain())
+        .mockReturnValueOnce(makeInsertChain())
+        .mockReturnValueOnce({
+          values: vi.fn().mockReturnValue(
+            asyncQuery({
+              run: vi.fn(() => {
+                throw new Error('message insert failed')
+              }),
+            }),
+          ),
+        })
+
+      const res = await invokeRequest({ message: 'hi', async: false })
+
+      expect(res.status).toBe(500)
+      expect(db.delete).toHaveBeenCalled()
+      expect(scheduleNext).toHaveBeenCalled()
+      expect(executeInWorker).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -1,12 +1,12 @@
 import { randomBytes } from 'node:crypto'
 import { join } from 'node:path'
 import {
-  type GroupConfig,
   a2aSkillSchema,
   attachmentsInputSchema,
   chatAppConfigSchema,
   createAgentInput,
   discordConfigSchema,
+  type GroupConfig,
   ghTriggerConfigSchema,
   glabTriggerConfigSchema,
   oauthAccessModeEnum,
@@ -19,7 +19,6 @@ import {
   worktreeCallParamsSchema,
 } from '@a2wave/shared'
 import {
-  type SQL,
   and,
   asc,
   count,
@@ -33,6 +32,7 @@ import {
   lte,
   notInArray,
   or,
+  type SQL,
   sql,
 } from 'drizzle-orm'
 import { type Context, Hono } from 'hono'
@@ -52,11 +52,10 @@ import {
   skills,
   users,
 } from '../db/schema.js'
-import { completeExecutionLease } from '../engine/execution-lease-registry.js'
 import { engineRegistry } from '../engine/index.js'
 import { buildTaskId } from '../engine/task-id.js'
+import { tryAcquireSlot } from '../engine/task-queue.js'
 import { taskQueueDb } from '../engine/task-queue-db.js'
-import { scheduleNext, tryAcquireSlot } from '../engine/task-queue.js'
 import {
   getAgentPermission,
   getAgentReadFilter,
@@ -67,13 +66,13 @@ import {
 import { collectAgentExecutionChecks } from '../lib/agent-execution-diagnose.js'
 import { buildExportZip } from '../lib/agent-export.js'
 import {
-  WorktreeOccupiedError,
   buildAgentConfig,
   removePerAgentWorkspace,
   resolveCleanupWorkDirs,
   resolveEngineType,
   resolveWorkDir,
   validateAgentProviderConfiguration,
+  WorktreeOccupiedError,
 } from '../lib/agent-helpers.js'
 import { importAgentFromUrl, importAgentFromZip } from '../lib/agent-import.js'
 import { revokeAgentTokensForAgent } from '../lib/agent-memory-token.js'
@@ -92,7 +91,6 @@ import {
 } from '../lib/attachment-materializer.js'
 import { logAudit } from '../lib/audit.js'
 import { discordConnectionManager } from '../lib/discord-service.js'
-import { executeChatRun } from '../lib/execute-chat-run.js'
 import { type DiagnoseSeverity, runAgentFeishuDiagnose } from '../lib/feishu-diagnose.js'
 import { feishuConnectionManager, normalizeFeishuConfig } from '../lib/feishu-service.js'
 import { normalizeOauthAccessMode } from '../lib/gateway-auth-errors.js'
@@ -105,8 +103,8 @@ import { canNonAdminUseMcp } from '../lib/mcp-stdio.js'
 import { clearAgentIndex } from '../lib/memory-index.js'
 import { removeAgentMemory, removeMemoryOverride } from '../lib/memory-storage.js'
 import {
-  OAUTH_ALLOWED_EMAILS_REQUIRED,
   isOauthAllowlistMissing,
+  OAUTH_ALLOWED_EMAILS_REQUIRED,
   resolveOauthAllowedEmailsUpdate,
 } from '../lib/oauth-publish.js'
 import { getCurrentUserId, getOwnerFilter } from '../lib/owner-filter.js'
@@ -117,18 +115,19 @@ import {
   stripReservedContextKeys,
 } from '../lib/run-channel.js'
 import { runWithLifecycle } from '../lib/run-launcher.js'
-import { scheduleTriggerManager } from '../lib/schedule-trigger.js'
+import { persistRunTurn, recoverRunStartup } from '../lib/run-startup.js'
 import type { ScheduleConfigInput } from '../lib/schedule-trigger.js'
+import { scheduleTriggerManager } from '../lib/schedule-trigger.js'
 import { canAgentOwnerUseSkill, canNonAdminUseSkill } from '../lib/skill-access.js'
 import { slackConnectionManager } from '../lib/slack-service.js'
 import {
-  MAX_BUCKETS,
-  MAX_TZ_OFFSET_SECONDS,
   boundaryBucketSql,
   bucketCount,
   bucketSequence,
   bucketStartSql,
   localDaySequence,
+  MAX_BUCKETS,
+  MAX_TZ_OFFSET_SECONDS,
   zoneOffsetSecondsAt,
 } from '../lib/time-buckets.js'
 import { runTokenSelect, stepTokenSelect, toTokenTotals } from '../lib/token-stats.js'
@@ -2665,9 +2664,7 @@ app.post('/:id/chat', async (c) => {
     // an untyped error (a workspace bookkeeping failure, a broken SCM config)
     // would otherwise pin the Agent at maxConcurrency until someone edits the
     // database.
-    await abandonRun()
-    completeExecutionLease(runId)
-    scheduleNext(taskQueueDb, id, (rid, aid) => void executeChatRun(aid, rid))
+    await recoverRunStartup({ runId, agentId: id, settleRun: abandonRun })
     if (
       err instanceof WorktreeOccupiedError ||
       err instanceof WorktreeBranchLockedError ||
@@ -2677,16 +2674,6 @@ app.post('/:id/chat', async (c) => {
     }
     throw err
   }
-
-  // Determine step order
-  const lastStep = (
-    await db
-      .select({ maxOrder: sql<number>`MAX(${runSteps.order})` })
-      .from(runSteps)
-      .where(eq(runSteps.runId, runId))
-      .limit(1)
-  )[0]
-  const nextOrder = (lastStep?.maxOrder ?? 0) + 1
 
   // 附件落盘 + prompt 注入（与飞书逐字节一致的路径提示）。无附件时 mergedPrompt ===
   // message、rootDir === null。原始 refs 存 runSteps.input.attachments（免迁移审计）。
@@ -2718,27 +2705,31 @@ app.post('/:id/chat', async (c) => {
   }
   // insert 失败即清理已落盘的附件目录再 rethrow，避免泄漏（review [P2]）。
   try {
-    await db.insert(runSteps).values({
-      id: stepId,
-      runId,
-      agentId: id,
-      order: nextOrder,
-      input: stepInput,
-      status: 'running',
-    })
-
-    // Write user message：存**用户原始输入**，不存注入了附件绝对路径的 mergedPrompt——否则
-    // 历史里用户原话会变成含 [图片]/[文件]/服务器路径的执行文本（review）。附件回显靠
-    // runSteps.input.attachments。mergedPrompt 仅用于引擎执行 + step 审计。
-    await db.insert(chatMessages).values({
-      id: createId('msg'),
-      runId,
-      role: 'user',
-      content: parsed.data.message,
+    await persistRunTurn({
+      step: {
+        id: stepId,
+        runId,
+        agentId: id,
+        input: stepInput,
+        status: 'running',
+      },
+      // Write user message：存**用户原始输入**，不存注入了附件绝对路径的 mergedPrompt——否则
+      // 历史里用户原话会变成含 [图片]/[文件]/服务器路径的执行文本（review）。附件回显靠
+      // runSteps.input.attachments。mergedPrompt 仅用于引擎执行 + step 审计。
+      message: {
+        id: createId('msg'),
+        runId,
+        role: 'user',
+        content: parsed.data.message,
+      },
     })
   } catch (err) {
-    if (attachmentRootDir) await cleanupMaterializedRoot(attachmentRootDir)
-    completeExecutionLease(runId)
+    await recoverRunStartup({
+      runId,
+      agentId: id,
+      cleanup: attachmentRootDir ? () => cleanupMaterializedRoot(attachmentRootDir) : undefined,
+      settleRun: abandonRun,
+    })
     throw err
   }
 

--- a/apps/api/src/routes/gateway.ts
+++ b/apps/api/src/routes/gateway.ts
@@ -1,22 +1,21 @@
 import {
+  attachmentsInputSchema,
   type GatewayError,
   GatewayErrorCode,
-  attachmentsInputSchema,
   worktreeCallParamsSchema,
 } from '@a2wave/shared'
 import { and, desc, eq } from 'drizzle-orm'
-import { Hono } from 'hono'
 import type { Context, Next } from 'hono'
+import { Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import { z } from 'zod'
 import { db } from '../db/client.js'
-import { agents, chatMessages, runSteps, runs } from '../db/schema.js'
-import { completeExecutionLease } from '../engine/execution-lease-registry.js'
+import { agents, runSteps, runs } from '../db/schema.js'
 import { engineRegistry } from '../engine/index.js'
 import { allTaskIdVariants, buildTaskId } from '../engine/task-id.js'
-import { taskQueueDb } from '../engine/task-queue-db.js'
 import { scheduleNext, tryAcquireSlot } from '../engine/task-queue.js'
-import { WorktreeOccupiedError, buildAgentConfig, resolveWorkDir } from '../lib/agent-helpers.js'
+import { taskQueueDb } from '../engine/task-queue-db.js'
+import { buildAgentConfig, resolveWorkDir, WorktreeOccupiedError } from '../lib/agent-helpers.js'
 import {
   cleanupMaterializedRoot,
   materializeForRun,
@@ -33,13 +32,13 @@ import { registerPendingContext, takePendingContext } from '../lib/pending-job-r
 import { cancelRunningTasksInBackground, claimRunCancellation } from '../lib/run-cancellation.js'
 import { buildGatewayChannel, stripReservedContextKeys } from '../lib/run-channel.js'
 import {
-  type IdempotentRun,
   findIdempotentRun,
+  type IdempotentRun,
   isActiveOrCompletedRun,
   isRunIdempotencyConflict,
 } from '../lib/run-idempotency.js'
 import { runWithLifecycle } from '../lib/run-launcher.js'
-import { createLogCollector, finishRunError, finishRunSuccess } from '../lib/run-lifecycle.js'
+import { persistRunTurn, recoverRunStartup } from '../lib/run-startup.js'
 import {
   type GatewayCaller,
   normalizeAuthType,
@@ -330,9 +329,11 @@ app.post('/:agentId/invoke', async (c) => {
     // concurrency slot, so it must be reclaimed on EVERY failure path — not
     // just the three typed ones. Leaving it behind wedges the Agent at
     // maxConcurrency forever, recoverable only by editing the database.
-    await db.delete(runs).where(eq(runs.id, runId))
-    completeExecutionLease(runId)
-    void scheduleNext(taskQueueDb, agentId, (rid, aid) => void executeChatRun(aid, rid))
+    await recoverRunStartup({
+      runId,
+      agentId,
+      settleRun: () => db.delete(runs).where(eq(runs.id, runId)),
+    })
     if (
       err instanceof WorktreeOccupiedError ||
       err instanceof WorktreeBranchLockedError ||
@@ -365,25 +366,30 @@ app.post('/:agentId/invoke', async (c) => {
   // materialize 已建 rootDir；到进入下方 lifecycle 的 finally 之前若 insert 抛错，rootDir 会
   // 泄漏（review [P2]）。这里兜一层：insert 失败即清理落盘目录再 rethrow。
   try {
-    await db.insert(runSteps).values({
-      id: stepId,
-      runId,
-      agentId,
-      order: 1,
-      input: stepInput,
-      status: 'running',
-    })
-
-    await db.insert(chatMessages).values({
-      id: createId('msg'),
-      runId,
-      role: 'user',
-      // 存用户原文，不存注入了附件路径的 mergedPrompt（历史回显靠 runSteps.input.attachments）。
-      content: parsed.data.message,
+    await persistRunTurn({
+      step: {
+        id: stepId,
+        runId,
+        agentId,
+        order: 1,
+        input: stepInput,
+        status: 'running',
+      },
+      message: {
+        id: createId('msg'),
+        runId,
+        role: 'user',
+        // 存用户原文，不存注入了附件路径的 mergedPrompt（历史回显靠 runSteps.input.attachments）。
+        content: parsed.data.message,
+      },
     })
   } catch (err) {
-    if (attachmentRootDir) await cleanupMaterializedRoot(attachmentRootDir)
-    completeExecutionLease(runId)
+    await recoverRunStartup({
+      runId,
+      agentId,
+      cleanup: attachmentRootDir ? () => cleanupMaterializedRoot(attachmentRootDir) : undefined,
+      settleRun: () => db.delete(runs).where(eq(runs.id, runId)),
+    })
     throw err
   }
 
@@ -507,7 +513,6 @@ app.get('/:agentId/runs/:runId', async (c) => {
 /** POST /:agentId/runs/:runId/cancel — 外部取消端点 */
 app.post('/:agentId/runs/:runId/cancel', async (c) => {
   const { agentId, runId } = c.req.param()
-  const agent = c.get('gatewayAgent')
 
   const run = (await db.select().from(runs).where(eq(runs.id, runId)).limit(1))[0]
   if (!run) {

--- a/apps/api/src/routes/oauth-gateway.ts
+++ b/apps/api/src/routes/oauth-gateway.ts
@@ -1,20 +1,19 @@
-import { GatewayErrorCode, attachmentsInputSchema } from '@a2wave/shared'
+import { attachmentsInputSchema, GatewayErrorCode } from '@a2wave/shared'
 import { and, desc, eq } from 'drizzle-orm'
+import type { Context, Next } from 'hono'
 // TODO: oauth-gateway and gateway share ~300 lines of invoke/runs/cancel logic.
 // Extract a shared handleInvoke(agent, caller, channelBuilder, triggerSource) helper
 // when either route needs to diverge (metrics tags, rate-limit granularity, etc.).
 import { Hono } from 'hono'
-import type { Context, Next } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import { z } from 'zod'
 import { db } from '../db/client.js'
-import { agents, chatMessages, runSteps, runs } from '../db/schema.js'
-import { completeExecutionLease } from '../engine/execution-lease-registry.js'
+import { agents, runSteps, runs } from '../db/schema.js'
 import { engineRegistry } from '../engine/index.js'
 import { allTaskIdVariants, buildTaskId } from '../engine/task-id.js'
-import { taskQueueDb } from '../engine/task-queue-db.js'
 import { scheduleNext, tryAcquireSlot } from '../engine/task-queue.js'
-import { WorktreeOccupiedError, buildAgentConfig, resolveWorkDir } from '../lib/agent-helpers.js'
+import { taskQueueDb } from '../engine/task-queue-db.js'
+import { buildAgentConfig, resolveWorkDir, WorktreeOccupiedError } from '../lib/agent-helpers.js'
 import {
   cleanupMaterializedRoot,
   materializeForRun,
@@ -44,6 +43,7 @@ import { registerPendingContext, takePendingContext } from '../lib/pending-job-r
 import { cancelRunningTasksInBackground, claimRunCancellation } from '../lib/run-cancellation.js'
 import { buildOAuthChannel, stripReservedContextKeys } from '../lib/run-channel.js'
 import { runWithLifecycle } from '../lib/run-launcher.js'
+import { persistRunTurn, recoverRunStartup } from '../lib/run-startup.js'
 import {
   type GatewayCaller,
   oauthUploaderId,
@@ -441,16 +441,15 @@ app.post('/:agentId/invoke', async (c) => {
     resolvedWorkDir = await resolveWorkDir(agent, undefined, runId, agentConfig.agentEnv)
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
-    await db
-      .update(runs)
-      .set({
-        status: 'failed',
-        result: { error: msg },
-        updatedAt: new Date(),
-      })
-      .where(eq(runs.id, runId))
-    completeExecutionLease(runId)
-    void scheduleNext(taskQueueDb, agentId, (rid, aid) => void executeChatRun(aid, rid))
+    await recoverRunStartup({
+      runId,
+      agentId,
+      settleRun: () =>
+        db
+          .update(runs)
+          .set({ status: 'failed', result: { error: msg }, updatedAt: new Date() })
+          .where(eq(runs.id, runId)),
+    })
     const busy =
       err instanceof WorktreeOccupiedError ||
       err instanceof WorktreeBranchLockedError ||
@@ -478,50 +477,39 @@ app.post('/:agentId/invoke', async (c) => {
     stepInput.attachments = materialized
   }
   try {
-    await db.insert(runSteps).values({
-      id: stepId,
-      runId,
-      agentId,
-      order: 1,
-      input: stepInput,
-      status: 'running',
-    })
-
-    await db.insert(chatMessages).values({
-      id: createId('msg'),
-      runId,
-      role: 'user',
-      // 存用户原文，不存注入了附件路径的 mergedPrompt（历史回显靠 runSteps.input.attachments）。
-      content: parsed.data.message,
+    await persistRunTurn({
+      step: {
+        id: stepId,
+        runId,
+        agentId,
+        order: 1,
+        input: stepInput,
+        status: 'running',
+      },
+      message: {
+        id: createId('msg'),
+        runId,
+        role: 'user',
+        // 存用户原文，不存注入了附件路径的 mergedPrompt（历史回显靠 runSteps.input.attachments）。
+        content: parsed.data.message,
+      },
     })
   } catch (err) {
-    // 先清理已落盘的附件目录（本分支），再走 main 侧的健壮失败收口（标 failed +
-    // scheduleNext + 500，不 rethrow——避免槽泄漏）。
-    if (attachmentRootDir) await cleanupMaterializedRoot(attachmentRootDir)
     logger.error({ err, runId, agentId }, 'Failed to initialize OAuth run after slot acquisition')
-    try {
-      await taskQueueDb.failRunSteps(runId)
-    } catch (cleanupError) {
-      logger.error({ err: cleanupError, runId }, 'Failed to mark OAuth run steps as failed')
-    }
-    try {
-      await db
-        .update(runs)
-        .set({
-          status: 'failed',
-          result: { error: 'Run setup failed' },
-          updatedAt: new Date(),
-        })
-        .where(eq(runs.id, runId))
-    } catch (cleanupError) {
-      logger.error({ err: cleanupError, runId }, 'Failed to mark OAuth run as failed')
-    }
-    try {
-      completeExecutionLease(runId)
-      void scheduleNext(taskQueueDb, agentId, (rid, aid) => void executeChatRun(aid, rid))
-    } catch (cleanupError) {
-      logger.error({ err: cleanupError, runId, agentId }, 'Failed to schedule next OAuth run')
-    }
+    await recoverRunStartup({
+      runId,
+      agentId,
+      cleanup: attachmentRootDir ? () => cleanupMaterializedRoot(attachmentRootDir) : undefined,
+      settleRun: () =>
+        db
+          .update(runs)
+          .set({
+            status: 'failed',
+            result: { error: 'Run setup failed' },
+            updatedAt: new Date(),
+          })
+          .where(eq(runs.id, runId)),
+    })
     return c.json(internalOAuthError({ runId }), 500)
   }
 
@@ -678,7 +666,6 @@ app.get('/:agentId/runs/:runId', async (c) => {
 
 app.post('/:agentId/runs/:runId/cancel', async (c) => {
   const { agentId, runId } = c.req.param()
-  const agent = c.get('gatewayAgent')
 
   const run = (await db.select().from(runs).where(eq(runs.id, runId)).limit(1))[0]
   if (!run) {

--- a/apps/web/src/hooks/__tests__/use-runs.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-runs.test.tsx
@@ -1,0 +1,115 @@
+import type { RunWithAgent } from '@a2wave/shared'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getMock = vi.fn()
+const fetchMock = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: (...args: unknown[]) => getMock(...args),
+    post: vi.fn(),
+  },
+}))
+
+import { useRun, useRuns } from '../use-runs'
+
+function makeRun(status: RunWithAgent['status'], id = `run_${status}`): RunWithAgent {
+  return {
+    id,
+    intent: 'test run',
+    status,
+    triggerSource: 'debug',
+    initiatorAgentId: 'agt_1',
+    agentName: 'Agent',
+    createdAt: new Date('2026-08-14T00:00:00.000Z'),
+    updatedAt: new Date('2026-08-14T00:00:00.000Z'),
+  }
+}
+
+function runsResponse(statuses: RunWithAgent['status'][]) {
+  return {
+    ok: true,
+    json: async () => ({
+      data: statuses.map((status) => makeRun(status)),
+      pagination: { total: statuses.length, page: 1, pageSize: 20, totalPages: 1 },
+    }),
+  }
+}
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, refetchOnWindowFocus: false },
+    },
+  })
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('run status polling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    getMock.mockReset()
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it.each(['pending', 'queued', 'running'] as const)(
+    'polls the run list while it contains a %s run',
+    async (status) => {
+      fetchMock.mockResolvedValue(runsResponse([status, 'completed']))
+
+      const { result } = renderHook(() => useRuns({ agentId: 'agt_1' }), {
+        wrapper: makeWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    },
+  )
+
+  it('stops polling the run list after every run becomes terminal', async () => {
+    fetchMock
+      .mockResolvedValueOnce(runsResponse(['running']))
+      .mockResolvedValue(runsResponse(['completed', 'failed', 'cancelled']))
+
+    const { result } = renderHook(() => useRuns(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    await vi.advanceTimersByTimeAsync(2_000)
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+    await vi.advanceTimersByTimeAsync(4_000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('continues polling a queued run detail', async () => {
+    getMock.mockResolvedValue({
+      data: { ...makeRun('queued'), steps: [], messages: [] },
+    })
+
+    const { result } = renderHook(() => useRun('run_queued'), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(getMock).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2))
+  })
+})

--- a/apps/web/src/hooks/use-runs.ts
+++ b/apps/web/src/hooks/use-runs.ts
@@ -1,6 +1,13 @@
-import { api } from '@/lib/api'
-import type { ChatMessage, PaginatedResponse, Run, RunStep, RunWithAgent } from '@a2wave/shared'
+import {
+  type ChatMessage,
+  isActiveRunStatus,
+  type PaginatedResponse,
+  type Run,
+  type RunStep,
+  type RunWithAgent,
+} from '@a2wave/shared'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { api } from '@/lib/api'
 
 const RUNS_KEY = ['runs'] as const
 const RUNS_STATS_KEY = ['runs', 'stats'] as const
@@ -226,6 +233,8 @@ export function useRuns(filter?: RunsFilter) {
       if (!res.ok) throw new Error('Failed to fetch runs')
       return res.json() as Promise<PaginatedResponse<RunWithAgent>>
     },
+    refetchInterval: (query) =>
+      query.state.data?.data.some((run) => isActiveRunStatus(run.status)) ? 2_000 : false,
   })
 }
 
@@ -240,7 +249,7 @@ export function useRun(id: string) {
     enabled: !!id,
     refetchInterval: (query) => {
       const status = query.state.data?.data?.status
-      return status === 'running' || status === 'pending' ? 2000 : false
+      return isActiveRunStatus(status) ? 2_000 : false
     },
   })
 }

--- a/packages/shared/src/__tests__/run-schema.test.ts
+++ b/packages/shared/src/__tests__/run-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { runSchema, runWithAgentSchema } from '../schemas/run.js'
+import { isActiveRunStatus, runSchema, runWithAgentSchema } from '../schemas/run.js'
 
 const BASE_RUN = {
   id: 'run_1',
@@ -34,5 +34,20 @@ describe('run caller provenance', () => {
       triggerAgentName: 'Order Router',
       agentName: 'Order Expert',
     })
+  })
+})
+
+describe('active run status', () => {
+  it.each(['pending', 'queued', 'running'] as const)('treats %s as active', (status) => {
+    expect(isActiveRunStatus(status)).toBe(true)
+  })
+
+  it.each(['completed', 'failed', 'cancelled'] as const)('treats %s as terminal', (status) => {
+    expect(isActiveRunStatus(status)).toBe(false)
+  })
+
+  it('treats missing status as inactive', () => {
+    expect(isActiveRunStatus(null)).toBe(false)
+    expect(isActiveRunStatus(undefined)).toBe(false)
   })
 })

--- a/packages/shared/src/schemas/run.ts
+++ b/packages/shared/src/schemas/run.ts
@@ -10,6 +10,19 @@ export const runStatusEnum = z.enum([
 ])
 export type RunStatus = z.infer<typeof runStatusEnum>
 
+export const ACTIVE_RUN_STATUSES = [
+  'pending',
+  'queued',
+  'running',
+] as const satisfies readonly RunStatus[]
+export type ActiveRunStatus = (typeof ACTIVE_RUN_STATUSES)[number]
+
+const activeRunStatusSet: ReadonlySet<RunStatus> = new Set(ACTIVE_RUN_STATUSES)
+
+export function isActiveRunStatus(status: RunStatus | null | undefined): status is ActiveRunStatus {
+  return status !== null && status !== undefined && activeRunStatusSet.has(status)
+}
+
 export const runTriggerSourceEnum = z.enum([
   'debug',
   'api',


### PR DESCRIPTION
## 问题

即时执行入口在获得并发槽后，如果初始化阶段失败，部分路径只释放内存 lease，没有统一收敛数据库 Run、步骤状态和持久队列。结果是数据库可能长期保留 `running`，继续占用并发计数并阻塞后续任务。运行列表同时缺少对 `queued` 等活跃状态的统一刷新判断，取消或完成后页面状态也可能滞后。

## 方案

- 新增统一的 Run 启动组件，将步骤序号计算、`run_steps` 与 `chat_messages` 写入放进同一事务，避免半写入和并发续问序号竞争。
- 新增分阶段失败恢复协调器，固定执行附件清理、步骤失败、渠道级 Run 收敛、lease 释放和队列唤醒；各渠道只保留自身应有的收敛语义。
- Web Chat、Gateway、OAuth Gateway、飞书和 A2A 共用同一持久化边界；需要释放并发槽的入口共用同一恢复机制。
- 在 shared 包定义活跃 Run 状态，列表和详情按 `pending / queued / running` 自适应轮询，终态自动停止。
- 补充启动事务、失败恢复、路由回收和前端轮询回归测试。

## 验证

- `pnpm typecheck` 通过。
- API 关联测试：5 个文件、231 项通过。
- Web 全量测试：106 个文件、867 项通过。
- Shared 全量测试：16 个文件、177 项通过。
- Web 与 CLI 生产构建通过；API `tsup` 与 DTS 构建通过。
- `pnpm lint` 退出码为 0；仓库当前仍有 724 个既有 warning，本 PR 未新增对应治理范围。
- Windows 全量测试仍受既有 POSIX 路径/权限断言影响；Provider installer、CLI 及部分 API 平台断言需由后续跨平台治理处理，Linux CI 作为最终全量门禁。