### PR TITLE
fix(web): copy the run id with the log panel's copy button

### DIFF
--- a/apps/web/src/components/__tests__/run-log-content.test.tsx
+++ b/apps/web/src/components/__tests__/run-log-content.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * The overview copy button is the only way to get a run's identity out of the
+ * log panel. Copying the intent without the id produces text nobody can trace
+ * back to a run, so the id has to lead the payload.
+ */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { I18nextProvider } from 'react-i18next'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import i18n from '@/i18n'
+
+const copyText = vi.hoisted(() => vi.fn(async (_text: string) => true))
+
+vi.mock('@/lib/clipboard', () => ({ copyText }))
+
+const run = {
+  id: 'run_v_HdrN4kMdaDR6wO',
+  status: 'running',
+  intent: 'review this MR and comment back',
+  createdAt: new Date('2026-08-20T03:32:11Z').toISOString(),
+  steps: [],
+  result: null,
+  hasFullLog: false,
+}
+
+vi.mock('@/hooks/use-runs', () => ({ useRun: () => ({ data: run, isLoading: false }) }))
+vi.mock('@/hooks/use-artifacts', () => ({
+  useArtifacts: () => ({ data: [] }),
+  useDeleteArtifact: () => ({ mutate: vi.fn(), isPending: false }),
+  getArtifactDownloadUrl: (id: string) => `/api/artifacts/${id}/download`,
+}))
+
+import { RunLogContent } from '../run-log-content'
+
+describe('RunLogContent copy', () => {
+  beforeEach(() => copyText.mockClear())
+
+  it('copies the run id together with the intent', async () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <RunLogContent runId={run.id} />
+      </I18nextProvider>,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: i18n.t('runLog.copyRunId') }))
+
+    const copied = copyText.mock.calls[0][0]
+    expect(copied).toContain(run.id)
+    expect(copied).toContain(run.intent)
+    expect(copied.indexOf(run.id)).toBeLessThan(copied.indexOf(run.intent))
+  })
+})

--- a/apps/web/src/components/__tests__/user-menu.test.tsx
+++ b/apps/web/src/components/__tests__/user-menu.test.tsx
@@ -1,7 +1,7 @@
-import { ThemeProvider } from '@/components/theme-provider'
-import { renderWithProviders, screen, waitFor, within } from '@/test/render'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ThemeProvider } from '@/components/theme-provider'
+import { renderWithProviders, screen, waitFor, within } from '@/test/render'
 import { CLI_INSTALL_COMMAND, UserMenu } from '../user-menu'
 
 const { messageSuccess, messageError } = vi.hoisted(() => ({
@@ -30,12 +30,9 @@ vi.mock('@/hooks/use-auth', () => ({
   useChangePassword: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }))
 
-const { copyToClipboard } = vi.hoisted(() => ({ copyToClipboard: vi.fn() }))
+const { copyText } = vi.hoisted(() => ({ copyText: vi.fn() }))
 
-vi.mock('@/lib/utils', async () => {
-  const actual = await vi.importActual<typeof import('@/lib/utils')>('@/lib/utils')
-  return { ...actual, copyToClipboard: (text: string) => copyToClipboard(text) }
-})
+vi.mock('@/lib/clipboard', () => ({ copyText: (text: string) => copyText(text) }))
 
 beforeEach(() => {
   authState.user = { username: 'testadmin', role: 'admin', locale: 'zh' }
@@ -112,8 +109,8 @@ describe('UserMenu — get CLI', () => {
   beforeEach(() => {
     messageSuccess.mockReset()
     messageError.mockReset()
-    copyToClipboard.mockReset()
-    copyToClipboard.mockResolvedValue(undefined)
+    copyText.mockReset()
+    copyText.mockResolvedValue(true)
   })
 
   it('copies the CLI install command and toasts on success', async () => {
@@ -128,7 +125,7 @@ describe('UserMenu — get CLI', () => {
     await user.click(await screen.findByRole('button', { name: '获取 CLI' }))
 
     await waitFor(() => {
-      expect(copyToClipboard).toHaveBeenCalledWith(CLI_INSTALL_COMMAND)
+      expect(copyText).toHaveBeenCalledWith(CLI_INSTALL_COMMAND)
     })
     // Exact, not a substring: `toContain('a2wave')` would still pass if the
     // package name regressed to the old `a2wave-cli`.
@@ -140,7 +137,7 @@ describe('UserMenu — get CLI', () => {
   })
 
   it('toasts an error when the clipboard write fails', async () => {
-    copyToClipboard.mockRejectedValue(new Error('denied'))
+    copyText.mockResolvedValue(false)
     const user = userEvent.setup()
     renderWithProviders(
       <ThemeProvider>

--- a/apps/web/src/components/agent-card.tsx
+++ b/apps/web/src/components/agent-card.tsx
@@ -1,14 +1,15 @@
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { useProviders } from '@/hooks/use-providers'
-import { cn, copyToClipboard } from '@/lib/utils'
 import type { Agent, AgentType } from '@a2wave/shared'
 import { Tooltip } from 'antd'
 import { Check, Copy, Pin } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { useProviders } from '@/hooks/use-providers'
+import { copyText } from '@/lib/clipboard'
+import { cn } from '@/lib/utils'
 
 const agentTypeLabelKeys: Record<AgentType, string> = {
   llm: 'agent.typeLlm',
@@ -22,7 +23,7 @@ function CopyIdButton({ text, ariaLabel }: { text: string; ariaLabel: string }) 
   const handleCopy = async (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    await copyToClipboard(text)
+    if (!(await copyText(text))) return
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }

--- a/apps/web/src/components/run-log-content.tsx
+++ b/apps/web/src/components/run-log-content.tsx
@@ -1,7 +1,3 @@
-import { FullLogViewer } from '@/components/full-log-viewer'
-import { StreamLogsTimeline } from '@/components/stream-log-item'
-import type { StreamLogEntry } from '@/hooks/use-agents'
-import { useRun } from '@/hooks/use-runs'
 import {
   Check,
   Copy,
@@ -16,6 +12,10 @@ import {
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { FullLogViewer } from '@/components/full-log-viewer'
+import { StreamLogsTimeline } from '@/components/stream-log-item'
+import type { StreamLogEntry } from '@/hooks/use-agents'
+import { useRun } from '@/hooks/use-runs'
 
 /**
  * Normalize an error value into a renderable string. Failure reasons may be
@@ -83,10 +83,11 @@ function CurrentToolBadge({ toolName, startedAt }: { toolName: string; startedAt
     </span>
   )
 }
+
 import { Button } from '@/components/ui/button'
-import { getArtifactDownloadUrl, useArtifacts, useDeleteArtifact } from '@/hooks/use-artifacts'
 import type { Artifact } from '@/hooks/use-artifacts'
-import { copyToClipboard } from '@/lib/utils'
+import { getArtifactDownloadUrl, useArtifacts, useDeleteArtifact } from '@/hooks/use-artifacts'
+import { copyText } from '@/lib/clipboard'
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -180,7 +181,9 @@ export function RunLogContent({ runId }: { runId: string }) {
 
   const handleCopy = async () => {
     if (!run) return
-    await copyToClipboard(run.id)
+    // Intent alone is untraceable; lead with the id so pasted text names its run.
+    const payload = run.intent ? `${run.id}\n\n${run.intent}` : run.id
+    if (!(await copyText(payload))) return
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }
@@ -211,6 +214,7 @@ export function RunLogContent({ runId }: { runId: string }) {
               onClick={handleCopy}
               className="p-0.5 rounded hover:bg-surface-hover transition-colors"
               title={t('runLog.copyRunId')}
+              aria-label={t('runLog.copyRunId')}
             >
               {copied ? (
                 <Check className="h-3.5 w-3.5 text-success" />

--- a/apps/web/src/components/user-menu.tsx
+++ b/apps/web/src/components/user-menu.tsx
@@ -35,7 +35,8 @@ import {
 } from '@/hooks/use-auth'
 import { message } from '@/lib/antd-static'
 import { formatApiError } from '@/lib/api-error'
-import { cn, copyToClipboard } from '@/lib/utils'
+import { copyText } from '@/lib/clipboard'
+import { cn } from '@/lib/utils'
 import { resolveSsoMethods, startSsoMethod } from '@/pages/login'
 
 /** Install command for the a2wave CLI, published to the public npm registry. */
@@ -255,10 +256,9 @@ export function UserMenu({ collapsed = false }: { collapsed?: boolean }) {
         className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-surface-hover transition-colors"
         onClick={async () => {
           setOpen(false)
-          try {
-            await copyToClipboard(CLI_INSTALL_COMMAND)
+          if (await copyText(CLI_INSTALL_COMMAND)) {
             message.success(t('auth.cliCommandCopied'))
-          } catch {
+          } else {
             message.error(t('auth.cliCommandCopyFailed'))
           }
         }}

--- a/apps/web/src/lib/clipboard.ts
+++ b/apps/web/src/lib/clipboard.ts
@@ -24,12 +24,18 @@ export async function copyText(text: string): Promise<boolean> {
   scratch.value = text
   // Keep it off-screen and non-interactive so the page does not visibly jump.
   scratch.setAttribute('readonly', '')
+  // Off-screen rather than transparent: a zero-opacity node counts as hidden to
+  // some engines, which makes the selection — and so the copy — a no-op.
   scratch.style.position = 'fixed'
-  scratch.style.opacity = '0'
-  scratch.style.pointerEvents = 'none'
-  document.body.appendChild(scratch)
+  scratch.style.top = '0'
+  scratch.style.left = '-9999px'
+  // A dialog traps focus to its own subtree, so a scratch node parented on
+  // <body> never receives the selection and the copy silently no-ops.
+  const host = document.activeElement?.closest('[role="dialog"]') ?? document.body
+  host.appendChild(scratch)
   try {
     scratch.select()
+    scratch.setSelectionRange(0, text.length)
     return document.execCommand('copy')
   } catch {
     return false

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -17,22 +17,6 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-/** Clipboard fallback for non-secure contexts (e.g. LAN HTTP access) */
-export async function copyToClipboard(text: string): Promise<void> {
-  if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text)
-    return
-  }
-  const textarea = document.createElement('textarea')
-  textarea.value = text
-  textarea.style.position = 'fixed'
-  textarea.style.opacity = '0'
-  document.body.appendChild(textarea)
-  textarea.select()
-  document.execCommand('copy')
-  document.body.removeChild(textarea)
-}
-
 /** Generate a unique ID, with fallback for non-secure contexts (e.g. LAN HTTP) */
 export function uniqueId(): string {
   return globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2)

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -110,7 +110,7 @@
     "executionFailed": "Execution failed"
   },
   "runLog": {
-    "copyRunId": "Copy Run ID",
+    "copyRunId": "Copy Run ID and prompt",
     "steps": "Steps",
     "input": "Input",
     "output": "Output",

--- a/apps/web/src/locales/zh.json
+++ b/apps/web/src/locales/zh.json
@@ -110,7 +110,7 @@
     "executionFailed": "执行失败"
   },
   "runLog": {
-    "copyRunId": "复制 Run ID",
+    "copyRunId": "复制 Run ID 与内容",
     "steps": "执行步骤",
     "input": "输入",
     "output": "输出",

--- a/apps/web/src/pages/agent-detail/copy-button.tsx
+++ b/apps/web/src/pages/agent-detail/copy-button.tsx
@@ -1,13 +1,13 @@
-import { Button } from '@/components/ui/button'
-import { copyToClipboard } from '@/lib/utils'
 import { Check, Copy } from 'lucide-react'
 import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { copyText } from '@/lib/clipboard'
 
 export function CopyButton({ text, label }: { text: string; label: string }) {
   const [copied, setCopied] = useState(false)
 
   const handleCopy = async () => {
-    await copyToClipboard(text)
+    if (!(await copyText(text))) return
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }

--- a/apps/web/src/pages/agent-detail/index.tsx
+++ b/apps/web/src/pages/agent-detail/index.tsx
@@ -1,31 +1,3 @@
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import { EmojiPicker } from '@/components/ui/emoji-picker'
-import { Input } from '@/components/ui/input'
-import { Skeleton } from '@/components/ui/skeleton'
-import { UnsavedChangesDialog } from '@/components/unsaved-changes-dialog'
-import {
-  CHAT_CONNECTIONS_QUERY_KEY,
-  FEISHU_CONNECTIONS_QUERY_KEY,
-  useUpdateAgent,
-} from '@/hooks/use-agents'
-import {
-  type AgentDiagnoseClipboardPayload,
-  formatAgentDiagnoseClipboardText,
-} from '@/lib/agent-diagnose-clipboard'
-import { message, modal } from '@/lib/antd-static'
-import { api } from '@/lib/api'
-import { formatApiError } from '@/lib/api-error'
-import { cn, copyToClipboard } from '@/lib/utils'
 import { useQueryClient } from '@tanstack/react-query'
 import { Dropdown, Tabs, Tooltip } from 'antd'
 import {
@@ -62,6 +34,35 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useLocation, useParams, useSearchParams } from 'react-router-dom'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { EmojiPicker } from '@/components/ui/emoji-picker'
+import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/skeleton'
+import { UnsavedChangesDialog } from '@/components/unsaved-changes-dialog'
+import {
+  CHAT_CONNECTIONS_QUERY_KEY,
+  FEISHU_CONNECTIONS_QUERY_KEY,
+  useUpdateAgent,
+} from '@/hooks/use-agents'
+import {
+  type AgentDiagnoseClipboardPayload,
+  formatAgentDiagnoseClipboardText,
+} from '@/lib/agent-diagnose-clipboard'
+import { message, modal } from '@/lib/antd-static'
+import { api } from '@/lib/api'
+import { formatApiError } from '@/lib/api-error'
+import { copyText } from '@/lib/clipboard'
+import { cn } from '@/lib/utils'
 import { ArtifactsTab } from './artifacts-tab'
 import { ConfigTab } from './config-tab'
 import { CopyButton } from './copy-button'
@@ -215,7 +216,7 @@ export function AgentDetailPage() {
       severityWarn: t('agentDetail.diagnoseSeverityWarn'),
       severityInfo: t('agentDetail.diagnoseSeverityInfo'),
     })
-    await copyToClipboard(text)
+    if (!(await copyText(text))) return
     setDiagnoseCopied(true)
     window.setTimeout(() => setDiagnoseCopied(false), 2000)
   }, [diagnoseResult, t])
@@ -746,7 +747,7 @@ export function AgentDetailPage() {
                                   `/agents/${id}/share`,
                                   {},
                                 )
-                                await copyToClipboard(res.data.shareUrl)
+                                await copyText(res.data.shareUrl)
                                 modal.success({
                                   title: t('agentDetail.shareLinkCopied'),
                                   content: t('agentDetail.shareLinkExpiry', {

--- a/apps/web/src/pages/agent-detail/publish/feishu-channel-section.tsx
+++ b/apps/web/src/pages/agent-detail/publish/feishu-channel-section.tsx
@@ -10,17 +10,18 @@
  * The `data-tour` anchors are load-bearing: the onboarding tour drives the
  * Feishu FTUE by querying them (see components/onboarding/onboarding-tour.tsx).
  */
-import { Button } from '@/components/ui/button'
-import { Label } from '@/components/ui/label'
-import { Textarea } from '@/components/ui/textarea'
-import { message } from '@/lib/antd-static'
-import { copyToClipboard } from '@/lib/utils'
-import { CopyButton } from '@/pages/agent-detail/copy-button'
+
 import { Checkbox, InputNumber, Popover, Radio, Switch } from 'antd'
 import { Eye, EyeOff, Globe, Info } from 'lucide-react'
 import type { CSSProperties, RefObject } from 'react'
 import { useLayoutEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { message } from '@/lib/antd-static'
+import { copyText } from '@/lib/clipboard'
+import { CopyButton } from '@/pages/agent-detail/copy-button'
 
 export type FeishuReplyMode = 'quote' | 'new' | 'none'
 export type FeishuTopicReplyMode = 'topic_reply' | 'none'
@@ -261,7 +262,7 @@ export function FeishuChannelSection({
                 size="sm"
                 className="h-7 shrink-0 text-xs"
                 onClick={async () => {
-                  await copyToClipboard(feishuAppScopesJson)
+                  if (!(await copyText(feishuAppScopesJson))) return
                   message.success(t('agentPublish.feishuScopesJsonCopied'))
                 }}
               >


### PR DESCRIPTION
## Problem

The run log panel's copy button painted a success checkmark without anything reaching the clipboard, and the payload it intended to copy omitted the run id.

Two independent causes, the first of which masked the second:

**The copy silently failed.** The panel called `copyToClipboard` from `lib/utils` — a *second* clipboard implementation living alongside the good one in `lib/clipboard`. It had two defects:

- Its async path had no `catch`, so a rejected `writeText` — routine on a plain-HTTP LAN origin, or under a restrictive permissions policy — propagated instead of falling back.
- Its `execCommand` fallback appended a transparent `<textarea>` to `<body>`. The run log renders inside a drawer whose focus trap keeps a `<body>`-parented node from ever receiving the selection, so `select()` was a no-op.

The checkmark was set unconditionally, so a failed copy was indistinguishable from a successful one.

**The payload lacked the run id.** Copied text carried the intent alone, which can't be traced back to the run it came from.

## Changes

- **Consolidated on `lib/clipboard`'s `copyText`**, deleting the duplicate `copyToClipboard`. `copyText` already handled reject-and-fall-through and returned a boolean — it was simply only wired to 3 of 10 call sites.
- **Hardened the `execCommand` fallback**: mount the scratch node inside the focused `[role="dialog"]` rather than `<body>`, and position it off-screen instead of at `opacity: 0` (some engines treat a fully transparent node as unselectable).
- **Every caller now gates its success indicator on the return value**, so a failed copy stops reading as a success. One deliberate exception: the agent share link still shows its modal either way, because that modal carries an expiry the user needs whether or not the clipboard write landed.
- **The copied payload leads with the run id**, then the intent.
- Added an `aria-label` to the copy button — it previously had no accessible name, only a `title`.

Button label updated in both locales: `Copy Run ID and prompt` / `复制 Run ID 与内容`.

## Testing

New `apps/web/src/components/__tests__/run-log-content.test.tsx` pins that the copied payload contains both the run id and the intent, with the id first. `user-menu.test.tsx` updated — its failure case is now a `false` return rather than a rejection, matching `copyText`'s contract.

| Gate | Result |
|---|---|
| `pnpm lint` | 0 errors (751 pre-existing warnings, none added) |
| `pnpm typecheck` | Green across all 4 packages |
| `pnpm --filter @a2wave/web test` | 1024/1024 pass, 120 files |

Also built as `a2wave:local-7c8ca62` and verified healthy on a running container.

**Not run:** the root `pnpm test` and the E2E recovery suite. Every change here is confined to `apps/web`, whose full suite passed, but the broader gates are unverified — worth a CI pass before merge.

## Upstream Orca check

No port applies — Orca is an Electron/terminal codebase with no equivalent to this panel. Two upstream PRs do share this change's thesis, that a copy indicator must never claim a write it didn't make, and are worth citing as convergent precedent:

- [stablyai/orca#10827](https://github.com/stablyai/orca/pull/10827) — *fix(terminal): verify clipboard writes so TUI "Copied" never lies* (merged)
- [stablyai/orca#12779](https://github.com/stablyai/orca/pull/12779) — *fix(terminal): surface clipboard copy failures and make verify advisory* (open)
