### PR TITLE
fix(api): preserve Windows Codex multiline prompts

### DIFF
--- a/apps/api/src/engine/__tests__/cli-process-runner.test.ts
+++ b/apps/api/src/engine/__tests__/cli-process-runner.test.ts
@@ -3,9 +3,9 @@ import { EventEmitter } from 'node:events'
 import { PassThrough } from 'node:stream'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
-  type CliProcessRunOptions,
   CliProcessRunner,
   type CliProcessRunnerOptions,
+  type CliProcessRunOptions,
   createLineDecoder,
 } from '../cli-process-runner.js'
 import {
@@ -20,6 +20,7 @@ vi.mock('../../lib/logger.js', () => ({
 }))
 
 class FakeChildProcess extends EventEmitter {
+  readonly stdin = new PassThrough()
   readonly stdout = new PassThrough()
   readonly stderr = new PassThrough()
   readonly kill = vi.fn((_signal?: NodeJS.Signals | number) => true)
@@ -64,6 +65,33 @@ afterEach(() => {
 })
 
 describe('CliProcessRunner contract', () => {
+  it('writes the complete provided input to child stdin after spawn', async () => {
+    const input = '<system>\r\nfirst line\r\nsecond line\r\n</system>'
+    const { runner, spawnProcess, children, options } = createHarness({ stdin: input })
+    const received: Buffer[] = []
+
+    const execution = runner.run(options)
+    const child = children[0]
+    const stdinEnded = new Promise<void>((resolve) => {
+      child.stdin.once('end', resolve)
+    })
+    child.stdin.on('data', (chunk: Buffer) => received.push(chunk))
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'example-cli',
+      [],
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] }),
+    )
+    expect(received).toHaveLength(0)
+
+    child.emit('spawn')
+    await stdinEnded
+    expect(Buffer.concat(received).toString('utf8')).toBe(input)
+
+    child.emit('close', 0)
+    await execution
+  })
+
   it('drops an overlong unterminated line before retaining later process-log lines', () => {
     const lines: string[] = []
     const decoder = createLineDecoder((line) => lines.push(line), { maxLineChars: 64 })

--- a/apps/api/src/engine/__tests__/cli-process-runner.windows.test.ts
+++ b/apps/api/src/engine/__tests__/cli-process-runner.windows.test.ts
@@ -39,3 +39,34 @@ it.skipIf(process.platform !== 'win32')(
     expect(output).toEqual(['hello & goodbye'])
   },
 )
+
+it.skipIf(process.platform !== 'win32')(
+  'streams multiline input through an npm-style .cmd shim without truncation',
+  async () => {
+    testRoot = mkdtempSync(join(tmpdir(), 'a2wave-cli-stdin-'))
+    const binDir = join(testRoot, 'bin with spaces')
+    mkdirSync(binDir)
+    writeFileSync(
+      join(binDir, 'fixture-cli.cmd'),
+      '@echo off\r\n"%~1" -e "process.stdin.pipe(process.stdout)"\r\n',
+    )
+
+    const input = '<system>\r\nfirst line\r\nsecond line\r\n</system>'
+    const output: string[] = []
+    const runner = new CliProcessRunner()
+    const result = await runner.run({
+      taskId: 'windows_cmd_stdin_fixture',
+      command: 'fixture-cli',
+      args: [process.execPath],
+      stdin: input,
+      cwd: testRoot,
+      env: { ...process.env, PATH: `${binDir};${process.env.PATH ?? ''}` },
+      timeoutMs: 10_000,
+      label: 'Windows cmd stdin fixture',
+      onStdoutLine: (line) => output.push(line),
+    })
+
+    expect(result).toMatchObject({ reason: 'completed', exitCode: 0 })
+    expect(output).toEqual(['<system>\r', 'first line\r', 'second line\r', '</system>'])
+  },
+)

--- a/apps/api/src/engine/__tests__/codex-args.test.ts
+++ b/apps/api/src/engine/__tests__/codex-args.test.ts
@@ -11,7 +11,11 @@ vi.mock('node:child_process', () => ({
   spawn: mockSpawn,
 }))
 
-import { CodexAgentEngine, buildCodexMcpInjection } from '../codex-agent.js'
+import {
+  buildCodexMcpInjection,
+  buildCodexPromptTransport,
+  CodexAgentEngine,
+} from '../codex-agent.js'
 import type { ResolvedMcpServer } from '../mcp-sync.js'
 
 const baseConfig = {
@@ -24,6 +28,7 @@ const baseConfig = {
 }
 
 class MockChildProcess extends EventEmitter {
+  stdin = new PassThrough()
   stdout = new PassThrough()
   stderr = new PassThrough()
   pid = 9000
@@ -68,12 +73,17 @@ describe('CodexAgentEngine buildArgs (CLI flag compatibility)', () => {
 
   it('首次 exec: 传 --json --skip-git-repo-check --model + --sandbox workspace-write（默认非 force）', async () => {
     const child = new MockChildProcess()
+    let stdin = ''
+    child.stdin.on('data', (chunk: Buffer) => {
+      stdin += chunk.toString('utf8')
+    })
     mockSpawn.mockReturnValue(child)
     const engine = new CodexAgentEngine(baseConfig)
     const p = getExecuteStream(engine)(
       { taskId: 't', workDir: '/tmp/w', prompt: 'hi', agentConfig: {} },
       'gpt-5-codex',
     )
+    child.emit('spawn')
     finishOk(child)
     await p
     const args = lastSpawnArgs()
@@ -87,8 +97,9 @@ describe('CodexAgentEngine buildArgs (CLI flag compatibility)', () => {
     expect(args).not.toContain('--cd')
     // cwd 走 spawn options
     expect(lastSpawnCwd()).toBe('/tmp/w')
-    // prompt 是最后一个位置参数
-    expect(args[args.length - 1]).toBe('hi')
+    // Windows reads the prompt from stdin; POSIX keeps the positional argument.
+    expect(args[args.length - 1]).toBe(process.platform === 'win32' ? '-' : 'hi')
+    expect(stdin).toBe(process.platform === 'win32' ? 'hi' : '')
   })
 
   it('readOnly 模式: --sandbox read-only 且无 bypass', async () => {
@@ -435,6 +446,26 @@ describe('CodexAgentEngine buildArgs (CLI flag compatibility)', () => {
     expect(args.slice(0, 3)).toEqual(['exec', 'resume', 'thr_1'])
     expect(args).toContain('--dangerously-bypass-approvals-and-sandbox')
     expect(args).not.toContain('--sandbox')
+  })
+})
+
+describe('buildCodexPromptTransport', () => {
+  const multilinePrompt = '<system>\nfirst line\nsecond line\n</system>'
+
+  it('uses stdin on Windows so cmd.exe never parses the multiline prompt', () => {
+    expect(buildCodexPromptTransport(multilinePrompt, 'win32')).toEqual({
+      promptArg: '-',
+      stdin: multilinePrompt,
+    })
+  })
+
+  it('keeps the existing positional prompt on Linux and macOS', () => {
+    expect(buildCodexPromptTransport(multilinePrompt, 'linux')).toEqual({
+      promptArg: multilinePrompt,
+    })
+    expect(buildCodexPromptTransport(multilinePrompt, 'darwin')).toEqual({
+      promptArg: multilinePrompt,
+    })
   })
 })
 

--- a/apps/api/src/engine/cli-engine-base.ts
+++ b/apps/api/src/engine/cli-engine-base.ts
@@ -23,17 +23,17 @@ import { BaseAgentEngine } from './base-engine.js'
 import { cliProcessRunner } from './cli-process-runner.js'
 import { probeCliVersion, runStatusProbe } from './login-status-helper.js'
 import {
-  PROCESS_INJECTION_ENV_NAMES,
   buildSafeAgentProcessEnv,
   isProcessInjectionEnvName,
   omitRuntimeEnvKeys,
+  PROCESS_INJECTION_ENV_NAMES,
   sanitizeAgentRuntimeEnv,
 } from './runtime-context.js'
 import type { ExecuteResult, TokenUsage } from './types.js'
 import { attachUsageToError } from './usage.js'
 
-export { extractUsageFromError } from './usage.js'
 export type { ErrorWithUsage } from './usage.js'
+export { extractUsageFromError } from './usage.js'
 
 // Process-injection env names are defined in runtime-context (the single point
 // every engine funnels agent env through via sanitizeAgentRuntimeEnv) and
@@ -63,6 +63,8 @@ export interface RunCliStreamOptions {
   env: NodeJS.ProcessEnv
   cwd: string
   timeoutMs: number
+  /** Complete input to write to the child process stdin after spawn. */
+  stdin?: string
   /** Called for each complete stdout line (line-buffered; remainder flushed on close) */
   onStdoutLine: (line: string) => void
   /** Also feed stderr lines to onStdoutLine (some CLIs emit events on stderr) */

--- a/apps/api/src/engine/cli-process-runner.ts
+++ b/apps/api/src/engine/cli-process-runner.ts
@@ -35,6 +35,8 @@ export interface CliProcessRunOptions {
   cwd: string
   timeoutMs: number
   label: string
+  /** Complete UTF-8 input written after spawn, then stdin is closed. */
+  stdin?: string
   onStdoutLine: (line: string) => void
   parseStderrLines?: boolean
   onSpawned?: () => void
@@ -214,7 +216,7 @@ export class CliProcessRunner {
       child = this.spawnProcess(options.command, options.args, {
         cwd: options.cwd,
         env: options.env,
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: [options.stdin === undefined ? 'ignore' : 'pipe', 'pipe', 'pipe'],
         detached: this.useProcessGroups,
       })
     } catch (error) {
@@ -282,7 +284,14 @@ export class CliProcessRunner {
         if (abortSignal.aborted) active.abortListener()
       }
 
-      child.once('spawn', () => options.onSpawned?.())
+      child.stdin?.on('error', (error) => {
+        logger.debug({ taskId: options.taskId, error }, `${options.label} stdin closed early`)
+      })
+
+      child.once('spawn', () => {
+        options.onSpawned?.()
+        if (options.stdin !== undefined) child.stdin?.end(options.stdin)
+      })
 
       child.stdout?.on('data', (value: Buffer | string) => {
         stdoutDecoder.write(Buffer.isBuffer(value) ? value : Buffer.from(value))

--- a/apps/api/src/engine/codex-agent.ts
+++ b/apps/api/src/engine/codex-agent.ts
@@ -36,6 +36,7 @@ import {
 
 /** Heartbeat interval for in-flight tool calls (ms). */
 const TOOL_HEARTBEAT_INTERVAL_MS = 20_000
+
 import type {
   ExecuteResult,
   ListModelsOptions,
@@ -68,6 +69,13 @@ const PROTECTED_CODEX_ENV_NAMES = new Set([
 
 function truncate(s: string, maxLen = 200): string {
   return s.length <= maxLen ? s : `${s.slice(0, maxLen)}...`
+}
+
+export function buildCodexPromptTransport(
+  prompt: string,
+  platform: NodeJS.Platform = process.platform,
+): { promptArg: string; stdin?: string } {
+  return platform === 'win32' ? { promptArg: '-', stdin: prompt } : { promptArg: prompt }
 }
 
 const EXIT_CODE_MESSAGES: Record<number, string> = {
@@ -439,7 +447,8 @@ export class CodexAgentEngine extends BaseCliAgentEngine {
       )
     }
 
-    const args = this.buildArgs(prompt, model, inputChatId, {
+    const promptTransport = buildCodexPromptTransport(prompt)
+    const args = this.buildArgs(promptTransport.promptArg, model, inputChatId, {
       readOnly: agentConfig?.readOnly !== undefined ? Boolean(agentConfig.readOnly) : undefined,
       force: agentConfig?.force !== undefined ? Boolean(agentConfig.force) : undefined,
       mcpConfigOverride: mcpInjection?.configOverride,
@@ -602,6 +611,7 @@ export class CodexAgentEngine extends BaseCliAgentEngine {
       env: execEnv,
       cwd: resolvedWorkDir,
       timeoutMs: streamTimeoutMs,
+      stdin: promptTransport.stdin,
       onStdoutLine: parseLine,
       // Codex's main event stream is on stdout in --json mode, but some error
       // messages land on stderr; parse those lines too (matching cursor-agent).


### PR DESCRIPTION
## Summary

- send Codex prompts through stdin on Windows so npm `.cmd` shims never parse multiline prompt text
- keep the existing positional prompt and native spawn behavior unchanged on Linux and macOS
- add unit coverage plus a real Windows npm-style `.cmd` regression fixture with CRLF input

## Why

On Windows, npm-installed Codex is launched through a `.cmd` shim. Passing a multiline prompt as the final argv value lets `cmd.exe` interpret the newlines, so Codex can receive only the first line (typically `<system>`). Codex officially supports `-` as the prompt argument for both `exec` and `exec resume`, reading the complete prompt from stdin.

## Tests

- `pnpm --filter @a2wave/api test -- src/engine/__tests__/codex-args.test.ts src/engine/__tests__/cli-process-runner.test.ts src/engine/__tests__/cli-process-runner.windows.test.ts` (45 passed)
- `pnpm --filter @a2wave/api exec vitest run src/engine` (913 passed, 1 skipped)
- `pnpm typecheck`
- Biome and `git diff --check`

## Scope

This intentionally changes prompt transport only for Codex on `win32`. Other providers and POSIX execution paths are unchanged.