### PR TITLE
feat(web): make URLs clickable in user message bubbles

### DIFF
--- a/apps/web/src/components/__tests__/linkified-text.test.tsx
+++ b/apps/web/src/components/__tests__/linkified-text.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { LinkifiedText } from '@/components/linkified-text'
+
+describe('LinkifiedText', () => {
+  it('renders plain text without links', () => {
+    render(<LinkifiedText text="no url here" />)
+    expect(screen.queryByRole('link')).toBeNull()
+    expect(screen.getByText('no url here')).toBeInTheDocument()
+  })
+
+  it('turns an http(s) URL into a link opening in a new tab', () => {
+    render(<LinkifiedText text="see https://example.com/a?b=1 for details" />)
+    const link = screen.getByRole('link', { name: 'https://example.com/a?b=1' })
+    expect(link).toHaveAttribute('href', 'https://example.com/a?b=1')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('links every URL in multi-line text and keeps surrounding text', () => {
+    const { container } = render(
+      <LinkifiedText text={'链接: https://gitlab.example.com/g/p/-/merge_requests/68\n主机: x'} />,
+    )
+    expect(screen.getAllByRole('link')).toHaveLength(1)
+    expect(container.textContent).toBe(
+      '链接: https://gitlab.example.com/g/p/-/merge_requests/68\n主机: x',
+    )
+  })
+
+  it('excludes trailing punctuation and CJK characters from the URL', () => {
+    render(<LinkifiedText text="发生了 https://example.com/x。请查看 (https://example.com/y)." />)
+    expect(screen.getByRole('link', { name: 'https://example.com/x' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'https://example.com/y' })).toBeInTheDocument()
+  })
+
+  it('ignores non-http schemes', () => {
+    render(<LinkifiedText text="javascript:alert(1) and file:///etc/passwd" />)
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+})

--- a/apps/web/src/components/chat/chat-message-list.tsx
+++ b/apps/web/src/components/chat/chat-message-list.tsx
@@ -3,16 +3,18 @@
  * app page so message rendering, streaming placeholders and empty states stay
  * identical across surfaces.
  */
+
+import { AlertCircle, Bot, User } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import { AttachmentChip } from '@/components/attachment-chip'
+import { LinkifiedText } from '@/components/linkified-text'
 import { MarkdownContent } from '@/components/markdown-content'
 import { StreamingStatus } from '@/components/streaming-status'
 import type { ChatMessageItem } from '@/hooks/use-agent-chat'
 import type { StreamLogEntry } from '@/hooks/use-agents'
 import { cn } from '@/lib/utils'
-import { AlertCircle, Bot, User } from 'lucide-react'
-import type { ReactNode } from 'react'
-import { useEffect, useRef } from 'react'
-import { useTranslation } from 'react-i18next'
 
 interface ChatMessageListProps {
   messages: ChatMessageItem[]
@@ -149,7 +151,7 @@ export function ChatMessageList({
                         ))}
                       </div>
                     )}
-                    <p className="text-sm whitespace-pre-wrap break-words">{message.content}</p>
+                    <LinkifiedText className="block text-sm" text={message.content} />
                   </>
                 ) : message.failed ? (
                   <div className="flex items-start gap-2">

--- a/apps/web/src/components/linkified-text.tsx
+++ b/apps/web/src/components/linkified-text.tsx
@@ -1,0 +1,45 @@
+import { Fragment } from 'react'
+import { cn } from '@/lib/utils'
+
+// CJK punctuation and quotes are excluded so pasted Chinese prose doesn't swallow them into the href.
+const URL_PATTERN = /https?:\/\/[^\s<>"'`，。；：！？、）】》」』]+/g
+const TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/
+
+function trimTrailing(url: string): string {
+  const trimmed = url.replace(TRAILING_PUNCTUATION, '')
+  return trimmed || url
+}
+
+/** Renders text with bare http(s) URLs turned into clickable links. */
+export function LinkifiedText({ text, className }: { text: string; className?: string }) {
+  const nodes: React.ReactNode[] = []
+  let lastIndex = 0
+
+  for (const match of text.matchAll(URL_PATTERN)) {
+    const start = match.index ?? 0
+    const url = trimTrailing(match[0])
+    if (start > lastIndex) nodes.push(text.slice(lastIndex, start))
+    nodes.push(
+      <a
+        key={`${start}-${url}`}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline underline-offset-2 break-all hover:opacity-80"
+      >
+        {url}
+      </a>,
+    )
+    lastIndex = start + url.length
+  }
+  if (lastIndex < text.length) nodes.push(text.slice(lastIndex))
+
+  return (
+    <span className={cn('whitespace-pre-wrap break-words', className)}>
+      {nodes.map((node, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional and static
+        <Fragment key={i}>{node}</Fragment>
+      ))}
+    </span>
+  )
+}

--- a/apps/web/src/components/run-detail-drawer.tsx
+++ b/apps/web/src/components/run-detail-drawer.tsx
@@ -1,13 +1,3 @@
-import { AttachmentChip } from '@/components/attachment-chip'
-import { MarkdownContent } from '@/components/markdown-content'
-import { RunLogContent } from '@/components/run-log-content'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import type { ChatMessageWithAttachments } from '@/hooks/use-chat-history'
-import { useCancelRun, useRerunRun, useRun } from '@/hooks/use-runs'
-import { historyRefToSentAttachment } from '@/lib/attachments'
-import { formatTokens } from '@/lib/format-tokens'
-import { cn } from '@/lib/utils'
 import { Drawer } from 'antd'
 import {
   Bot,
@@ -22,6 +12,17 @@ import {
 } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { AttachmentChip } from '@/components/attachment-chip'
+import { LinkifiedText } from '@/components/linkified-text'
+import { MarkdownContent } from '@/components/markdown-content'
+import { RunLogContent } from '@/components/run-log-content'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import type { ChatMessageWithAttachments } from '@/hooks/use-chat-history'
+import { useCancelRun, useRerunRun, useRun } from '@/hooks/use-runs'
+import { historyRefToSentAttachment } from '@/lib/attachments'
+import { formatTokens } from '@/lib/format-tokens'
+import { cn } from '@/lib/utils'
 
 const statusVariant = {
   pending: 'secondary' as const,
@@ -312,7 +313,7 @@ function ChatContent({
                         })}
                       </div>
                     )}
-                    <p className="text-sm whitespace-pre-wrap break-words">{message.content}</p>
+                    <LinkifiedText className="block text-sm" text={message.content} />
                   </>
                 ) : (
                   <MarkdownContent content={message.content} />


### PR DESCRIPTION
## Problem

Agent replies render through `MarkdownContent`, which autolinks via remark-gfm. User messages render as raw text, so a merge-request link delivered by a GitLab/GitHub repository trigger showed up as inert text in the test drawer — you had to select and copy it by hand.

## Change

- New `LinkifiedText` component that turns bare URLs into `target="_blank" rel="noopener noreferrer"` links.
  - Only `http`/`https` are linked, so no `javascript:` / `file:` scheme can slip in.
  - CJK punctuation and trailing ASCII punctuation are excluded from the href, so `…/merge_requests/68。` and `(…)` are not swallowed into the link.
- Used for the user bubbles in the shared chat transcript (`chat-message-list.tsx`, backing both the agent test drawer and the chat page) and in `run-detail-drawer.tsx`.
- The failed-message bubble stays plain text — it renders error strings, not user content.

## Testing

- New `apps/web/src/components/__tests__/linkified-text.test.tsx`, 5 cases (written first, red → green): plain text, single URL attributes, multi-line + surrounding text preserved, trailing/CJK punctuation trimmed, non-http schemes ignored.
- `pnpm typecheck` green across all 4 packages; Biome clean on the changed files with no new warnings.

## Upstream check

Reviewed open PRs on the repo (#63 auth device grant, #59 Feishu P2P session) — no overlap with this change.
