### PR TITLE
fix(git-trigger): skip a queued run whose merge request already finished

### DIFF
--- a/apps/api/src/db/schema.pg.ts
+++ b/apps/api/src/db/schema.pg.ts
@@ -720,6 +720,28 @@ export const runs = pgTable(
        * handoff in execute-chat-run.ts).
        */
       queuedTurn?: boolean
+      /**
+       * The merge/pull request a `glab` / `gh` run was fired for.
+       *
+       * Persisted (rather than left in the in-memory channel context) because
+       * the pre-execution staleness check runs when the run leaves the queue —
+       * possibly in a later process lifetime — and needs to re-probe the forge
+       * for the request's current state.
+       */
+      gitTriggerOrigin?: {
+        provider: 'glab' | 'gh'
+        event: string
+        project: string
+        host?: string
+        number: number
+        /**
+         * Whether the run waited in the queue. Only a queued run can have gone
+         * stale, so an immediately-dispatched one skips the probe entirely.
+         * Absent on rows written before this field existed — treated as queued,
+         * which costs one redundant probe rather than missing a stale run.
+         */
+        queued?: boolean
+      }
       /** Persisted Slack/Discord context for queued and restart execution. */
       nativeChatContext?: Record<string, unknown>
       /** Durable remote identifiers resolved only after native event reservation/acknowledgement. */

--- a/apps/api/src/db/schema.sqlite.ts
+++ b/apps/api/src/db/schema.sqlite.ts
@@ -713,6 +713,28 @@ export const runs = sqliteTable(
        * handoff in execute-chat-run.ts).
        */
       queuedTurn?: boolean
+      /**
+       * The merge/pull request a `glab` / `gh` run was fired for.
+       *
+       * Persisted (rather than left in the in-memory channel context) because
+       * the pre-execution staleness check runs when the run leaves the queue —
+       * possibly in a later process lifetime — and needs to re-probe the forge
+       * for the request's current state.
+       */
+      gitTriggerOrigin?: {
+        provider: 'glab' | 'gh'
+        event: string
+        project: string
+        host?: string
+        number: number
+        /**
+         * Whether the run waited in the queue. Only a queued run can have gone
+         * stale, so an immediately-dispatched one skips the probe entirely.
+         * Absent on rows written before this field existed — treated as queued,
+         * which costs one redundant probe rather than missing a stale run.
+         */
+        queued?: boolean
+      }
       /** Persisted Slack/Discord context for queued and restart execution. */
       nativeChatContext?: Record<string, unknown>
       /** Durable remote identifiers resolved only after native event reservation/acknowledgement. */

--- a/apps/api/src/lib/__tests__/execute-chat-run.test.ts
+++ b/apps/api/src/lib/__tests__/execute-chat-run.test.ts
@@ -216,6 +216,11 @@ vi.mock('../pending-job-registry.js', () => ({
   sweepPendingContexts: vi.fn(),
 }))
 
+const mockGitTriggerRunSkipReason = vi.fn<() => Promise<string | null>>(async () => null)
+vi.mock('../git-trigger-run-preflight.js', () => ({
+  gitTriggerRunSkipReason: () => mockGitTriggerRunSkipReason(),
+}))
+
 const mockResolveNativeChatAttachments = vi.fn().mockResolvedValue([])
 vi.mock('../native-chat-attachments.js', () => ({
   resolveNativeChatAttachments: (...args: unknown[]) => mockResolveNativeChatAttachments(...args),
@@ -302,6 +307,7 @@ describe('executeChatRun', () => {
       return previous?.result?.chatId
     })
     mockResolveWorkDir.mockResolvedValue('/default/work/dir')
+    mockGitTriggerRunSkipReason.mockResolvedValue(null)
     mockResolveNativeChatAttachments.mockResolvedValue([])
     mockMaterializeForRun.mockImplementation(
       async (opts: { message: string; sources?: unknown[] | undefined }) => {
@@ -1228,5 +1234,162 @@ describe('executeChatRun', () => {
     await executeChatRun('agt_1', 'run_1')
 
     expect(mockFinishRunError).toHaveBeenCalled()
+  })
+
+  // ----------------------------------------------------------
+  // Git-trigger staleness preflight
+  // ----------------------------------------------------------
+
+  /**
+   * A poll fires while a merge request is open, but the Run may only reach
+   * execution minutes later — after the request was merged. The observed cost
+   * of letting it through is a full Agent turn (25K input tokens) spent to
+   * conclude "already merged, nothing to review". The preflight replaces that
+   * with one CLI call, so the checks below are about *where* it sits: before
+   * any workspace, attachment or Agent work.
+   */
+  const gitTriggerRun = {
+    ...baseRun,
+    triggerSource: 'glab',
+    executionMetadata: {
+      gitTriggerOrigin: {
+        provider: 'glab',
+        event: 'opened',
+        project: 'group/repo',
+        number: 42,
+      },
+    },
+  }
+
+  it('cancels a git-trigger run whose request was merged before it started', async () => {
+    mockGitTriggerRunSkipReason.mockResolvedValue('MR group/repo!42 was merged')
+    setupSelectSequence(baseAgent, gitTriggerRun, baseScmSource, undefined)
+
+    const { executeChatRun } = await import('../execute-chat-run.js')
+    await executeChatRun('agt_1', 'run_1')
+
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'cancelled',
+        result: { error: 'MR group/repo!42 was merged' },
+      }),
+    )
+    expect(mockExecuteWithRetry).not.toHaveBeenCalled()
+  })
+
+  it('runs the preflight before resolving a workspace or materializing attachments', async () => {
+    // The point of the check is saving work, so it must precede the expensive
+    // preparation — a cancelled run that already created a worktree has spent
+    // most of what the check exists to avoid.
+    mockGitTriggerRunSkipReason.mockResolvedValue('MR group/repo!42 was merged')
+    setupSelectSequence(baseAgent, gitTriggerRun, baseScmSource, undefined)
+
+    const { executeChatRun } = await import('../execute-chat-run.js')
+    await executeChatRun('agt_1', 'run_1')
+
+    expect(mockResolveWorkDir).not.toHaveBeenCalled()
+    expect(mockMaterializeForRun).not.toHaveBeenCalled()
+  })
+
+  it('releases the queue slot when a git-trigger run is skipped', async () => {
+    // Skipping must not leak the concurrency slot: the whole agent would stall
+    // behind a run that never executes.
+    mockGitTriggerRunSkipReason.mockResolvedValue('MR group/repo!42 was merged')
+    setupSelectSequence(baseAgent, gitTriggerRun, baseScmSource, undefined)
+
+    const { executeChatRun } = await import('../execute-chat-run.js')
+    await executeChatRun('agt_1', 'run_1')
+
+    expect(mockScheduleNext).toHaveBeenCalled()
+  })
+
+  it('executes normally when the request is still open', async () => {
+    mockGitTriggerRunSkipReason.mockResolvedValue(null)
+    setupSelectSequence(baseAgent, gitTriggerRun, baseScmSource, undefined)
+
+    const { executeChatRun } = await import('../execute-chat-run.js')
+    await executeChatRun('agt_1', 'run_1')
+
+    expect(mockExecuteWithRetry).toHaveBeenCalled()
+  })
+
+  it('does not probe a run that was dispatched immediately, never queued', async () => {
+    /**
+     * The manager runs `executeChatRun` directly when a slot was free, i.e.
+     * milliseconds after the poll listed the request as open — the staleness
+     * window this check exists for does not exist there. Probing anyway would
+     * spend a second forge call per run against the same rate limits the 30s
+     * interval floor was chosen to respect, and could essentially never fire.
+     */
+    setupSelectSequence(
+      baseAgent,
+      {
+        ...gitTriggerRun,
+        executionMetadata: {
+          gitTriggerOrigin: { ...gitTriggerRun.executionMetadata.gitTriggerOrigin, queued: false },
+        },
+      },
+      baseScmSource,
+      undefined,
+    )
+
+    const { executeChatRun } = await import('../execute-chat-run.js')
+    await executeChatRun('agt_1', 'run_1')
+
+    expect(mockGitTriggerRunSkipReason).not.toHaveBeenCalled()
+    expect(mockExecuteWithRetry).toHaveBeenCalled()
+  })
+
+  it('never probes for a run that has no git-trigger origin', async () => {
+    // Every other channel pays nothing for this feature.
+    setupSelectSequence(baseAgent, baseRun, baseScmSource, undefined)
+
+    const { executeChatRun } = await import('../execute-chat-run.js')
+    await executeChatRun('agt_1', 'run_1')
+
+    expect(mockGitTriggerRunSkipReason).not.toHaveBeenCalled()
+    expect(mockExecuteWithRetry).toHaveBeenCalled()
+  })
+
+  it('retries the cancellation transition rather than leaving the run stuck running', async () => {
+    /**
+     * Every caller invokes executeChatRun as `void executeChatRun(...)`, so a
+     * rejection here is an unhandled rejection nobody acts on — and the row
+     * stays 'running', pinning the agent's concurrency slot forever. The
+     * orphan reaper cannot recover it either: its verdict is instance
+     * ownership, and this instance is alive and heartbeating. With
+     * maxConcurrency 1 that parks the whole queue, which is why the sibling
+     * failRunBeforeLifecycle wraps the identical CAS in retryUntilSuccess.
+     */
+    vi.useFakeTimers()
+    mockGitTriggerRunSkipReason.mockResolvedValue('MR group/repo!42 was merged')
+    setupSelectSequence(baseAgent, gitTriggerRun, baseScmSource, undefined)
+    mockDbRun
+      .mockImplementationOnce(() => {
+        throw new Error('SQLITE_BUSY: database is locked')
+      })
+      .mockReturnValue({ changes: 1 })
+
+    const { executeChatRun } = await import('../execute-chat-run.js')
+    const pending = executeChatRun('agt_1', 'run_1')
+    await vi.advanceTimersByTimeAsync(1_000)
+    await expect(pending).resolves.toBeUndefined()
+
+    expect(mockUpdateSet).toHaveBeenCalledWith(expect.objectContaining({ status: 'cancelled' }))
+    // The slot is released only after the row actually reached a terminal state.
+    expect(mockCompleteExecutionLease).toHaveBeenCalledWith('run_1')
+    expect(mockScheduleNext).toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it('executes anyway when the preflight itself throws', async () => {
+    // Fail open: a broken probe must never cancel legitimate work.
+    mockGitTriggerRunSkipReason.mockRejectedValue(new Error('probe exploded'))
+    setupSelectSequence(baseAgent, gitTriggerRun, baseScmSource, undefined)
+
+    const { executeChatRun } = await import('../execute-chat-run.js')
+    await executeChatRun('agt_1', 'run_1')
+
+    expect(mockExecuteWithRetry).toHaveBeenCalled()
   })
 })

--- a/apps/api/src/lib/__tests__/git-trigger-manager.test.ts
+++ b/apps/api/src/lib/__tests__/git-trigger-manager.test.ts
@@ -48,6 +48,9 @@ vi.mock('../../db/client.js', () => {
         const resolve = () => {
           if (table.__name === 'agents') return agentRow
           const values = Object.fromEntries(eqCalls)
+          if (table.__name === 'runs') {
+            return runRows.find((candidate) => candidate.id === values.id)
+          }
           const key = `${values.agentId}|${values.channel}|${values.repoKey}`
           return stateRows.get(key)
         }
@@ -87,7 +90,22 @@ vi.mock('../../db/client.js', () => {
             }),
         }),
     }),
-    update: () => ({ set: () => ({ where: () => asyncQuery({ run: () => {} }) }) }),
+    // Run rows are mutated in place so a post-insert update (the queued marker)
+    // is observable; a no-op update would make that assertion vacuously read
+    // back the inserted value.
+    update: (table: { __name?: string }) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () =>
+          asyncQuery({
+            run: () => {
+              if (table.__name !== 'runs') return
+              const id = Object.fromEntries(eqCalls).id
+              const row = runRows.find((candidate) => candidate.id === id)
+              if (row) Object.assign(row, values)
+            },
+          }),
+      }),
+    }),
     delete: () => ({ where: () => asyncQuery({ run: () => {} }) }),
   }
   return { db }
@@ -101,7 +119,7 @@ vi.mock('../../db/schema.js', () => ({
     channel: 'channel',
     repoKey: 'repoKey',
   },
-  runs: { __name: 'runs', id: 'id' },
+  runs: { __name: 'runs', id: 'id', executionMetadata: 'executionMetadata' },
 }))
 
 vi.mock('drizzle-orm', () => ({
@@ -554,5 +572,104 @@ describe('config guards', () => {
   it('refuses to start on an invalid config', () => {
     gitTriggerManager.start('agt_1', 'glab', { provider: 'glab', repos: [] })
     expect(gitTriggerManager.getActiveJobKeys()).not.toContain('agt_1:glab')
+  })
+})
+
+describe('run origin persistence', () => {
+  /**
+   * The staleness preflight runs when the Run *executes*, which for a queued
+   * run is a different process lifetime from the poll that fired it. The
+   * in-memory channel context does not survive that, so the request identity
+   * has to be on the run row itself.
+   */
+  it('persists the fired request identity on the run row', async () => {
+    stateRows.set('agt_1|glab|group/repo', {
+      agentId: 'agt_1',
+      channel: 'glab',
+      repoKey: 'group/repo',
+      state: { requests: {}, polledAt: 'seed' },
+      lastError: null,
+    })
+    listOpenRequests.mockResolvedValue({ requests: [pr(42)], complete: true })
+
+    await pollOnce(config({ repos: [{ project: 'group/repo', host: 'gitlab.example.com' }] }))
+
+    expect(runRows).toHaveLength(1)
+    expect(runRows[0].executionMetadata).toMatchObject({
+      gitTriggerOrigin: {
+        provider: 'glab',
+        event: 'opened',
+        project: 'group/repo',
+        host: 'gitlab.example.com',
+        number: 42,
+      },
+    })
+  })
+
+  it('records the request own project under a group scope, not the watch entry', async () => {
+    // Under a group scope the entry names a namespace; probing that would ask
+    // the forge about a merge request that does not exist there.
+    stateRows.set('agt_1|glab|group:group', {
+      agentId: 'agt_1',
+      channel: 'glab',
+      repoKey: 'group:group',
+      state: { requests: {}, polledAt: 'seed' },
+      lastError: null,
+    })
+    listOpenRequests.mockResolvedValue({
+      requests: [pr(7, { project: 'group/sub/repo' })],
+      complete: true,
+    })
+
+    await pollOnce(config({ repos: [{ project: 'group', scope: 'group' }] }))
+
+    expect(runRows).toHaveLength(1)
+    expect(
+      (runRows[0].executionMetadata as { gitTriggerOrigin: { project: string } }).gitTriggerOrigin
+        .project,
+    ).toBe('group/sub/repo')
+  })
+})
+
+describe('run origin queued marker', () => {
+  /**
+   * The staleness preflight only makes sense for a run that waited in the
+   * queue. A run dispatched straight away starts milliseconds after the poll
+   * saw the request open, so probing it would double the channel's forge call
+   * volume to answer a question that cannot have changed.
+   */
+  function seedWarmState() {
+    stateRows.set('agt_1|glab|group/repo', {
+      agentId: 'agt_1',
+      channel: 'glab',
+      repoKey: 'group/repo',
+      state: { requests: {}, polledAt: 'seed' },
+      lastError: null,
+    })
+    listOpenRequests.mockResolvedValue({ requests: [pr(42)], complete: true })
+  }
+
+  it('marks a queued run so it is probed before execution', async () => {
+    seedWarmState()
+    tryAcquireSlot.mockReturnValue('queued')
+
+    await pollOnce()
+
+    expect(
+      (runRows[0].executionMetadata as { gitTriggerOrigin: { queued?: boolean } }).gitTriggerOrigin
+        .queued,
+    ).toBe(true)
+  })
+
+  it('marks an immediately-dispatched run so it is not probed', async () => {
+    seedWarmState()
+    tryAcquireSlot.mockReturnValue('acquired')
+
+    await pollOnce()
+
+    expect(
+      (runRows[0].executionMetadata as { gitTriggerOrigin: { queued?: boolean } }).gitTriggerOrigin
+        .queued,
+    ).toBe(false)
   })
 })

--- a/apps/api/src/lib/__tests__/git-trigger-request-state.test.ts
+++ b/apps/api/src/lib/__tests__/git-trigger-request-state.test.ts
@@ -1,0 +1,119 @@
+/**
+ * `fetchRequestState` — the pre-execution staleness probe for git-trigger runs.
+ *
+ * A trigger legitimately fires while a request is open, but the Run may only
+ * leave the queue minutes later — by which time the request can already be
+ * merged. This probe is what lets execution skip such a run before any tokens
+ * are spent, so its contract matters in one specific way: it must NEVER throw
+ * and must return 'unknown' (fail open) on every CLI failure shape, because a
+ * transient forge error must not cancel a legitimate run.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const runStatusProbe = vi.fn()
+vi.mock('../../engine/login-status-helper.js', () => ({
+  runStatusProbe: (...args: unknown[]) => runStatusProbe(...args),
+}))
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+import { fetchRequestState } from '../git-trigger-cli.js'
+
+function probeResult(overrides: Record<string, unknown> = {}) {
+  return { exitCode: 0, stdout: '', stderr: '', timedOut: false, notFound: false, ...overrides }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('fetchRequestState — glab', () => {
+  it('maps GitLab states to the live-state verdict', async () => {
+    for (const [state, expected] of [
+      ['opened', 'open'],
+      ['merged', 'merged'],
+      ['closed', 'closed'],
+      // 'locked' is a transient mid-merge state; treated as unknown so the
+      // caller fails open rather than cancelling on a state that can revert.
+      ['locked', 'unknown'],
+    ] as const) {
+      runStatusProbe.mockResolvedValue(probeResult({ stdout: JSON.stringify({ state }) }))
+      expect(await fetchRequestState('glab', 'group/sub/repo', 42)).toBe(expected)
+    }
+  })
+
+  it('queries the single-MR endpoint with the project path URL-encoded', async () => {
+    runStatusProbe.mockResolvedValue(probeResult({ stdout: '{"state":"opened"}' }))
+    await fetchRequestState('glab', 'group/sub/repo', 42)
+    expect(runStatusProbe).toHaveBeenCalledWith(
+      'glab',
+      ['api', 'projects/group%2Fsub%2Frepo/merge_requests/42'],
+      expect.anything(),
+    )
+  })
+
+  it('forwards the host through GITLAB_HOST', async () => {
+    runStatusProbe.mockResolvedValue(probeResult({ stdout: '{"state":"opened"}' }))
+    await fetchRequestState('glab', 'group/repo', 7, 'gitlab.example.com')
+    const opts = runStatusProbe.mock.calls[0][2] as { env: Record<string, string> }
+    expect(opts.env.GITLAB_HOST).toBe('gitlab.example.com')
+  })
+
+  it('tolerates a banner before the JSON body', async () => {
+    runStatusProbe.mockResolvedValue(
+      probeResult({
+        stdout:
+          'Warning: Multiple config files found. Only the first one will be used.\n{"state":"merged"}',
+      }),
+    )
+    expect(await fetchRequestState('glab', 'group/repo', 1)).toBe('merged')
+  })
+})
+
+describe('fetchRequestState — gh', () => {
+  it('distinguishes merged from closed-unmerged', async () => {
+    runStatusProbe.mockResolvedValue(
+      probeResult({ stdout: JSON.stringify({ state: 'closed', merged: true }) }),
+    )
+    expect(await fetchRequestState('gh', 'octo/repo', 5)).toBe('merged')
+
+    runStatusProbe.mockResolvedValue(
+      probeResult({ stdout: JSON.stringify({ state: 'closed', merged: false }) }),
+    )
+    expect(await fetchRequestState('gh', 'octo/repo', 5)).toBe('closed')
+
+    runStatusProbe.mockResolvedValue(
+      probeResult({ stdout: JSON.stringify({ state: 'open', merged: false }) }),
+    )
+    expect(await fetchRequestState('gh', 'octo/repo', 5)).toBe('open')
+  })
+
+  it('queries the REST pulls endpoint', async () => {
+    runStatusProbe.mockResolvedValue(probeResult({ stdout: '{"state":"open"}' }))
+    await fetchRequestState('gh', 'octo/repo', 5)
+    expect(runStatusProbe).toHaveBeenCalledWith(
+      'gh',
+      ['api', 'repos/octo/repo/pulls/5'],
+      expect.anything(),
+    )
+  })
+})
+
+describe('fetchRequestState — fail-open contract', () => {
+  it.each([
+    ['CLI not installed', { notFound: true }],
+    ['timeout', { timedOut: true }],
+    ['non-zero exit (404 body)', { exitCode: 1, stdout: '{"message":"404 Not Found"}' }],
+    ['unparsable stdout', { stdout: 'A new version of glab is available' }],
+    ['missing state field', { stdout: '{"iid":42}' }],
+  ])('returns unknown on %s', async (_label, overrides) => {
+    runStatusProbe.mockResolvedValue(probeResult(overrides))
+    expect(await fetchRequestState('glab', 'group/repo', 42)).toBe('unknown')
+  })
+
+  it('returns unknown when the probe itself rejects', async () => {
+    runStatusProbe.mockRejectedValue(new Error('spawn failed'))
+    expect(await fetchRequestState('glab', 'group/repo', 42)).toBe('unknown')
+  })
+})

--- a/apps/api/src/lib/__tests__/git-trigger-run-preflight.test.ts
+++ b/apps/api/src/lib/__tests__/git-trigger-run-preflight.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Pre-execution staleness decision for git-trigger runs.
+ *
+ * The rule under test: a run fired for `opened`/`updated`/`commented` describes
+ * an OPEN request, so if that request has left the open set by the time the run
+ * actually starts, executing it spends tokens on work that is already moot —
+ * and to the operator it looks like "a closed MR triggered my agent". A run
+ * fired for `closed` is the opposite: its subject is SUPPOSED to be gone, so it
+ * must never be skipped. Every ambiguous verdict fails open into "run it".
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fetchRequestState = vi.fn()
+vi.mock('../git-trigger-cli.js', () => ({
+  fetchRequestState: (...args: unknown[]) => fetchRequestState(...args),
+}))
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+import { gitTriggerRunSkipReason } from '../git-trigger-run-preflight.js'
+
+const origin = {
+  provider: 'glab' as const,
+  event: 'opened' as const,
+  project: 'group/repo',
+  number: 42,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('gitTriggerRunSkipReason', () => {
+  it('skips an opened-run whose request was merged before execution', async () => {
+    fetchRequestState.mockResolvedValue('merged')
+    const reason = await gitTriggerRunSkipReason(origin)
+    expect(reason).toMatch(/merged/)
+    expect(reason).toContain('group/repo')
+    expect(reason).toContain('42')
+  })
+
+  it('skips an updated-run whose request was closed unmerged', async () => {
+    fetchRequestState.mockResolvedValue('closed')
+    expect(await gitTriggerRunSkipReason({ ...origin, event: 'updated' })).toMatch(/closed/)
+  })
+
+  it('never probes for a closed-event run — its subject is supposed to be gone', async () => {
+    expect(await gitTriggerRunSkipReason({ ...origin, event: 'closed' })).toBeNull()
+    expect(fetchRequestState).not.toHaveBeenCalled()
+  })
+
+  it('runs when the request is still open', async () => {
+    fetchRequestState.mockResolvedValue('open')
+    expect(await gitTriggerRunSkipReason(origin)).toBeNull()
+  })
+
+  it('fails open on an unknown verdict', async () => {
+    fetchRequestState.mockResolvedValue('unknown')
+    expect(await gitTriggerRunSkipReason(origin)).toBeNull()
+  })
+
+  it('fails open when the probe rejects unexpectedly', async () => {
+    fetchRequestState.mockRejectedValue(new Error('boom'))
+    expect(await gitTriggerRunSkipReason(origin)).toBeNull()
+  })
+
+  it('forwards host and provider to the probe', async () => {
+    fetchRequestState.mockResolvedValue('open')
+    await gitTriggerRunSkipReason({ ...origin, provider: 'gh', host: 'ghe.example.com' })
+    expect(fetchRequestState).toHaveBeenCalledWith('gh', 'group/repo', 42, 'ghe.example.com')
+  })
+})

--- a/apps/api/src/lib/execute-chat-run.ts
+++ b/apps/api/src/lib/execute-chat-run.ts
@@ -15,6 +15,7 @@ import {
   materializeForRun,
   refsToSources,
 } from './attachment-materializer.js'
+import { gitTriggerRunSkipReason } from './git-trigger-run-preflight.js'
 import { WorktreeBranchLockedError, WorktreeDirtyError } from './git-workspace.js'
 import { createId } from './id.js'
 import { logger } from './logger.js'
@@ -77,6 +78,33 @@ export async function executeChatRun(
     logger.info({ runId, status: run.status }, 'Skipping execution for a non-running run')
     completeExecutionLease(runId)
     return
+  }
+
+  /**
+   * A `glab` / `gh` run fired for an OPEN request that has since been merged or
+   * closed is already moot — the poll saw it open, but the run only reaches
+   * execution once the queue and the preceding runs let it through, and a
+   * fast-moving repository merges well inside that window. Executing anyway
+   * costs a full Agent turn to conclude "already merged, nothing to review".
+   *
+   * Checked here, before the workspace, attachments and Agent config, because
+   * the entire point is to spend one CLI call instead of that turn. Fails open
+   * on any probe error, and never applies to a `closed`-event run.
+   */
+  const gitTriggerOrigin = run.executionMetadata?.gitTriggerOrigin
+  // `queued === false` means the manager dispatched this run straight away, so
+  // no meaningful time passed between the poll and now. Absent (older rows) is
+  // treated as queued: one redundant probe beats missing a stale run.
+  if (gitTriggerOrigin && gitTriggerOrigin.queued !== false) {
+    const skipReason = await gitTriggerRunSkipReason(gitTriggerOrigin).catch((err) => {
+      logger.warn({ err, runId, agentId }, 'git-trigger preflight failed; executing anyway')
+      return null
+    })
+    if (skipReason) {
+      logger.info({ runId, agentId, ...gitTriggerOrigin }, 'Skipping stale git-trigger run')
+      await cancelStaleGitTriggerRun(runId, agentId, skipReason)
+      return
+    }
   }
 
   // Native chat events persist their channel context before acknowledgement. Restore it when a
@@ -337,6 +365,62 @@ async function cleanupPreparedExecution(
     context: { type: 'run', runId, agentId, phase: 'pre-execution' },
   })
   completeExecutionLease(runId)
+}
+
+/**
+ * Terminalize a run whose triggering request finished before it started.
+ *
+ * `cancelled`, not `failed`: nothing went wrong, the work simply became
+ * unnecessary — and the run lists already separate the two, so an operator sees
+ * "skipped because the MR merged" rather than a red failure to investigate.
+ *
+ * The transition retries for the same reason `failRunBeforeLifecycle` does, and
+ * it is not optional here: every caller invokes `executeChatRun` as
+ * `void executeChatRun(...)`, so a rejected write is an unhandled rejection
+ * nobody acts on, leaving the row `running` and its concurrency slot pinned
+ * forever. The orphan reaper cannot clear it either — its verdict is instance
+ * ownership, and this instance is alive and heartbeating. At `maxConcurrency: 1`
+ * that parks the agent's entire queue.
+ */
+async function cancelStaleGitTriggerRun(
+  runId: string,
+  agentId: string,
+  reason: string,
+): Promise<void> {
+  let ownsTerminalTransition = false
+  await retryUntilSuccess(
+    async () => {
+      const transition = await db
+        .update(runs)
+        .set({ status: 'cancelled', result: { error: reason }, updatedAt: new Date() })
+        .where(and(eq(runs.id, runId), eq(runs.status, 'running')))
+        .returning({ id: runs.id })
+      ownsTerminalTransition = didChangeOneRow(transition)
+      if (ownsTerminalTransition) return
+
+      // Lost the CAS: someone else terminalized it. Settled either way, so stop.
+      const current = (
+        await db.select({ status: runs.status }).from(runs).where(eq(runs.id, runId)).limit(1)
+      )[0]
+      if (current?.status !== 'running') return
+      throw new Error('Run is still running after the staleness-cancellation transition')
+    },
+    {
+      initialDelayMs: 1_000,
+      maxDelayMs: 30_000,
+      onFailure: (transitionError, retryDelayMs) => {
+        logger.error(
+          { err: transitionError, runId, agentId, retryDelayMs },
+          'Failed to cancel a stale git-trigger run; retaining the workload lease and retrying',
+        )
+      },
+    },
+  )
+
+  await cleanupPreparedExecution(runId, agentId)
+  if (ownsTerminalTransition) {
+    void scheduleNext(taskQueueDb, agentId, (rid, aid) => void executeChatRun(aid, rid))
+  }
 }
 
 export async function failRunBeforeLifecycle(

--- a/apps/api/src/lib/git-trigger-cli.ts
+++ b/apps/api/src/lib/git-trigger-cli.ts
@@ -605,6 +605,63 @@ async function fetchGitHubNodes(project: string, host?: string): Promise<unknown
 }
 
 /**
+ * Live state of one merge/pull request, as reported by the forge right now.
+ *
+ * `unknown` is the deliberate answer to every failure shape — CLI missing,
+ * timeout, non-zero exit, unparsable output, an unrecognised state value
+ * (GitLab's transient `locked` included). The one caller uses this to decide
+ * whether a queued Run may be skipped, and a transient forge error must fail
+ * open into "run it" rather than silently cancelling legitimate work.
+ */
+export type GitTriggerRequestLiveState = 'open' | 'merged' | 'closed' | 'unknown'
+
+/**
+ * Fetch the current state of a single merge/pull request. Never throws.
+ *
+ * Exists for the pre-execution staleness check: a trigger fires while the
+ * request is open, but the Run may leave the queue minutes later, after the
+ * request was already merged. One cheap CLI call here is what lets execution
+ * decline before any tokens are spent.
+ */
+export async function fetchRequestState(
+  provider: GitTriggerProvider,
+  project: string,
+  number: number,
+  host?: string,
+): Promise<GitTriggerRequestLiveState> {
+  const binary = CLI_BINARY[provider]
+  const path =
+    provider === 'glab'
+      ? `projects/${encodeURIComponent(project)}/merge_requests/${number}`
+      : `repos/${project}/pulls/${number}`
+  try {
+    const result = await runStatusProbe(binary, ['api', path], {
+      timeoutMs: POLL_TIMEOUT_MS,
+      logTag: `git-trigger:${provider}`,
+      env: hostEnv(provider, host),
+    })
+    if (result.notFound || result.timedOut || result.exitCode !== 0) return 'unknown'
+
+    const parsed = extractJson(result.stdout) as { state?: unknown; merged?: unknown } | null
+    if (!parsed || typeof parsed !== 'object' || typeof parsed.state !== 'string') return 'unknown'
+
+    if (provider === 'glab') {
+      if (parsed.state === 'opened') return 'open'
+      if (parsed.state === 'merged') return 'merged'
+      if (parsed.state === 'closed') return 'closed'
+      return 'unknown'
+    }
+    // GitHub reports merged PRs as state=closed; `merged` carries the distinction.
+    if (parsed.state === 'open') return 'open'
+    if (parsed.state === 'closed') return parsed.merged === true ? 'merged' : 'closed'
+    return 'unknown'
+  } catch (err) {
+    logger.warn({ err, provider, project, number, host }, 'git-trigger: request state probe threw')
+    return 'unknown'
+  }
+}
+
+/**
  * Build the GitLab listing path for one watch entry and page.
  *
  * The three scopes are three collections, not three filters — GitLab exposes a

--- a/apps/api/src/lib/git-trigger-manager.ts
+++ b/apps/api/src/lib/git-trigger-manager.ts
@@ -187,6 +187,38 @@ async function pruneRemovedRepoStates(
   }
 }
 
+/**
+ * Clear the `queued` marker on a run that took a slot immediately.
+ *
+ * Best-effort: failing to clear it only costs that run one redundant forge
+ * probe, which must never be worth failing a dispatch over.
+ */
+async function markGitTriggerRunUnqueued(runId: string): Promise<void> {
+  try {
+    const [row] = await db
+      .select({ executionMetadata: runs.executionMetadata })
+      .from(runs)
+      .where(eq(runs.id, runId))
+      .limit(1)
+    const origin = row?.executionMetadata?.gitTriggerOrigin
+    if (!origin) return
+    await db
+      .update(runs)
+      .set({
+        executionMetadata: {
+          ...row.executionMetadata,
+          gitTriggerOrigin: { ...origin, queued: false },
+        },
+      })
+      .where(eq(runs.id, runId))
+  } catch (err) {
+    logger.warn(
+      { err, runId },
+      'git-trigger: could not clear the queued marker; run will be probed',
+    )
+  }
+}
+
 class GitTriggerManager {
   private jobs = new Map<string, NodeJS.Timeout>()
   /** Guards against a slow poll overlapping the next tick on the same channel. */
@@ -660,6 +692,27 @@ class GitTriggerManager {
       status: 'pending',
       triggerSource: provider,
       triggerUserName: channelResult.displayName ?? undefined,
+      /**
+       * Persisted so the pre-execution staleness check can still identify the
+       * request after the poll's process is gone. A queued run executes in a
+       * later lifetime, where the in-memory channel context no longer exists —
+       * and the whole point of that check is to catch a request merged during
+       * exactly that gap.
+       */
+      executionMetadata: {
+        gitTriggerOrigin: {
+          provider,
+          event,
+          project,
+          ...(repo.host ? { host: repo.host } : {}),
+          number: request.number,
+          // Overwritten below once the queue's verdict is known. Defaults to
+          // true so a crash between the insert and that update leaves the run
+          // probed rather than silently unchecked — one extra CLI call is the
+          // cheaper mistake.
+          queued: true,
+        },
+      },
     })
 
     registerPendingContext(runId, { channel: channelResult.ctx })
@@ -713,6 +766,15 @@ class GitTriggerManager {
       logger.info({ agentId: agent.id, provider, runId }, 'git-trigger: run queued')
       return 'dispatched'
     }
+
+    /**
+     * Dispatched immediately, so the request cannot have gone stale: execution
+     * starts milliseconds after the poll listed it as open. Recording that
+     * spares this run the pre-execution forge probe, which would otherwise
+     * double the channel's call volume to re-answer a question the poll just
+     * answered.
+     */
+    await markGitTriggerRunUnqueued(runId)
 
     executeChatRun(agent.id, runId).catch((err) =>
       logger.error({ err, agentId: agent.id, runId }, 'git-trigger: run execution failed'),

--- a/apps/api/src/lib/git-trigger-run-preflight.ts
+++ b/apps/api/src/lib/git-trigger-run-preflight.ts
@@ -1,0 +1,63 @@
+/**
+ * Pre-execution staleness check for `glab` / `gh` triggered runs.
+ *
+ * A trigger legitimately fires while a merge/pull request is open, but the Run
+ * may only leave the queue minutes later — and fast-moving repositories merge
+ * within a minute of opening. Executing then spends the Agent's tokens on a
+ * request that is already merged, which to the operator reads as "a closed MR
+ * triggered my agent even though I never subscribed to closed".
+ *
+ * The rule: a run fired for `opened` / `updated` / `commented` describes an
+ * OPEN request; if the request has left the open set by execution time, the
+ * run is skipped. A `closed`-event run is never checked — its subject is
+ * supposed to be gone. Every ambiguous verdict (CLI failure, transient state)
+ * fails open into "run it": a duplicate wake is visible and cheap next to a
+ * silently cancelled legitimate run.
+ */
+import type { GitTriggerProvider } from '@a2wave/shared'
+import { fetchRequestState } from './git-trigger-cli.js'
+import { logger } from './logger.js'
+
+/**
+ * Identity of the request one git-trigger run was fired for, as persisted on
+ * the run row.
+ *
+ * `event` is a plain string rather than `GitTriggerEvent`: this is read back
+ * out of a JSON column written by an older build, so it must describe what the
+ * column can actually hold. Only the `closed` value is behaviourally special
+ * and it is compared by value, so an unrecognised event degrades into the
+ * ordinary "probe it" path rather than a type error at the read site.
+ */
+export interface GitTriggerRunOrigin {
+  provider: GitTriggerProvider
+  event: string
+  project: string
+  number: number
+  host?: string
+}
+
+/**
+ * Why this run should be skipped, or null to execute it.
+ *
+ * Costs one CLI call (no tokens) and never throws.
+ */
+export async function gitTriggerRunSkipReason(origin: GitTriggerRunOrigin): Promise<string | null> {
+  if (origin.event === 'closed') return null
+
+  try {
+    const state = await fetchRequestState(
+      origin.provider,
+      origin.project,
+      origin.number,
+      origin.host,
+    )
+    if (state !== 'merged' && state !== 'closed') return null
+
+    const noun = origin.provider === 'glab' ? 'Merge request' : 'Pull request'
+    const ref = origin.provider === 'glab' ? '!' : '#'
+    return `${noun} ${origin.project}${ref}${origin.number} was ${state} before this run started; skipped the "${origin.event}" run to avoid spending tokens on a finished request.`
+  } catch (err) {
+    logger.warn({ err, ...origin }, 'git-trigger: preflight probe threw; failing open')
+    return null
+  }
+}

--- a/apps/web/src/content/manual/en/15-runs.md
+++ b/apps/web/src/content/manual/en/15-runs.md
@@ -11,13 +11,13 @@ A Run is a single execution record of an Agent. Regardless of the trigger method
 | `running` | Currently executing |
 | `completed` | Completed successfully |
 | `failed` | Errored during execution |
-| `cancelled` | Cancelled / evicted |
+| `cancelled` | Cancelled / evicted / its merge request was merged or closed while the run waited in the queue |
 
 Concurrency is controlled by the Agent's `maxConcurrency`: it runs immediately if a slot is free, otherwise it enters the queue.
 
 ## Trigger source and call provenance
 
-Every Run is tagged with its source: `debug` (Web debugging) / `api` / `feishu` / `slack` / `discord` / `a2a` / `schedule` / `oauth` / `chat_app` (chat page). The run list places all known provenance layers before the input intent in this order:
+Every Run is tagged with its source: `debug` (Web debugging) / `api` / `feishu` / `slack` / `discord` / `a2a` / `schedule` / `oauth` / `chat_app` (chat page) / `glab` (GitLab repository trigger) / `gh` (GitHub repository trigger). The run list places all known provenance layers before the input intent in this order:
 
 | Available information | Display example |
 |-----------------------|-----------------|

--- a/apps/web/src/content/manual/zh/15-runs.md
+++ b/apps/web/src/content/manual/zh/15-runs.md
@@ -11,13 +11,13 @@ Run 是 Agent 的一次执行记录。无论通过哪种方式触发，每次执
 | `running` | 正在执行 |
 | `completed` | 成功完成 |
 | `failed` | 执行出错 |
-| `cancelled` | 被取消 / 被驱逐 |
+| `cancelled` | 被取消 / 被驱逐 / 触发它的 MR 在排队期间已合并或关闭 |
 
 并发由 Agent 的 `maxConcurrency` 控制：有空槽立即跑，否则进队列。
 
 ## 触发来源与调用链
 
-每条 Run 都标注来源：`debug`（Web 调试）/ `api` / `feishu` / `slack` / `discord` / `a2a` / `schedule` / `oauth` / `chat_app`（对话网页）。运行列表会把已知的调用来源按以下顺序显示在输入意图前：
+每条 Run 都标注来源：`debug`（Web 调试）/ `api` / `feishu` / `slack` / `discord` / `a2a` / `schedule` / `oauth` / `chat_app`（对话网页）/ `glab`（GitLab 仓库触发）/ `gh`（GitHub 仓库触发）。运行列表会把已知的调用来源按以下顺序显示在输入意图前：
 
 | 可用信息 | 显示示例 |
 |----------|----------|

--- a/docs/agent/git-trigger-channels.md
+++ b/docs/agent/git-trigger-channels.md
@@ -48,6 +48,34 @@ requests across nine unrelated namespaces**, exhausting the whole tick page budg
 on its own. It could therefore never prove the open set was seen, and `closed`
 would have been permanently suspended.
 
+## Staleness preflight
+
+The poll sees an open request; the Run may only execute minutes later, behind
+the queue and whatever runs precede it. A repository that merges within a minute
+of opening therefore produces Runs whose subject is already merged — measured on
+a real deployment, one such Run burned 25K input + 46K cached tokens to conclude
+"already merged, nothing to review".
+
+So a queued Run re-probes its own request before doing any work, and terminates
+as **`cancelled`** if it left the open set. Three rules keep that from becoming a
+new failure mode:
+
+- Only for `opened` / `updated` / `commented`. A `closed`-event Run's subject is
+  *supposed* to be gone.
+- Only when the Run actually **queued**. An immediately-dispatched Run starts
+  milliseconds after the listing, so probing it would double the channel's forge
+  call volume to re-answer the question the poll just answered. The marker is
+  written by `triggerRun`; absent (pre-existing rows) means probe, since one
+  wasted call beats missing a stale Run.
+- **Fails open** on every ambiguous verdict — CLI missing, timeout, non-zero
+  exit, unparsable output, GitLab's transient `locked`. A broken probe must never
+  cancel legitimate work.
+
+The cancellation retries like any other terminal transition: callers invoke
+`executeChatRun` as `void`, so a rejected write is an unhandled rejection that
+would leave the row `running` with its concurrency slot pinned — and the orphan
+reaper cannot recover it, because the instance is alive and heartbeating.
+
 ## Paging budget
 
 - Wide scopes page up to `GIT_TRIGGER_MAX_PAGES`.


### PR DESCRIPTION
## Problem

A `glab` / `gh` poll fires while a merge request is open, but the Run may only execute minutes later — behind the queue and the runs before it. A repository that merges within a minute of opening therefore produces Runs whose subject is already merged.

Measured on a live deployment (`product-group/inner-product/ai/weknora!48`):

| Time | Event |
|------|-------|
| 13:34:06 | MR opened |
| 13:34:57 | Poll lists it as open, Run created with the `opened` intent |
| 13:35:03 | **MR merged** (57s after opening) |
| 13:36:35 | Run finally reaches execution |

The Agent then spent **25.4K input + 46.1K cached tokens** only to conclude "MR !48 当前状态已是 merged，按规则跳过评审". To the operator this reads as "a closed MR triggered my agent" even though the config only ever subscribed to `opened` and `updated`.

The subscription filtering itself is correct — `diffRepoState` gates `closed` inference on `wanted.has('closed')`, and no run in the sample fired a `closed` event. The cost is purely the gap between the poll and execution, which stacks the 60s poll interval, queue wait at `maxConcurrency: 1`, and the review task's own duration.

## Change

A queued Run re-probes its own request before doing any work and terminates as `cancelled` if it left the open set. One CLI call (no tokens) replaces a full Agent turn.

Three rules keep the check from becoming a new failure mode:

- **Only for `opened` / `updated` / `commented`.** A `closed`-event Run's subject is *supposed* to be gone.
- **Only when the Run actually queued.** An immediately-dispatched Run starts milliseconds after the listing, so probing it would double the channel's forge call volume to re-answer what the poll just answered. Rows predating this field are treated as queued — one wasted call beats missing a stale Run.
- **Fails open on every ambiguous verdict** — CLI missing, timeout, non-zero exit, unparsable output, GitLab's transient `locked`. A broken probe must never cancel legitimate work.

The cancellation retries like any other terminal transition. This one is load-bearing: every caller invokes `executeChatRun` as `void`, so a rejected write would be an unhandled rejection leaving the row `running` with its concurrency slot pinned — and the orphan reaper cannot recover it, since the instance is alive and heartbeating. At `maxConcurrency: 1` that parks the agent's entire queue.

## Scope note

This eliminates the wasted work, not the delay itself. Shortening the window is a separate tuning question (poll interval, `maxConcurrency`).

## Verification

TDD throughout, Red → Green. 26 new tests. The queued-marker test was mutation-tested (production line disabled → test fails as expected).

- **Lint** — 0 errors; 751 warnings, byte-identical to the pre-change baseline
- **Typecheck** — fully green, test files included
- **Test** — apps/api 6375 passed; shared 246 / cli 1131 / web 1024 / arch gates 258; 0 failures
- **DB** — JSON column type only; `db:generate:pg:migration` confirms no DDL change. Both dialect schemas regenerated

## Docs

- `docs/agent/git-trigger-channels.md` — new "Staleness preflight" section
- User manual (zh + en) — `cancelled` status meaning, plus `glab` / `gh` added to the trigger-source list, which had omitted them

🤖 Generated with [Claude Code](https://claude.com/claude-code)