### PR TITLE
fix(api): preserve complete Claude multi-result output

### DIFF
--- a/apps/api/src/engine/__tests__/claude-code-log-entries.test.ts
+++ b/apps/api/src/engine/__tests__/claude-code-log-entries.test.ts
@@ -233,7 +233,244 @@ describe('ClaudeCodeEngine onLogEntry callbacks', () => {
     )
     child.emit('close', 0)
     const result = await promise
+    expect(result.output).toBe('final')
     expect((result as { usage?: unknown }).usage).toEqual({ inputTokens: 100, outputTokens: 20 })
+  })
+
+  it('returns all distinct successful results while excluding streamed progress and child output', async () => {
+    const child = new MockChildProcess()
+    mockSpawn.mockReturnValue(child)
+    const engine = new ClaudeCodeEngine(engineConfig)
+    const onUpdate = vi.fn<(content: string) => void>()
+    const promise = getExecuteStream(engine)(
+      {
+        taskId: 'task_cc_multiple_results',
+        workDir: '/tmp',
+        prompt: 'hello',
+        onUpdate,
+        agentConfig: {},
+      },
+      'claude-sonnet-4-6',
+    )
+    child.stdout.write(
+      `${JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'Checking the repository...' }] },
+      })}\n`,
+    )
+    child.stdout.write(
+      `${JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        uuid: 'result-main',
+        origin: { kind: 'human' },
+        result: 'Main conclusion.',
+        usage: { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 50 },
+      })}\n`,
+    )
+    child.stdout.write(
+      `${JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'Background child report.' }] },
+      })}\n`,
+    )
+    child.stdout.write(
+      `${JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        uuid: 'result-task-notification',
+        origin: { kind: 'task-notification' },
+        result: 'Additional evidence.',
+        usage: { input_tokens: 40, output_tokens: 6, cache_creation_input_tokens: 10 },
+      })}\n`,
+    )
+    child.stdout.write(
+      `${JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        uuid: 'result-task-notification',
+        origin: { kind: 'task-notification' },
+        result: 'Additional evidence.',
+        usage: { input_tokens: 40, output_tokens: 6, cache_creation_input_tokens: 10 },
+      })}\n`,
+    )
+    child.stdout.write(
+      `${JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'Late background child output.' }] },
+      })}\n`,
+    )
+    child.emit('close', 0)
+
+    const result = await promise
+    expect(result.output).toBe('Main conclusion.\n\nAdditional evidence.')
+    expect(result.output).not.toContain('Checking the repository')
+    expect(result.output).not.toContain('Background child report')
+    expect(result.output).not.toContain('Late background child output')
+    expect((result as { usage?: unknown }).usage).toEqual({
+      inputTokens: 140,
+      outputTokens: 26,
+      cacheReadTokens: 50,
+      cacheWriteTokens: 10,
+    })
+    expect(onUpdate.mock.calls.at(-1)?.[0]).toBe(result.output)
+  })
+
+  it('prefers cumulative modelUsage so subagent tokens are included exactly once', async () => {
+    const child = new MockChildProcess()
+    mockSpawn.mockReturnValue(child)
+    const engine = new ClaudeCodeEngine(engineConfig)
+    const promise = getExecuteStream(engine)(
+      { taskId: 'task_cc_model_usage', workDir: '/tmp', prompt: 'hello', agentConfig: {} },
+      'claude-opus-5',
+    )
+    child.stdout.write(
+      `${JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        uuid: 'result-main',
+        origin: { kind: 'human' },
+        result: 'Main conclusion.',
+        usage: { input_tokens: 100, output_tokens: 20 },
+        modelUsage: {
+          'claude-opus-5': {
+            inputTokens: 130,
+            outputTokens: 24,
+            cacheReadInputTokens: 50,
+            cacheCreationInputTokens: 7,
+            costUSD: 1,
+          },
+          'claude-haiku-4-5': {
+            inputTokens: 20,
+            outputTokens: 5,
+            cacheReadInputTokens: 5,
+            cacheCreationInputTokens: 2,
+            costUSD: 0.1,
+          },
+        },
+      })}\n`,
+    )
+    const taskNotificationResult = {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      uuid: 'result-task-notification',
+      origin: { kind: 'task-notification' },
+      result: 'Additional evidence.',
+      usage: { input_tokens: 40, output_tokens: 6 },
+      modelUsage: {
+        'claude-opus-5': {
+          inputTokens: 150,
+          outputTokens: 30,
+          cacheReadInputTokens: 60,
+          cacheCreationInputTokens: 8,
+          costUSD: 1.2,
+        },
+        'claude-haiku-4-5': {
+          inputTokens: 25,
+          outputTokens: 7,
+          cacheReadInputTokens: 5,
+          cacheCreationInputTokens: 2,
+          costUSD: 0.2,
+        },
+      },
+    }
+    child.stdout.write(`${JSON.stringify(taskNotificationResult)}\n`)
+    child.stdout.write(`${JSON.stringify(taskNotificationResult)}\n`)
+    child.emit('close', 0)
+
+    const result = await promise
+    expect((result as { usage?: unknown }).usage).toEqual({
+      inputTokens: 175,
+      outputTokens: 37,
+      cacheReadTokens: 65,
+      cacheWriteTokens: 10,
+    })
+  })
+
+  it('replaces an earlier result when a later result is its complete cumulative snapshot', async () => {
+    const child = new MockChildProcess()
+    mockSpawn.mockReturnValue(child)
+    const engine = new ClaudeCodeEngine(engineConfig)
+    const promise = getExecuteStream(engine)(
+      { taskId: 'task_cc_result_snapshot', workDir: '/tmp', prompt: 'hello', agentConfig: {} },
+      'claude-sonnet-4-6',
+    )
+    child.stdout.write(
+      `${JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        uuid: 'result-main',
+        result: 'Main conclusion.',
+      })}\n`,
+    )
+    child.stdout.write(
+      `${JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        uuid: 'result-task-notification',
+        origin: { kind: 'task-notification' },
+        result: 'Main conclusion.\n\nAdditional evidence.',
+      })}\n`,
+    )
+    child.emit('close', 0)
+
+    const result = await promise
+    expect(result.output).toBe('Main conclusion.\n\nAdditional evidence.')
+  })
+
+  it('keeps internal peer results out of the public output while counting their usage', async () => {
+    const child = new MockChildProcess()
+    mockSpawn.mockReturnValue(child)
+    const engine = new ClaudeCodeEngine(engineConfig)
+    const promise = getExecuteStream(engine)(
+      { taskId: 'task_cc_result_origins', workDir: '/tmp', prompt: 'hello', agentConfig: {} },
+      'claude-sonnet-4-6',
+    )
+    child.stdout.write(
+      `${JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        uuid: 'result-main',
+        origin: { kind: 'human' },
+        result: 'Main conclusion.',
+        usage: { input_tokens: 10, output_tokens: 2 },
+      })}\n`,
+    )
+    child.stdout.write(
+      `${JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        uuid: 'result-peer',
+        origin: { kind: 'peer' },
+        result: 'Internal coordination reply.',
+        usage: { input_tokens: 4, output_tokens: 1 },
+      })}\n`,
+    )
+    child.stdout.write(
+      `${JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        uuid: 'result-task-notification',
+        origin: { kind: 'task-notification' },
+        result: 'Additional evidence.',
+        usage: { input_tokens: 6, output_tokens: 3 },
+      })}\n`,
+    )
+    child.emit('close', 0)
+
+    const result = await promise
+    expect(result.output).toBe('Main conclusion.\n\nAdditional evidence.')
+    expect((result as { usage?: unknown }).usage).toEqual({ inputTokens: 20, outputTokens: 6 })
   })
 
   it('attaches usage from an error result to the rejected Error', async () => {

--- a/apps/api/src/engine/__tests__/cli-invocation-surface.snapshot.json
+++ b/apps/api/src/engine/__tests__/cli-invocation-surface.snapshot.json
@@ -29,7 +29,7 @@
     },
     "claude-code": {
       "sourceFile": "apps/api/src/engine/claude-code.ts",
-      "minVersion": "2.1.47",
+      "minVersion": "2.1.208",
       "surface": [
         "--allowedTools=mcp__*",
         "--append-system-prompt",

--- a/apps/api/src/engine/__tests__/cli-invocation-surface.test.ts
+++ b/apps/api/src/engine/__tests__/cli-invocation-surface.test.ts
@@ -14,7 +14,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { PRESET_PROVIDERS, PROVIDER_KINDS, isVersionAtLeast } from '@a2wave/shared'
+import { isVersionAtLeast, PRESET_PROVIDERS, PROVIDER_KINDS } from '@a2wave/shared'
 import { describe, expect, it } from 'vitest'
 import { extractCliSurface } from './helpers/extract-cli-surface.js'
 
@@ -126,6 +126,10 @@ describe('CLI invocation surface contract', () => {
 })
 
 describe('Provider CLI lock pins', () => {
+  it('requires Claude Code with origin-aware reliable Result streams', () => {
+    expect(presetOf('claude-code')?.minVersion).toBe('2.1.208')
+  })
+
   it('never pins a version below the Provider minVersion floor', () => {
     for (const preset of PRESET_PROVIDERS) {
       const pinned = lock.providers.find((entry) => entry.kind === preset.kind)

--- a/apps/api/src/engine/__tests__/qoder-agent.test.ts
+++ b/apps/api/src/engine/__tests__/qoder-agent.test.ts
@@ -245,6 +245,30 @@ describe('QoderAgentEngine stream close handling', () => {
     expect(result.chatId).toBe('ses_new')
   })
 
+  it('keeps assistant output that arrives before an empty terminal result', async () => {
+    const child = new MockChildProcess()
+    mockSpawn.mockReturnValue(child)
+    const engine = new QoderAgentEngine(baseConfig)
+    const onUpdate = vi.fn<(content: string) => void>()
+    const p = getExecuteStream(engine)(
+      { taskId: 't', workDir: '/tmp', prompt: 'hi', onUpdate, agentConfig: {} },
+      'auto',
+    )
+    child.stdout.write(line({ type: 'result', is_error: false, result: 'Main conclusion.' }))
+    child.stdout.write(
+      line({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: '\n\nAdditional evidence.' }] },
+      }),
+    )
+    child.stdout.write(line({ type: 'result', subtype: 'success', is_error: false }))
+    child.emit('close', 0)
+
+    const result = await p
+    expect(result.output).toBe('Main conclusion.\n\nAdditional evidence.')
+    expect(onUpdate).toHaveBeenLastCalledWith(result.output)
+  })
+
   it('does not report placeholder usage from Qoder credit-based billing', async () => {
     const child = new MockChildProcess()
     mockSpawn.mockReturnValue(child)

--- a/apps/api/src/engine/__tests__/trae-agent.test.ts
+++ b/apps/api/src/engine/__tests__/trae-agent.test.ts
@@ -271,6 +271,30 @@ describe('TraeAgentEngine stream close handling', () => {
     expect(result.chatId).toBe('ses_new')
   })
 
+  it('keeps assistant output that arrives before an empty terminal result', async () => {
+    const child = new MockChildProcess()
+    mockSpawn.mockReturnValue(child)
+    const engine = new TraeAgentEngine(baseConfig)
+    const onUpdate = vi.fn<(content: string) => void>()
+    const p = getExecuteStream(engine)(
+      { taskId: 't', workDir: '/tmp', prompt: 'hi', onUpdate, agentConfig: {} },
+      'kimi-k2',
+    )
+    child.stdout.write(line({ type: 'result', is_error: false, result: 'Main conclusion.' }))
+    child.stdout.write(
+      line({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: '\n\nAdditional evidence.' }] },
+      }),
+    )
+    child.stdout.write(line({ type: 'result', subtype: 'success', is_error: false }))
+    child.emit('close', 0)
+
+    const result = await p
+    expect(result.output).toBe('Main conclusion.\n\nAdditional evidence.')
+    expect(onUpdate).toHaveBeenLastCalledWith(result.output)
+  })
+
   it('result usage is normalized and passed through to ExecuteResult.usage', async () => {
     const child = new MockChildProcess()
     mockSpawn.mockReturnValue(child)

--- a/apps/api/src/engine/claude-code.ts
+++ b/apps/api/src/engine/claude-code.ts
@@ -37,7 +37,7 @@ import type {
   StreamExecuteRequest,
   TokenUsage,
 } from './types.js'
-import { extractClaudeStyleUsage } from './usage.js'
+import { accumulateUsage, extractClaudeStyleUsage } from './usage.js'
 
 /** Heartbeat interval for in-flight tool calls (ms). */
 const TOOL_HEARTBEAT_INTERVAL_MS = 20_000
@@ -240,6 +240,87 @@ function tryParseJson(text: string): Record<string, unknown> | null {
   } catch {
     return null
   }
+}
+
+const CLAUDE_USAGE_FIELDS = [
+  'inputTokens',
+  'outputTokens',
+  'reasoningTokens',
+  'cacheReadTokens',
+  'cacheWriteTokens',
+] as const
+
+/** Keep the most complete usage snapshot when one Result UUID is replayed. */
+function mergeClaudeResultUsage(previous: TokenUsage | undefined, next: TokenUsage): TokenUsage {
+  const merged: TokenUsage = { ...previous }
+  for (const field of CLAUDE_USAGE_FIELDS) {
+    const value = next[field]
+    if (typeof value !== 'number') continue
+    merged[field] = Math.max(previous?.[field] ?? 0, value)
+  }
+  return merged
+}
+
+/** Sum per-turn Result usage into the usage total for this one CLI execution. */
+function sumClaudeResultUsage(
+  usageByUuid: ReadonlyMap<string, TokenUsage>,
+  legacyUsage: TokenUsage | undefined,
+): TokenUsage | undefined {
+  let total = legacyUsage
+  for (const usage of usageByUuid.values()) total = accumulateUsage(total, usage)
+  return total
+}
+
+/** Aggregate the SDK's cumulative, whole-agent-tree model usage snapshot. */
+function extractClaudeModelUsage(data: Record<string, unknown>): TokenUsage | undefined {
+  const modelUsage =
+    data.modelUsage && typeof data.modelUsage === 'object' && !Array.isArray(data.modelUsage)
+      ? (data.modelUsage as Record<string, unknown>)
+      : undefined
+  if (!modelUsage) return undefined
+
+  let total: TokenUsage | undefined
+  for (const rawUsage of Object.values(modelUsage)) {
+    if (!rawUsage || typeof rawUsage !== 'object' || Array.isArray(rawUsage)) continue
+    const usage = rawUsage as Record<string, unknown>
+    const normalized: TokenUsage = {}
+    if (typeof usage.inputTokens === 'number') normalized.inputTokens = usage.inputTokens
+    if (typeof usage.outputTokens === 'number') normalized.outputTokens = usage.outputTokens
+    if (typeof usage.cacheReadInputTokens === 'number') {
+      normalized.cacheReadTokens = usage.cacheReadInputTokens
+    }
+    if (typeof usage.cacheCreationInputTokens === 'number') {
+      normalized.cacheWriteTokens = usage.cacheCreationInputTokens
+    }
+    total = accumulateUsage(total, normalized)
+  }
+  return total
+}
+
+/**
+ * Compose successful Result turns without losing background-task continuations.
+ * A later cumulative snapshot replaces the text it already contains; unrelated
+ * turns are appended, and exact replays are displayed only once.
+ */
+function composeClaudeResultText(resultTexts: Iterable<string>): string {
+  let output = ''
+  const seen = new Set<string>()
+  for (const rawText of resultTexts) {
+    const text = rawText.trim()
+    if (!text || seen.has(text)) continue
+    seen.add(text)
+    if (!output) {
+      output = text
+      continue
+    }
+    if (text.startsWith(`${output}\n`)) {
+      output = text
+      continue
+    }
+    if (output.startsWith(`${text}\n`)) continue
+    output = `${output}\n\n${text}`
+  }
+  return output
 }
 
 export interface ClaudeCodeEngineConfig extends CliEngineBaseConfig {
@@ -663,10 +744,16 @@ export class ClaudeCodeEngine extends BaseCliAgentEngine {
 
     let sessionId = inputChatId
     let outputBuffer = ''
+    let resultOutput = ''
     let resultReceived = false
     let resultIsError = false
     let resultErrorText = ''
-    let lastUsage: TokenUsage | undefined
+    let totalUsage: TokenUsage | undefined
+    let cumulativeModelUsage: TokenUsage | undefined
+    let legacyUsage: TokenUsage | undefined
+    const resultUsageByUuid = new Map<string, TokenUsage>()
+    const primaryResultTexts = new Map<string, string>()
+    const taskNotificationResultTexts = new Map<string, string>()
     // Map callId -> toolName so terminal tool_call entries carry the name
     // the UI renders. CC's stream-json doesn't repeat the toolName on the
     // tool_result message, and the timeline component displays toolName
@@ -810,12 +897,60 @@ export class ClaudeCodeEngine extends BaseCliAgentEngine {
         case 'result': {
           resultReceived = true
           resultIsError = data.is_error === true
-          // A later result without usage must not clear already captured usage.
+          const resultUuid = typeof data.uuid === 'string' && data.uuid ? data.uuid : undefined
+          const origin =
+            data.origin && typeof data.origin === 'object' && !Array.isArray(data.origin)
+              ? (data.origin as Record<string, unknown>)
+              : undefined
+          // The SDK defines an absent origin on a user-triggered turn as human.
+          // Startup failures can also omit it, but those take the error path.
+          const originKind = typeof origin?.kind === 'string' ? origin.kind : 'human'
           const usage = extractClaudeStyleUsage(data)
-          if (usage) lastUsage = usage
+          if (usage) {
+            if (resultUuid) {
+              resultUsageByUuid.set(
+                resultUuid,
+                mergeClaudeResultUsage(resultUsageByUuid.get(resultUuid), usage),
+              )
+            } else {
+              // Current locked Claude Code versions provide UUIDs. For legacy
+              // streams, preserve the latest/most-complete snapshot rather
+              // than guessing that repeated terminal frames are new turns.
+              legacyUsage = mergeClaudeResultUsage(legacyUsage, usage)
+            }
+          }
+          const modelUsage = extractClaudeModelUsage(data)
+          if (modelUsage) {
+            // modelUsage is cumulative for the whole CLI call and includes
+            // subagents. Keep the most complete snapshot instead of summing
+            // Result frames, which would count earlier turns more than once.
+            cumulativeModelUsage = mergeClaudeResultUsage(cumulativeModelUsage, modelUsage)
+          }
+          totalUsage = cumulativeModelUsage ?? sumClaudeResultUsage(resultUsageByUuid, legacyUsage)
           const resultText = typeof data.result === 'string' ? data.result : ''
           if (resultText) {
-            outputBuffer = resultText.trim()
+            if (data.is_error === true) {
+              outputBuffer = resultText.trim()
+            } else {
+              const normalizedResultText = resultText.trim()
+              const resultKey = resultUuid
+                ? `uuid:${resultUuid}`
+                : `anonymous:${originKind}:${normalizedResultText}`
+              if (originKind === 'human') {
+                primaryResultTexts.set(resultKey, normalizedResultText)
+              } else if (originKind === 'task-notification') {
+                taskNotificationResultTexts.set(resultKey, normalizedResultText)
+              } else {
+                // peer/coordinator/channel turns are internal orchestration
+                // traffic: retain their usage and log entry, not their text.
+              }
+              const primaryResultText = Array.from(primaryResultTexts.values()).at(-1)
+              resultOutput = composeClaudeResultText([
+                ...(primaryResultText ? [primaryResultText] : []),
+                ...taskNotificationResultTexts.values(),
+              ])
+              outputBuffer = resultOutput
+            }
             onUpdate?.(outputBuffer)
           }
           if (resultIsError) {
@@ -833,7 +968,7 @@ export class ClaudeCodeEngine extends BaseCliAgentEngine {
             type: 'result',
             subtype: resultIsError ? 'error' : 'success',
             durationMs: typeof data.duration_ms === 'number' ? data.duration_ms : undefined,
-            ...(lastUsage ? { usage: lastUsage } : {}),
+            ...(usage ? { usage } : {}),
             ...(fastModeState ? { fastModeState } : {}),
             ts: Date.now(),
           })
@@ -860,7 +995,7 @@ export class ClaudeCodeEngine extends BaseCliAgentEngine {
       // CC's main stream is stdout, but some errors land on stderr — parse
       // those lines too (the base also collects them for the settle verdict).
       parseStderrLines: true,
-      getUsage: () => lastUsage,
+      getUsage: () => totalUsage,
       onSpawned: () => onLogEntry?.({ type: 'system', subtype: 'spawned', ts: Date.now() }),
       cleanup: () => heartbeat.stop(),
       settle: ({ exitCode, stderr }) => {
@@ -868,24 +1003,26 @@ export class ClaudeCodeEngine extends BaseCliAgentEngine {
           return {
             ok: false,
             error: new Error(resultErrorText || stderr || 'Claude Code stream execution failed'),
-            usage: lastUsage,
+            usage: totalUsage,
           }
         }
         if (resultReceived || exitCode === 0) {
+          const finalOutput = resultOutput || outputBuffer
+          if (resultOutput && finalOutput !== outputBuffer) onUpdate?.(finalOutput)
           return {
             ok: true,
             result: {
               success: true,
-              output: outputBuffer,
+              output: finalOutput,
               chatId: sessionId,
-              ...(lastUsage ? { usage: lastUsage } : {}),
+              ...(totalUsage ? { usage: totalUsage } : {}),
             },
           }
         }
         return {
           ok: false,
           error: new Error(formatExitError(exitCode ?? 1, stderr)),
-          usage: lastUsage,
+          usage: totalUsage,
         }
       },
     })

--- a/packages/shared/src/schemas/provider.ts
+++ b/packages/shared/src/schemas/provider.ts
@@ -281,14 +281,13 @@ const PRESET_PROVIDER_DEFS: PresetProvider[] = [
     checkScript: 'claude --version',
     skillsDir: '.claude/skills',
     mcpConfigPath: '.mcp.json',
-    // `--effort` first shipped in 2.1.47 (2.1.45 rejects it; 2.1.46 was never
-    // published). An unknown option is fatal to the CLI's argument parser, so a
-    // build below this floor fails at spawn the moment an Agent configures a
-    // reasoning level. `--settings` is older and already present at that
-    // version, so one floor covers both. The floor guards the FLAG only: which
-    // levels are legal is a property of the model and is discovered per
-    // credential — 2.1.47 itself advertised just low/medium/high.
-    minVersion: '2.1.47',
+    // Result `origin` shipped in 2.1.126 and lets the stream adapter separate
+    // the user answer from task-notification follow-ups and internal Agent
+    // traffic. Version 2.1.208 then fixed truncated stream-json output and
+    // missing Result frames for large `claude -p` responses. Both are required
+    // for the adapter's lossless final-output contract. (`--effort` and inline
+    // `--settings`, the other versioned flags used here, predate this floor.)
+    minVersion: '2.1.208',
   },
   {
     kind: 'codex',


### PR DESCRIPTION
## Summary

Fix incomplete Claude Code output when a single execution emits multiple Result messages.

- Treat the terminal Result as the authoritative execution state.
- Compose the latest human Result with distinct `task-notification` follow-ups.
- Exclude internal `peer`, `coordinator`, and `channel` results from public output while retaining their token usage.
- Prefer cumulative whole-agent-tree `modelUsage`, with UUID-aware per-Result usage as a fallback.
- Require Claude Code 2.1.208 for reliable origin-aware Result streams.
- Add regressions ensuring Qoder and Trae retain assistant output when their terminal Result has no text.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore

## Testing checklist

- [ ] `pnpm lint` passes (targeted Biome check passed with 0 errors)
- [x] `pnpm typecheck` passes
- [ ] `pnpm test` passes; focused engine regression tests pass (79/79)
- [x] E2E not applicable: this is an engine stream aggregation change with no route or UI changes
- [x] User-facing docs, i18n copy, and in-app manual updates are not applicable

## AI assistance disclosure

- [ ] This change was substantially AI-generated. If checked, I confirm I understand the code and have tested it myself (see CONTRIBUTING.md).

## Additional notes

The full test suite passed before synchronizing with the latest `main`. After synchronization, the affected engine suites, typecheck, targeted Biome checks, and diff validation were rerun successfully.

The implementation intentionally separates execution state from output composition: the terminal Result determines success or failure, while successful human and task-notification Result text is composed without exposing internal orchestration messages.