### PR TITLE
build(deps): pin @types/node to the Node 22 runtime we ship on

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,13 @@ updates:
       production-minor-patch:
         dependency-type: production
         update-types: [minor, patch]
+    ignore:
+      # @types/node must track the Node runtime we actually build and run on.
+      # `engines` requires >=22 and every CI job pins node-version: 22, so a major
+      # bump type-checks our code against an API surface the runtime does not have.
+      # Raise this together with the engines floor and the workflow pins.
+      - dependency-name: '@types/node'
+        update-types: [version-update:semver-major]
     labels: [dependencies]
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Why

`@types/node` must track the Node runtime we actually build and run on. The root `engines` requires `node >=22` and every workflow pins `node-version: 22`, so a major bump type-checks the codebase against an API surface the runtime does not provide.

Dependabot #50 (`@types/node` 22.19.10 → 26.2.0) made the cost concrete. Every unit and integration test stayed green — lint, all four `test-api` shards, `test-web`, `test-cli`, `pgschema`, `audit` — while three jobs failed on tightened type declarations alone:

| Job | Failure |
|---|---|
| `typecheck` | `BlobPart` no longer accepts `Buffer<ArrayBufferLike>` — `apps/cli/src/commands/agents.ts:463`, `chat.ts:274` |
| `scm-storage-integration` | `apps/web/src/lib/sse-stream.ts:94` — `number | Timeout` not assignable to `Timeout | null` |
| `license-inventory` | `docs/dependency-license-inventory.md` out of date |

Adopting it would have meant reworking Blob construction in the CLI and the SSE watchdog in web to satisfy types that do not describe Node 22's real behaviour.

## What

Adds a `version-update:semver-major` ignore for `@types/node` to the npm entry in `.github/dependabot.yml`, with a comment recording the constraint so the next reader knows when to lift it.

Minor and patch bumps are unaffected and still flow through the existing `dev-dependencies` group.

## When to lift this

Raise the ignore together with the `engines` floor and the `node-version` pins in the workflows, so types and runtime move as one.

## Testing

Config-only change; no runtime or product code touched. YAML validated and the parsed `ignore` entry confirmed. #50 closed with the same rationale.