### PR TITLE
feat(telegram): add Telegram bot channel at parity with Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Turn the agent CLIs you already use into shared services your whole team can call.**
 
 Describe an Agent in plain language, bind a model provider, publish it to Feishu,
-Slack, Discord, an HTTP API, or a schedule. No flowcharts, no glue code.
+Slack, Discord, Telegram, an HTTP API, or a schedule. No flowcharts, no glue code.
 
 [![CI](https://github.com/LilithGames/a2wave/actions/workflows/ci.yml/badge.svg)](https://github.com/LilithGames/a2wave/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
@@ -24,7 +24,7 @@ Slack, Discord, an HTTP API, or a schedule. No flowcharts, no glue code.
 
 a2wave turns the agent CLIs you already use — **Claude Code, Cursor Agent, OpenAI
 Codex, and more** — into shared, governed services, reachable from Feishu, Slack,
-Discord, an HTTP API, or a schedule.
+Discord, Telegram, an HTTP API, or a schedule.
 
 Describe an Agent in natural language, bind a model provider, extend it with Skills
 and MCP servers, publish. a2wave handles credential injection, run queueing, audit
@@ -54,7 +54,7 @@ rebuild its reasoning as a graph.
   OpenCode, Qoder, Trae, Kimi and Pi are interchangeable execution engines,
   installed on demand from a pinned, checksum-verified lockfile.
 - 🌊 **Publish to multiple channels** — one Agent, reachable via HTTP API, Feishu,
-  Slack, Discord, A2A, schedules, GitLab / GitHub repository triggers, and a
+  Slack, Discord, Telegram, A2A, schedules, GitLab / GitHub repository triggers, and a
   first-party chat page.
 - 🖥️ **Web dashboard** — build and publish Agents, manage providers, Skills, MCP
   servers and SCM sources, watch runs, and browse the audit trail from one console.
@@ -159,7 +159,7 @@ port is not published to the host.
 
 ## Channels
 
-A published Agent is reachable through HTTP API, Feishu, Slack, Discord, the A2A
+A published Agent is reachable through HTTP API, Feishu, Slack, Discord, Telegram, the A2A
 protocol, scheduled triggers, GitLab / GitHub repository triggers, and the
 first-party chat page.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 **把你已经在用的 Agent CLI，变成整个团队都能调用的共享服务。**
 
-用自然语言描述一个 Agent，绑定模型 Provider，发布到飞书、Slack、Discord、HTTP API
+用自然语言描述一个 Agent，绑定模型 Provider，发布到飞书、Slack、Discord、Telegram、HTTP API
 或定时任务。不画流程图，不写胶水代码。
 
 [![CI](https://github.com/LilithGames/a2wave/actions/workflows/ci.yml/badge.svg)](https://github.com/LilithGames/a2wave/actions/workflows/ci.yml)
@@ -23,7 +23,7 @@
 ## a2wave 是什么
 
 a2wave 把你已经在用的 Agent CLI——**Claude Code、Cursor Agent、OpenAI Codex 等**——变成
-受治理的共享服务，可从飞书、Slack、Discord、HTTP API 或定时任务直接触达。
+受治理的共享服务，可从飞书、Slack、Discord、Telegram、HTTP API 或定时任务直接触达。
 
 用自然语言描述一个 Agent，绑定模型 Provider，用 Skills 和 MCP Server 扩展能力，然后发布。
 凭证注入、运行排队、审计留痕、权限控制和消息投递，都交给 a2wave——全部在内置的 Web
@@ -49,7 +49,7 @@ a2wave 把你已经在用的 Agent CLI——**Claude Code、Cursor Agent、OpenA
 
 - 🤖 **自带 Agent CLI** —— Claude Code、Cursor Agent、OpenAI Codex、OpenCode、Qoder、
   Trae、Kimi、Pi 均可作为可互换的执行引擎，按需从锁定并校验哈希的 lockfile 安装。
-- 🌊 **一次发布，多渠道触达** —— 同一个 Agent 可通过 HTTP API、飞书、Slack、Discord、
+- 🌊 **一次发布，多渠道触达** —— 同一个 Agent 可通过 HTTP API、飞书、Slack、Discord、Telegram、
   A2A 协议、定时任务、GitLab / GitHub 仓库触发和平台自建聊天页触达。
 - 🖥️ **Web 控制台** —— 构建与发布 Agent、管理 Provider / Skill / MCP Server / 代码源、
   查看运行记录与审计留痕，都在同一个 Web 界面完成。
@@ -142,7 +142,7 @@ sidecar 容器，或用 `--database-url postgres://…` 指向外部数据库。
 
 ## 发布渠道
 
-已发布的 Agent 可通过 HTTP API、飞书、Slack、Discord、A2A 协议、定时任务、
+已发布的 Agent 可通过 HTTP API、飞书、Slack、Discord、Telegram、A2A 协议、定时任务、
 GitLab / GitHub 仓库触发，以及平台自建的聊天页触达。
 
 > 飞书渠道目前支持飞书（feishu.cn）应用；Lark 国际版（larksuite.com）暂不可配置。

--- a/apps/api/drizzle-pg/0017_telegram_channel.sql
+++ b/apps/api/drizzle-pg/0017_telegram_channel.sql
@@ -1,0 +1,3 @@
+DROP INDEX "runs_native_chat_event_unique";--> statement-breakpoint
+ALTER TABLE "agents" ADD COLUMN "telegram_config" jsonb;--> statement-breakpoint
+CREATE UNIQUE INDEX "runs_native_chat_event_unique" ON "runs" USING btree ("initiator_agent_id","trigger_source","trigger_event_id") WHERE trigger_source IN ('slack', 'discord', 'telegram', 'qq_official') AND trigger_event_id IS NOT NULL;

--- a/apps/api/drizzle-pg/meta/0017_snapshot.json
+++ b/apps/api/drizzle-pg/meta/0017_snapshot.json
@@ -1,0 +1,4278 @@
+{
+  "id": "157eac98-f46a-48f3-8645-a34d0ee172c6",
+  "prevId": "39d75107-b1a6-4545-ada8-89396dc30df0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.a2a_tasks": {
+      "name": "a2a_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "a2a_tasks_updated_at_idx": {
+          "name": "a2a_tasks_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_members": {
+      "name": "agent_members",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_members_user_id_idx": {
+          "name": "agent_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_members_agent_id_agents_id_fk": {
+          "name": "agent_members_agent_id_agents_id_fk",
+          "tableFrom": "agent_members",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_members_user_id_users_id_fk": {
+          "name": "agent_members_user_id_users_id_fk",
+          "tableFrom": "agent_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_members_created_by_users_id_fk": {
+          "name": "agent_members_created_by_users_id_fk",
+          "tableFrom": "agent_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_members_agent_id_user_id_pk": {
+          "name": "agent_members_agent_id_user_id_pk",
+          "columns": [
+            "agent_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cursor'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'🤖'"
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_group_ids": {
+          "name": "skill_group_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_server_ids": {
+          "name": "mcp_server_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kb_document_ids": {
+          "name": "kb_document_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_status": {
+          "name": "publish_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "provider_api_key": {
+          "name": "provider_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_base_url": {
+          "name": "provider_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_oauth_token": {
+          "name": "provider_oauth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_provider_api_key": {
+          "name": "memory_provider_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_api_key": {
+          "name": "embedding_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'apiKey'"
+        },
+        "endpoint_api_key": {
+          "name": "endpoint_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_auth_type": {
+          "name": "publish_auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'api_key'"
+        },
+        "publish_ip_whitelist": {
+          "name": "publish_ip_whitelist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_description": {
+          "name": "publish_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_channels": {
+          "name": "publish_channels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_access_mode": {
+          "name": "oauth_access_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'feishu_scope'"
+        },
+        "oauth_allowed_emails": {
+          "name": "oauth_allowed_emails",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2a_skills": {
+          "name": "a2a_skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2a_route_targets": {
+          "name": "a2a_route_targets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_local_child_output": {
+          "name": "show_local_child_output",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_remote_child_output": {
+          "name": "show_remote_child_output",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feishu_config": {
+          "name": "feishu_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_config": {
+          "name": "slack_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_config": {
+          "name": "discord_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_config": {
+          "name": "telegram_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq_official_config": {
+          "name": "qq_official_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_app_config": {
+          "name": "chat_app_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_policy": {
+          "name": "artifact_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_config": {
+          "name": "schedule_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "glab_config": {
+          "name": "glab_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gh_config": {
+          "name": "gh_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_type": {
+          "name": "workspace_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'temp'"
+        },
+        "scm_source_id": {
+          "name": "scm_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "a2a_auth_type": {
+          "name": "a2a_auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api_key'"
+        },
+        "a2a_endpoint_api_key": {
+          "name": "a2a_endpoint_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trust_forwarded_identity": {
+          "name": "trust_forwarded_identity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "schedule_run_as_owner": {
+          "name": "schedule_run_as_owner",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "schedule_run_as_user_id": {
+          "name": "schedule_run_as_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agents_user_id_idx": {
+          "name": "agents_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_provider_id_providers_id_fk": {
+          "name": "agents_provider_id_providers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_scm_source_id_scm_sources_id_fk": {
+          "name": "agents_scm_source_id_scm_sources_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "scm_sources",
+          "columnsFrom": [
+            "scm_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_schedule_run_as_user_id_users_id_fk": {
+          "name": "agents_schedule_run_as_user_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "schedule_run_as_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_user_id_users_id_fk": {
+          "name": "agents_user_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifact_shares": {
+      "name": "artifact_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artifact_shares_artifact_id_idx": {
+          "name": "artifact_shares_artifact_id_idx",
+          "columns": [
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_shares_expires_at_idx": {
+          "name": "artifact_shares_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_shares_artifact_id_artifacts_id_fk": {
+          "name": "artifact_shares_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_shares",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_shares_created_by_users_id_fk": {
+          "name": "artifact_shares_created_by_users_id_fk",
+          "tableFrom": "artifact_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'file'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artifacts_run_id_idx": {
+          "name": "artifacts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_user_id_idx": {
+          "name": "artifacts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_expires_at_idx": {
+          "name": "artifacts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_run_id_runs_id_fk": {
+          "name": "artifacts_run_id_runs_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifacts_agent_id_agents_id_fk": {
+          "name": "artifacts_agent_id_agents_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifacts_user_id_users_id_fk": {
+          "name": "artifacts_user_id_users_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment_refs": {
+      "name": "attachment_refs",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "attachment_refs_token_idx": {
+          "name": "attachment_refs_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_refs_run_id_runs_id_fk": {
+          "name": "attachment_refs_run_id_runs_id_fk",
+          "tableFrom": "attachment_refs",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "attachment_refs_token_run_id_pk": {
+          "name": "attachment_refs_token_run_id_pk",
+          "columns": [
+            "token",
+            "run_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_action_created_at_idx": {
+          "name": "audit_logs_action_created_at_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_user_id_created_at_idx": {
+          "name": "audit_logs_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_resource_created_at_idx": {
+          "name": "audit_logs_resource_created_at_idx",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_messages_run_id_idx": {
+          "name": "chat_messages_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_run_id_runs_id_fk": {
+          "name": "chat_messages_run_id_runs_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_installations": {
+      "name": "cli_installations",
+      "schema": "",
+      "columns": {
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "installed_version": {
+          "name": "installed_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_output": {
+          "name": "last_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cli_tokens_user_id_idx": {
+          "name": "cli_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_tokens_user_id_users_id_fk": {
+          "name": "cli_tokens_user_id_users_id_fk",
+          "tableFrom": "cli_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_hash_unique": {
+          "name": "cli_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_authorizations": {
+      "name": "device_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code_hash": {
+          "name": "device_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "device_authorizations_expires_at_idx": {
+          "name": "device_authorizations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_authorizations_user_id_users_id_fk": {
+          "name": "device_authorizations_user_id_users_id_fk",
+          "tableFrom": "device_authorizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_authorizations_device_code_hash_unique": {
+          "name": "device_authorizations_device_code_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code_hash"
+          ]
+        },
+        "device_authorizations_user_code_unique": {
+          "name": "device_authorizations_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluation_cases": {
+      "name": "evaluation_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turns": {
+          "name": "turns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "evaluation_cases_set_id_idx": {
+          "name": "evaluation_cases_set_id_idx",
+          "columns": [
+            {
+              "expression": "set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evaluation_cases_set_sort_idx": {
+          "name": "evaluation_cases_set_sort_idx",
+          "columns": [
+            {
+              "expression": "set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_cases_set_id_evaluation_sets_id_fk": {
+          "name": "evaluation_cases_set_id_evaluation_sets_id_fk",
+          "tableFrom": "evaluation_cases",
+          "tableTo": "evaluation_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluation_results": {
+      "name": "evaluation_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_name": {
+          "name": "case_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turns_snapshot": {
+          "name": "turns_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actual_turns": {
+          "name": "actual_turns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review": {
+          "name": "review",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "evaluation_results_task_id_idx": {
+          "name": "evaluation_results_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evaluation_results_task_sort_idx": {
+          "name": "evaluation_results_task_sort_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_task_id_evaluation_tasks_id_fk": {
+          "name": "evaluation_results_task_id_evaluation_tasks_id_fk",
+          "tableFrom": "evaluation_results",
+          "tableTo": "evaluation_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evaluation_results_case_id_evaluation_cases_id_fk": {
+          "name": "evaluation_results_case_id_evaluation_cases_id_fk",
+          "tableFrom": "evaluation_results",
+          "tableTo": "evaluation_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluation_sets": {
+      "name": "evaluation_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "evaluation_sets_agent_id_idx": {
+          "name": "evaluation_sets_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_sets_agent_id_agents_id_fk": {
+          "name": "evaluation_sets_agent_id_agents_id_fk",
+          "tableFrom": "evaluation_sets",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evaluation_sets_user_id_users_id_fk": {
+          "name": "evaluation_sets_user_id_users_id_fk",
+          "tableFrom": "evaluation_sets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluation_tasks": {
+      "name": "evaluation_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_name": {
+          "name": "set_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_snapshot": {
+          "name": "config_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "evaluation_tasks_agent_id_created_at_idx": {
+          "name": "evaluation_tasks_agent_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evaluation_tasks_status_idx": {
+          "name": "evaluation_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_tasks_agent_id_agents_id_fk": {
+          "name": "evaluation_tasks_agent_id_agents_id_fk",
+          "tableFrom": "evaluation_tasks",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evaluation_tasks_set_id_evaluation_sets_id_fk": {
+          "name": "evaluation_tasks_set_id_evaluation_sets_id_fk",
+          "tableFrom": "evaluation_tasks",
+          "tableTo": "evaluation_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "evaluation_tasks_user_id_users_id_fk": {
+          "name": "evaluation_tasks_user_id_users_id_fk",
+          "tableFrom": "evaluation_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feishu_card_callbacks": {
+      "name": "feishu_card_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_session_id": {
+          "name": "trigger_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_chat_id": {
+          "name": "previous_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_open_id": {
+          "name": "trigger_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_message_id": {
+          "name": "original_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "debug_suffix": {
+          "name": "debug_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feishu_card_callbacks_agent_id_idx": {
+          "name": "feishu_card_callbacks_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feishu_card_callbacks_expires_at_idx": {
+          "name": "feishu_card_callbacks_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feishu_card_callbacks_agent_id_agents_id_fk": {
+          "name": "feishu_card_callbacks_agent_id_agents_id_fk",
+          "tableFrom": "feishu_card_callbacks",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feishu_pending_messages": {
+      "name": "feishu_pending_messages",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feishu_pending_messages_agent_id_idx": {
+          "name": "feishu_pending_messages_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feishu_pending_messages_agent_id_agents_id_fk": {
+          "name": "feishu_pending_messages_agent_id_agents_id_fk",
+          "tableFrom": "feishu_pending_messages",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feishu_pending_messages_message_id_agent_id_pk": {
+          "name": "feishu_pending_messages_message_id_agent_id_pk",
+          "columns": [
+            "message_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_trigger_states": {
+      "name": "git_trigger_states",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "git_trigger_states_agent_id_agents_id_fk": {
+          "name": "git_trigger_states_agent_id_agents_id_fk",
+          "tableFrom": "git_trigger_states",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "git_trigger_states_agent_id_channel_repo_key_pk": {
+          "name": "git_trigger_states_agent_id_channel_repo_key_pk",
+          "columns": [
+            "agent_id",
+            "channel",
+            "repo_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_heartbeats": {
+      "name": "instance_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_documents": {
+      "name": "kb_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feishu_doc_token": {
+          "name": "feishu_doc_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feishu_doc_type": {
+          "name": "feishu_doc_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feishu_url": {
+          "name": "feishu_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feishu_app_id": {
+          "name": "feishu_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feishu_app_secret": {
+          "name": "feishu_app_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notion_page_id": {
+          "name": "notion_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notion_url": {
+          "name": "notion_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notion_token": {
+          "name": "notion_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_sync": {
+          "name": "auto_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_interval_min": {
+          "name": "sync_interval_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kb_documents_user_id_users_id_fk": {
+          "name": "kb_documents_user_id_users_id_fk",
+          "tableFrom": "kb_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdio'"
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_config": {
+          "name": "group_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usage_scope": {
+          "name": "usage_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_servers_user_id_users_id_fk": {
+          "name": "mcp_servers_user_id_users_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cursor'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_preset": {
+          "name": "is_preset",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "init_script": {
+          "name": "init_script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_script": {
+          "name": "check_script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills_dir": {
+          "name": "skills_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_config_path": {
+          "name": "mcp_config_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "providers_kind_unique": {
+          "name": "providers_kind_unique",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_steps": {
+      "name": "run_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "run_steps_run_id_created_at_idx": {
+          "name": "run_steps_run_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_steps_created_at_idx": {
+          "name": "run_steps_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_steps_run_id_runs_id_fk": {
+          "name": "run_steps_run_id_runs_id_fk",
+          "tableFrom": "run_steps",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_steps_agent_id_agents_id_fk": {
+          "name": "run_steps_agent_id_agents_id_fk",
+          "tableFrom": "run_steps",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_metadata": {
+          "name": "execution_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_session_id": {
+          "name": "trigger_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_event_id": {
+          "name": "trigger_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_dir": {
+          "name": "work_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_instance_id": {
+          "name": "owner_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worktree_config": {
+          "name": "worktree_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_agent_id": {
+          "name": "initiator_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_user_name": {
+          "name": "trigger_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_agent_name": {
+          "name": "trigger_agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runs_initiator_agent_id_idx": {
+          "name": "runs_initiator_agent_id_idx",
+          "columns": [
+            {
+              "expression": "initiator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_agent_trigger_session_status_created_at_idx": {
+          "name": "runs_agent_trigger_session_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "initiator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_idempotency_key_unique": {
+          "name": "runs_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "initiator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "trigger_source IN ('api', 'a2a') AND trigger_session_id IS NOT NULL AND status IN ('pending', 'queued', 'running', 'completed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_oauth_active_session_unique": {
+          "name": "runs_oauth_active_session_unique",
+          "columns": [
+            {
+              "expression": "initiator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "trigger_source = 'oauth' AND trigger_session_id IS NOT NULL AND status IN ('pending', 'queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_native_chat_event_unique": {
+          "name": "runs_native_chat_event_unique",
+          "columns": [
+            {
+              "expression": "initiator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "trigger_source IN ('slack', 'discord', 'telegram', 'qq_official') AND trigger_event_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_user_id_idx": {
+          "name": "runs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_initiator_agent_created_at_idx": {
+          "name": "runs_initiator_agent_created_at_idx",
+          "columns": [
+            {
+              "expression": "initiator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_status_created_at_idx": {
+          "name": "runs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_user_id_created_at_idx": {
+          "name": "runs_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_status_updated_at_idx": {
+          "name": "runs_status_updated_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_initiator_agent_id_agents_id_fk": {
+          "name": "runs_initiator_agent_id_agents_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "initiator_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_user_id_users_id_fk": {
+          "name": "runs_user_id_users_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scm_sources": {
+      "name": "scm_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_sync_completed_at": {
+          "name": "initial_sync_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codegraph_status": {
+          "name": "codegraph_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "codegraph_last_indexed_at": {
+          "name": "codegraph_last_indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codegraph_last_error": {
+          "name": "codegraph_last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspaces_path": {
+          "name": "workspaces_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deletion_requested_at": {
+          "name": "deletion_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_requested_by": {
+          "name": "deletion_requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scm_sources_deletion_requested_by_users_id_fk": {
+          "name": "scm_sources_deletion_requested_by_users_id_fk",
+          "tableFrom": "scm_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deletion_requested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scm_sources_user_id_users_id_fk": {
+          "name": "scm_sources_user_id_users_id_fk",
+          "tableFrom": "scm_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scm_sources_local_path_unique": {
+          "name": "scm_sources_local_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "local_path"
+          ]
+        },
+        "scm_sources_workspaces_path_unique": {
+          "name": "scm_sources_workspaces_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspaces_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scm_workload_leases": {
+      "name": "scm_workload_leases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workload_type": {
+          "name": "workload_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workload_id": {
+          "name": "workload_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scm_source_id": {
+          "name": "scm_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "owner_instance_id": {
+          "name": "owner_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scm_workload_leases_workload_unique": {
+          "name": "scm_workload_leases_workload_unique",
+          "columns": [
+            {
+              "expression": "workload_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workload_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scm_workload_leases_agent_id_idx": {
+          "name": "scm_workload_leases_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scm_workload_leases_scm_source_id_idx": {
+          "name": "scm_workload_leases_scm_source_id_idx",
+          "columns": [
+            {
+              "expression": "scm_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scm_workload_leases_agent_id_agents_id_fk": {
+          "name": "scm_workload_leases_agent_id_agents_id_fk",
+          "tableFrom": "scm_workload_leases",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scm_workload_leases_scm_source_id_scm_sources_id_fk": {
+          "name": "scm_workload_leases_scm_source_id_scm_sources_id_fk",
+          "tableFrom": "scm_workload_leases",
+          "tableTo": "scm_sources",
+          "columnsFrom": [
+            "scm_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scm_workspace_removals": {
+      "name": "scm_workspace_removals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scm_source_id": {
+          "name": "scm_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_instance_id": {
+          "name": "owner_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_token": {
+          "name": "attempt_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_started_at": {
+          "name": "attempt_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scm_workspace_removals_scm_source_id_idx": {
+          "name": "scm_workspace_removals_scm_source_id_idx",
+          "columns": [
+            {
+              "expression": "scm_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scm_workspace_removals_target_unique": {
+          "name": "scm_workspace_removals_target_unique",
+          "columns": [
+            {
+              "expression": "scm_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scm_workspace_removals_scm_source_id_scm_sources_id_fk": {
+          "name": "scm_workspace_removals_scm_source_id_scm_sources_id_fk",
+          "tableFrom": "scm_workspace_removals",
+          "tableTo": "scm_sources",
+          "columnsFrom": [
+            "scm_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "settings_category_key_pk": {
+          "name": "settings_category_key_pk",
+          "columns": [
+            "category",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_groups": {
+      "name": "skill_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'package'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skill_groups_user_id_users_id_fk": {
+          "name": "skill_groups_user_id_users_id_fk",
+          "tableFrom": "skill_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "remote_source": {
+          "name": "remote_source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dirty": {
+          "name": "source_dirty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skills_group_id_skill_groups_id_fk": {
+          "name": "skills_group_id_skill_groups_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "skill_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "skills_user_id_users_id_fk": {
+          "name": "skills_user_id_users_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_invitations": {
+      "name": "user_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_invitations_created_at_idx": {
+          "name": "user_invitations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_invitations_email_idx": {
+          "name": "user_invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_invitations_invited_by_users_id_fk": {
+          "name": "user_invitations_invited_by_users_id_fk",
+          "tableFrom": "user_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_invitations_accepted_user_id_users_id_fk": {
+          "name": "user_invitations_accepted_user_id_users_id_fk",
+          "tableFrom": "user_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_invitations_code_unique": {
+          "name": "user_invitations_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idaas_sub": {
+          "name": "idaas_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idaas_issuer": {
+          "name": "idaas_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idaas_protocol": {
+          "name": "idaas_protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'zh'"
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_idaas_identity_unique": {
+          "name": "users_idaas_identity_unique",
+          "columns": [
+            {
+              "expression": "idaas_issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idaas_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle-pg/meta/_journal.json
+++ b/apps/api/drizzle-pg/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1787209260592,
       "tag": "0016_burly_shinobi_shaw",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1787298932153,
+      "tag": "0017_telegram_channel",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/drizzle/0119_telegram_channel.sql
+++ b/apps/api/drizzle/0119_telegram_channel.sql
@@ -1,0 +1,3 @@
+DROP INDEX `runs_native_chat_event_unique`;--> statement-breakpoint
+CREATE UNIQUE INDEX `runs_native_chat_event_unique` ON `runs` (`initiator_agent_id`,`trigger_source`,`trigger_event_id`) WHERE trigger_source IN ('slack', 'discord', 'telegram', 'qq_official') AND trigger_event_id IS NOT NULL;--> statement-breakpoint
+ALTER TABLE `agents` ADD `telegram_config` text;

--- a/apps/api/drizzle/meta/0119_snapshot.json
+++ b/apps/api/drizzle/meta/0119_snapshot.json
@@ -1,0 +1,4048 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1306e293-f63a-48ca-b9da-ea8d4b271543",
+  "prevId": "ee9e803c-0db1-4412-bb3e-0a355deaf692",
+  "tables": {
+    "a2a_tasks": {
+      "name": "a2a_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "a2a_tasks_updated_at_idx": {
+          "name": "a2a_tasks_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_members": {
+      "name": "agent_members",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'viewer'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_members_user_id_idx": {
+          "name": "agent_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_members_agent_id_agents_id_fk": {
+          "name": "agent_members_agent_id_agents_id_fk",
+          "tableFrom": "agent_members",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_members_user_id_users_id_fk": {
+          "name": "agent_members_user_id_users_id_fk",
+          "tableFrom": "agent_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_members_created_by_users_id_fk": {
+          "name": "agent_members_created_by_users_id_fk",
+          "tableFrom": "agent_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_members_agent_id_user_id_pk": {
+          "columns": [
+            "agent_id",
+            "user_id"
+          ],
+          "name": "agent_members_agent_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cursor'"
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'🤖'"
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_group_ids": {
+          "name": "skill_group_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_ids": {
+          "name": "mcp_server_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kb_document_ids": {
+          "name": "kb_document_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publish_status": {
+          "name": "publish_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "provider_api_key": {
+          "name": "provider_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_base_url": {
+          "name": "provider_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_oauth_token": {
+          "name": "provider_oauth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memory_provider_api_key": {
+          "name": "memory_provider_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_api_key": {
+          "name": "embedding_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'apiKey'"
+        },
+        "endpoint_api_key": {
+          "name": "endpoint_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publish_auth_type": {
+          "name": "publish_auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'api_key'"
+        },
+        "publish_ip_whitelist": {
+          "name": "publish_ip_whitelist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publish_description": {
+          "name": "publish_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publish_channels": {
+          "name": "publish_channels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_access_mode": {
+          "name": "oauth_access_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'feishu_scope'"
+        },
+        "oauth_allowed_emails": {
+          "name": "oauth_allowed_emails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "a2a_skills": {
+          "name": "a2a_skills",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "a2a_route_targets": {
+          "name": "a2a_route_targets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_local_child_output": {
+          "name": "show_local_child_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_remote_child_output": {
+          "name": "show_remote_child_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feishu_config": {
+          "name": "feishu_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slack_config": {
+          "name": "slack_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_config": {
+          "name": "discord_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "telegram_config": {
+          "name": "telegram_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qq_official_config": {
+          "name": "qq_official_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_app_config": {
+          "name": "chat_app_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_policy": {
+          "name": "artifact_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_config": {
+          "name": "schedule_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "glab_config": {
+          "name": "glab_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gh_config": {
+          "name": "gh_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_type": {
+          "name": "workspace_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'temp'"
+        },
+        "scm_source_id": {
+          "name": "scm_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "a2a_auth_type": {
+          "name": "a2a_auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'api_key'"
+        },
+        "a2a_endpoint_api_key": {
+          "name": "a2a_endpoint_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trust_forwarded_identity": {
+          "name": "trust_forwarded_identity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "schedule_run_as_owner": {
+          "name": "schedule_run_as_owner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "schedule_run_as_user_id": {
+          "name": "schedule_run_as_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agents_user_id_idx": {
+          "name": "agents_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agents_provider_id_providers_id_fk": {
+          "name": "agents_provider_id_providers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_scm_source_id_scm_sources_id_fk": {
+          "name": "agents_scm_source_id_scm_sources_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "scm_sources",
+          "columnsFrom": [
+            "scm_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_schedule_run_as_user_id_users_id_fk": {
+          "name": "agents_schedule_run_as_user_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "schedule_run_as_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_user_id_users_id_fk": {
+          "name": "agents_user_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artifact_shares": {
+      "name": "artifact_shares",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "artifact_shares_artifact_id_idx": {
+          "name": "artifact_shares_artifact_id_idx",
+          "columns": [
+            "artifact_id"
+          ],
+          "isUnique": false
+        },
+        "artifact_shares_expires_at_idx": {
+          "name": "artifact_shares_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "artifact_shares_artifact_id_artifacts_id_fk": {
+          "name": "artifact_shares_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_shares",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_shares_created_by_users_id_fk": {
+          "name": "artifact_shares_created_by_users_id_fk",
+          "tableFrom": "artifact_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artifacts": {
+      "name": "artifacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'file'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "artifacts_run_id_idx": {
+          "name": "artifacts_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "artifacts_user_id_idx": {
+          "name": "artifacts_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "artifacts_expires_at_idx": {
+          "name": "artifacts_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "artifacts_run_id_runs_id_fk": {
+          "name": "artifacts_run_id_runs_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifacts_agent_id_agents_id_fk": {
+          "name": "artifacts_agent_id_agents_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifacts_user_id_users_id_fk": {
+          "name": "artifacts_user_id_users_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attachment_refs": {
+      "name": "attachment_refs",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "attachment_refs_token_idx": {
+          "name": "attachment_refs_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "attachment_refs_run_id_runs_id_fk": {
+          "name": "attachment_refs_run_id_runs_id_fk",
+          "tableFrom": "attachment_refs",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "attachment_refs_token_run_id_pk": {
+          "columns": [
+            "token",
+            "run_id"
+          ],
+          "name": "attachment_refs_token_run_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_action_created_at_idx": {
+          "name": "audit_logs_action_created_at_idx",
+          "columns": [
+            "action",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_user_id_created_at_idx": {
+          "name": "audit_logs_user_id_created_at_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_resource_created_at_idx": {
+          "name": "audit_logs_resource_created_at_idx",
+          "columns": [
+            "resource",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_messages": {
+      "name": "chat_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_messages_run_id_idx": {
+          "name": "chat_messages_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_run_id_runs_id_fk": {
+          "name": "chat_messages_run_id_runs_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cli_installations": {
+      "name": "cli_installations",
+      "columns": {
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "installed_version": {
+          "name": "installed_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_output": {
+          "name": "last_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cli_tokens": {
+      "name": "cli_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cli_tokens_token_hash_unique": {
+          "name": "cli_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "cli_tokens_user_id_idx": {
+          "name": "cli_tokens_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cli_tokens_user_id_users_id_fk": {
+          "name": "cli_tokens_user_id_users_id_fk",
+          "tableFrom": "cli_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_authorizations": {
+      "name": "device_authorizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code_hash": {
+          "name": "device_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "device_authorizations_device_code_hash_unique": {
+          "name": "device_authorizations_device_code_hash_unique",
+          "columns": [
+            "device_code_hash"
+          ],
+          "isUnique": true
+        },
+        "device_authorizations_user_code_unique": {
+          "name": "device_authorizations_user_code_unique",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": true
+        },
+        "device_authorizations_expires_at_idx": {
+          "name": "device_authorizations_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_authorizations_user_id_users_id_fk": {
+          "name": "device_authorizations_user_id_users_id_fk",
+          "tableFrom": "device_authorizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evaluation_cases": {
+      "name": "evaluation_cases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evaluation_cases_set_id_idx": {
+          "name": "evaluation_cases_set_id_idx",
+          "columns": [
+            "set_id"
+          ],
+          "isUnique": false
+        },
+        "evaluation_cases_set_sort_idx": {
+          "name": "evaluation_cases_set_sort_idx",
+          "columns": [
+            "set_id",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evaluation_cases_set_id_evaluation_sets_id_fk": {
+          "name": "evaluation_cases_set_id_evaluation_sets_id_fk",
+          "tableFrom": "evaluation_cases",
+          "tableTo": "evaluation_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evaluation_results": {
+      "name": "evaluation_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "case_name": {
+          "name": "case_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turns_snapshot": {
+          "name": "turns_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actual_turns": {
+          "name": "actual_turns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evaluation_results_task_id_idx": {
+          "name": "evaluation_results_task_id_idx",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "evaluation_results_task_sort_idx": {
+          "name": "evaluation_results_task_sort_idx",
+          "columns": [
+            "task_id",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_task_id_evaluation_tasks_id_fk": {
+          "name": "evaluation_results_task_id_evaluation_tasks_id_fk",
+          "tableFrom": "evaluation_results",
+          "tableTo": "evaluation_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evaluation_results_case_id_evaluation_cases_id_fk": {
+          "name": "evaluation_results_case_id_evaluation_cases_id_fk",
+          "tableFrom": "evaluation_results",
+          "tableTo": "evaluation_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evaluation_sets": {
+      "name": "evaluation_sets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evaluation_sets_agent_id_idx": {
+          "name": "evaluation_sets_agent_id_idx",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evaluation_sets_agent_id_agents_id_fk": {
+          "name": "evaluation_sets_agent_id_agents_id_fk",
+          "tableFrom": "evaluation_sets",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evaluation_sets_user_id_users_id_fk": {
+          "name": "evaluation_sets_user_id_users_id_fk",
+          "tableFrom": "evaluation_sets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evaluation_tasks": {
+      "name": "evaluation_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "set_name": {
+          "name": "set_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_snapshot": {
+          "name": "config_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evaluation_tasks_agent_id_created_at_idx": {
+          "name": "evaluation_tasks_agent_id_created_at_idx",
+          "columns": [
+            "agent_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "evaluation_tasks_status_idx": {
+          "name": "evaluation_tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evaluation_tasks_agent_id_agents_id_fk": {
+          "name": "evaluation_tasks_agent_id_agents_id_fk",
+          "tableFrom": "evaluation_tasks",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evaluation_tasks_set_id_evaluation_sets_id_fk": {
+          "name": "evaluation_tasks_set_id_evaluation_sets_id_fk",
+          "tableFrom": "evaluation_tasks",
+          "tableTo": "evaluation_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "evaluation_tasks_user_id_users_id_fk": {
+          "name": "evaluation_tasks_user_id_users_id_fk",
+          "tableFrom": "evaluation_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feishu_card_callbacks": {
+      "name": "feishu_card_callbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_session_id": {
+          "name": "trigger_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_chat_id": {
+          "name": "previous_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_open_id": {
+          "name": "trigger_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_message_id": {
+          "name": "original_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "debug_suffix": {
+          "name": "debug_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "feishu_card_callbacks_agent_id_idx": {
+          "name": "feishu_card_callbacks_agent_id_idx",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "feishu_card_callbacks_expires_at_idx": {
+          "name": "feishu_card_callbacks_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "feishu_card_callbacks_agent_id_agents_id_fk": {
+          "name": "feishu_card_callbacks_agent_id_agents_id_fk",
+          "tableFrom": "feishu_card_callbacks",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feishu_pending_messages": {
+      "name": "feishu_pending_messages",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "feishu_pending_messages_agent_id_idx": {
+          "name": "feishu_pending_messages_agent_id_idx",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "feishu_pending_messages_agent_id_agents_id_fk": {
+          "name": "feishu_pending_messages_agent_id_agents_id_fk",
+          "tableFrom": "feishu_pending_messages",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feishu_pending_messages_message_id_agent_id_pk": {
+          "columns": [
+            "message_id",
+            "agent_id"
+          ],
+          "name": "feishu_pending_messages_message_id_agent_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "git_trigger_states": {
+      "name": "git_trigger_states",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "git_trigger_states_agent_id_agents_id_fk": {
+          "name": "git_trigger_states_agent_id_agents_id_fk",
+          "tableFrom": "git_trigger_states",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "git_trigger_states_agent_id_channel_repo_key_pk": {
+          "columns": [
+            "agent_id",
+            "channel",
+            "repo_key"
+          ],
+          "name": "git_trigger_states_agent_id_channel_repo_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "instance_heartbeats": {
+      "name": "instance_heartbeats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "kb_documents": {
+      "name": "kb_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feishu_doc_token": {
+          "name": "feishu_doc_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feishu_doc_type": {
+          "name": "feishu_doc_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feishu_url": {
+          "name": "feishu_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feishu_app_id": {
+          "name": "feishu_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feishu_app_secret": {
+          "name": "feishu_app_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notion_page_id": {
+          "name": "notion_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notion_url": {
+          "name": "notion_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notion_token": {
+          "name": "notion_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_sync": {
+          "name": "auto_sync",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sync_interval_min": {
+          "name": "sync_interval_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kb_documents_user_id_users_id_fk": {
+          "name": "kb_documents_user_id_users_id_fk",
+          "tableFrom": "kb_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'stdio'"
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_config": {
+          "name": "group_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "usage_scope": {
+          "name": "usage_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_servers_user_id_users_id_fk": {
+          "name": "mcp_servers_user_id_users_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "providers": {
+      "name": "providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cursor'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_preset": {
+          "name": "is_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "init_script": {
+          "name": "init_script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "check_script": {
+          "name": "check_script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skills_dir": {
+          "name": "skills_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_config_path": {
+          "name": "mcp_config_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "providers_kind_unique": {
+          "name": "providers_kind_unique",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_steps": {
+      "name": "run_steps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "run_steps_run_id_created_at_idx": {
+          "name": "run_steps_run_id_created_at_idx",
+          "columns": [
+            "run_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "run_steps_created_at_idx": {
+          "name": "run_steps_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_steps_run_id_runs_id_fk": {
+          "name": "run_steps_run_id_runs_id_fk",
+          "tableFrom": "run_steps",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_steps_agent_id_agents_id_fk": {
+          "name": "run_steps_agent_id_agents_id_fk",
+          "tableFrom": "run_steps",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_metadata": {
+          "name": "execution_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_session_id": {
+          "name": "trigger_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_event_id": {
+          "name": "trigger_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "work_dir": {
+          "name": "work_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_instance_id": {
+          "name": "owner_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_config": {
+          "name": "worktree_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initiator_agent_id": {
+          "name": "initiator_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_user_name": {
+          "name": "trigger_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_agent_name": {
+          "name": "trigger_agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "runs_initiator_agent_id_idx": {
+          "name": "runs_initiator_agent_id_idx",
+          "columns": [
+            "initiator_agent_id"
+          ],
+          "isUnique": false
+        },
+        "runs_agent_trigger_session_status_created_at_idx": {
+          "name": "runs_agent_trigger_session_status_created_at_idx",
+          "columns": [
+            "initiator_agent_id",
+            "trigger_session_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "runs_idempotency_key_unique": {
+          "name": "runs_idempotency_key_unique",
+          "columns": [
+            "initiator_agent_id",
+            "trigger_source",
+            "trigger_session_id"
+          ],
+          "isUnique": true,
+          "where": "trigger_source IN ('api', 'a2a') AND trigger_session_id IS NOT NULL AND status IN ('pending', 'queued', 'running', 'completed')"
+        },
+        "runs_oauth_active_session_unique": {
+          "name": "runs_oauth_active_session_unique",
+          "columns": [
+            "initiator_agent_id",
+            "trigger_source",
+            "trigger_session_id"
+          ],
+          "isUnique": true,
+          "where": "trigger_source = 'oauth' AND trigger_session_id IS NOT NULL AND status IN ('pending', 'queued', 'running')"
+        },
+        "runs_native_chat_event_unique": {
+          "name": "runs_native_chat_event_unique",
+          "columns": [
+            "initiator_agent_id",
+            "trigger_source",
+            "trigger_event_id"
+          ],
+          "isUnique": true,
+          "where": "trigger_source IN ('slack', 'discord', 'telegram', 'qq_official') AND trigger_event_id IS NOT NULL"
+        },
+        "runs_user_id_idx": {
+          "name": "runs_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "runs_initiator_agent_created_at_idx": {
+          "name": "runs_initiator_agent_created_at_idx",
+          "columns": [
+            "initiator_agent_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "runs_status_created_at_idx": {
+          "name": "runs_status_created_at_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "runs_user_id_created_at_idx": {
+          "name": "runs_user_id_created_at_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "runs_status_updated_at_idx": {
+          "name": "runs_status_updated_at_idx",
+          "columns": [
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "runs_initiator_agent_id_agents_id_fk": {
+          "name": "runs_initiator_agent_id_agents_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "initiator_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_user_id_users_id_fk": {
+          "name": "runs_user_id_users_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scm_sources": {
+      "name": "scm_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initial_sync_completed_at": {
+          "name": "initial_sync_completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codegraph_status": {
+          "name": "codegraph_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "codegraph_last_indexed_at": {
+          "name": "codegraph_last_indexed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codegraph_last_error": {
+          "name": "codegraph_last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspaces_path": {
+          "name": "workspaces_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "deletion_requested_at": {
+          "name": "deletion_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deletion_requested_by": {
+          "name": "deletion_requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scm_sources_local_path_unique": {
+          "name": "scm_sources_local_path_unique",
+          "columns": [
+            "local_path"
+          ],
+          "isUnique": true
+        },
+        "scm_sources_workspaces_path_unique": {
+          "name": "scm_sources_workspaces_path_unique",
+          "columns": [
+            "workspaces_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "scm_sources_deletion_requested_by_users_id_fk": {
+          "name": "scm_sources_deletion_requested_by_users_id_fk",
+          "tableFrom": "scm_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deletion_requested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scm_sources_user_id_users_id_fk": {
+          "name": "scm_sources_user_id_users_id_fk",
+          "tableFrom": "scm_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scm_workload_leases": {
+      "name": "scm_workload_leases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workload_type": {
+          "name": "workload_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workload_id": {
+          "name": "workload_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scm_source_id": {
+          "name": "scm_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'reserved'"
+        },
+        "owner_instance_id": {
+          "name": "owner_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scm_workload_leases_workload_unique": {
+          "name": "scm_workload_leases_workload_unique",
+          "columns": [
+            "workload_type",
+            "workload_id"
+          ],
+          "isUnique": true
+        },
+        "scm_workload_leases_agent_id_idx": {
+          "name": "scm_workload_leases_agent_id_idx",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "scm_workload_leases_scm_source_id_idx": {
+          "name": "scm_workload_leases_scm_source_id_idx",
+          "columns": [
+            "scm_source_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scm_workload_leases_agent_id_agents_id_fk": {
+          "name": "scm_workload_leases_agent_id_agents_id_fk",
+          "tableFrom": "scm_workload_leases",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scm_workload_leases_scm_source_id_scm_sources_id_fk": {
+          "name": "scm_workload_leases_scm_source_id_scm_sources_id_fk",
+          "tableFrom": "scm_workload_leases",
+          "tableTo": "scm_sources",
+          "columnsFrom": [
+            "scm_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scm_workspace_removals": {
+      "name": "scm_workspace_removals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scm_source_id": {
+          "name": "scm_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_instance_id": {
+          "name": "owner_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_token": {
+          "name": "attempt_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'legacy'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_started_at": {
+          "name": "attempt_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scm_workspace_removals_scm_source_id_idx": {
+          "name": "scm_workspace_removals_scm_source_id_idx",
+          "columns": [
+            "scm_source_id"
+          ],
+          "isUnique": false
+        },
+        "scm_workspace_removals_target_unique": {
+          "name": "scm_workspace_removals_target_unique",
+          "columns": [
+            "scm_source_id",
+            "workspace_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "scm_workspace_removals_scm_source_id_scm_sources_id_fk": {
+          "name": "scm_workspace_removals_scm_source_id_scm_sources_id_fk",
+          "tableFrom": "scm_workspace_removals",
+          "tableTo": "scm_sources",
+          "columnsFrom": [
+            "scm_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "settings_category_key_pk": {
+          "columns": [
+            "category",
+            "key"
+          ],
+          "name": "settings_category_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_groups": {
+      "name": "skill_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'package'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skill_groups_user_id_users_id_fk": {
+          "name": "skill_groups_user_id_users_id_fk",
+          "tableFrom": "skill_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skills": {
+      "name": "skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "remote_source": {
+          "name": "remote_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_dirty": {
+          "name": "source_dirty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skills_group_id_skill_groups_id_fk": {
+          "name": "skills_group_id_skill_groups_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "skill_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "skills_user_id_users_id_fk": {
+          "name": "skills_user_id_users_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_invitations": {
+      "name": "user_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_invitations_code_unique": {
+          "name": "user_invitations_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        },
+        "user_invitations_created_at_idx": {
+          "name": "user_invitations_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "user_invitations_email_idx": {
+          "name": "user_invitations_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_invitations_invited_by_users_id_fk": {
+          "name": "user_invitations_invited_by_users_id_fk",
+          "tableFrom": "user_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_invitations_accepted_user_id_users_id_fk": {
+          "name": "user_invitations_accepted_user_id_users_id_fk",
+          "tableFrom": "user_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idaas_sub": {
+          "name": "idaas_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idaas_issuer": {
+          "name": "idaas_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idaas_protocol": {
+          "name": "idaas_protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'zh'"
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_idaas_identity_unique": {
+          "name": "users_idaas_identity_unique",
+          "columns": [
+            "idaas_issuer",
+            "idaas_sub"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -834,6 +834,13 @@
       "when": 1787209251849,
       "tag": "0118_steady_celestials",
       "breakpoints": true
+    },
+    {
+      "idx": 119,
+      "version": "6",
+      "when": 1787298928923,
+      "tag": "0119_telegram_channel",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.pg.ts
+++ b/apps/api/src/db/schema.pg.ts
@@ -20,6 +20,7 @@ import {
   SKILL_DEFAULTS,
   type scheduleConfigSchema,
   type slackConfigSchema,
+  type telegramConfigSchema,
 } from '@a2wave/shared'
 import { sql } from 'drizzle-orm'
 import {
@@ -580,6 +581,8 @@ export const agents = pgTable(
     slackConfig: jsonb('slack_config').$type<z.input<typeof slackConfigSchema>>(),
     /** Discord Gateway bot configuration JSON. */
     discordConfig: jsonb('discord_config').$type<z.input<typeof discordConfigSchema>>(),
+    /** Telegram Bot API long-polling configuration JSON. */
+    telegramConfig: jsonb('telegram_config').$type<z.input<typeof telegramConfigSchema>>(),
     /** QQ Official Bot WebSocket Gateway configuration JSON. */
     qqOfficialConfig: jsonb('qq_official_config').$type<z.input<typeof qqOfficialConfigSchema>>(),
     /** Chat app page presentation config JSON (copy only — never credentials). */
@@ -779,6 +782,13 @@ export const runs = pgTable(
             mimeType?: string
             size?: number
           }
+        | {
+            source: 'telegram'
+            remoteId: string
+            name: string
+            mimeType?: string
+            size?: number
+          }
       )[]
     }>(),
     /** Run trigger transport. */
@@ -789,6 +799,7 @@ export const runs = pgTable(
         'feishu',
         'slack',
         'discord',
+        'telegram',
         'qq_official',
         'a2a',
         'schedule',
@@ -870,7 +881,7 @@ export const runs = pgTable(
     nativeChatEventUnique: uniqueIndex('runs_native_chat_event_unique')
       .on(table.initiatorAgentId, table.triggerSource, table.triggerEventId)
       .where(
-        sql`trigger_source IN ('slack', 'discord', 'qq_official') AND trigger_event_id IS NOT NULL`,
+        sql`trigger_source IN ('slack', 'discord', 'telegram', 'qq_official') AND trigger_event_id IS NOT NULL`,
       ),
     userIdIdx: index('runs_user_id_idx').on(table.userId),
     // Per-agent time series (GET /agents/:id/stats/timeseries): every query is

--- a/apps/api/src/db/schema.sqlite.ts
+++ b/apps/api/src/db/schema.sqlite.ts
@@ -13,6 +13,7 @@ import {
   SKILL_DEFAULTS,
   type scheduleConfigSchema,
   type slackConfigSchema,
+  type telegramConfigSchema,
 } from '@a2wave/shared'
 import { sql } from 'drizzle-orm'
 import { index, integer, primaryKey, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
@@ -559,6 +560,10 @@ export const agents = sqliteTable(
     discordConfig: text('discord_config', { mode: 'json' }).$type<
       z.input<typeof discordConfigSchema>
     >(),
+    /** Telegram Bot API long-polling configuration JSON. */
+    telegramConfig: text('telegram_config', { mode: 'json' }).$type<
+      z.input<typeof telegramConfigSchema>
+    >(),
     /** QQ Official Bot WebSocket Gateway configuration JSON. */
     qqOfficialConfig: text('qq_official_config', { mode: 'json' }).$type<
       z.input<typeof qqOfficialConfigSchema>
@@ -774,6 +779,13 @@ export const runs = sqliteTable(
             mimeType?: string
             size?: number
           }
+        | {
+            source: 'telegram'
+            remoteId: string
+            name: string
+            mimeType?: string
+            size?: number
+          }
       )[]
     }>(),
     /** Run trigger transport. */
@@ -784,6 +796,7 @@ export const runs = sqliteTable(
         'feishu',
         'slack',
         'discord',
+        'telegram',
         'qq_official',
         'a2a',
         'schedule',
@@ -865,7 +878,7 @@ export const runs = sqliteTable(
     nativeChatEventUnique: uniqueIndex('runs_native_chat_event_unique')
       .on(table.initiatorAgentId, table.triggerSource, table.triggerEventId)
       .where(
-        sql`trigger_source IN ('slack', 'discord', 'qq_official') AND trigger_event_id IS NOT NULL`,
+        sql`trigger_source IN ('slack', 'discord', 'telegram', 'qq_official') AND trigger_event_id IS NOT NULL`,
       ),
     userIdIdx: index('runs_user_id_idx').on(table.userId),
     // Per-agent time series (GET /agents/:id/stats/timeseries): every query is

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -70,6 +70,7 @@ import { getSetting, refreshSettingsCache } from './lib/settings.js'
 import { ensureAdminExists } from './lib/setup.js'
 import { slackConnectionManager } from './lib/slack-service.js'
 import { startStaleLeaseSweeper } from './lib/stale-lease-sweeper.js'
+import { telegramConnectionManager } from './lib/telegram-service.js'
 import { apiBodyLimit } from './middleware/api-body-limit.js'
 import { authMiddleware, memoryAuthMiddleware, requireAdmin } from './middleware/auth-middleware.js'
 import { csrfOriginMiddleware } from './middleware/csrf-origin.js'
@@ -494,6 +495,7 @@ function gracefulShutdown(signal: string) {
       stopFeishu: () => feishuConnectionManager.stopAll(),
       stopSlack: () => slackConnectionManager.stopAll(),
       stopDiscord: () => discordConnectionManager.stopAll(),
+      stopTelegram: () => telegramConnectionManager.stopAll(),
       stopQQOfficial: () => qqOfficialConnectionManager.stopAll(),
       stopSchedules: () => {
         scheduleTriggerManager.stopAll()
@@ -530,6 +532,7 @@ function gracefulShutdown(signal: string) {
       stopFeishu: () => feishuConnectionManager.stopAll(),
       stopSlack: () => slackConnectionManager.stopAll(),
       stopDiscord: () => discordConnectionManager.stopAll(),
+      stopTelegram: () => telegramConnectionManager.stopAll(),
       stopQQOfficial: () => qqOfficialConnectionManager.stopAll(),
       stopSchedules: () => {
         scheduleTriggerManager.stopAll()
@@ -776,6 +779,9 @@ void ensureAdminExists()
     discordConnectionManager
       .restoreConnections()
       .catch((err) => logger.error(err, 'discordConnectionManager.restoreConnections failed'))
+    telegramConnectionManager
+      .restoreConnections()
+      .catch((err) => logger.error(err, 'telegramConnectionManager.restoreConnections failed'))
     qqOfficialConnectionManager
       .restoreConnections()
       .catch((err) => logger.error(err, 'qqOfficialConnectionManager.restoreConnections failed'))

--- a/apps/api/src/lib/__tests__/graceful-shutdown.test.ts
+++ b/apps/api/src/lib/__tests__/graceful-shutdown.test.ts
@@ -16,6 +16,7 @@ describe('runGracefulShutdownSequence', () => {
         stopFeishu: vi.fn(() => calls.push('stopFeishu')),
         stopSlack: vi.fn(() => calls.push('stopSlack')),
         stopDiscord: vi.fn(() => calls.push('stopDiscord')),
+        stopTelegram: vi.fn(() => calls.push('stopTelegram')),
         stopQQOfficial: vi.fn(() => calls.push('stopQQOfficial')),
         stopSchedules: vi.fn(() => calls.push('stopSchedules')),
         drainExecutionLeases: vi.fn(async () => {
@@ -59,6 +60,7 @@ describe('runGracefulShutdownSequence', () => {
       'stopFeishu',
       'stopSlack',
       'stopDiscord',
+      'stopTelegram',
       'stopQQOfficial',
       'stopSchedules',
       'shutdownEngines:start',

--- a/apps/api/src/lib/__tests__/run-channel.test.ts
+++ b/apps/api/src/lib/__tests__/run-channel.test.ts
@@ -23,7 +23,6 @@ import { X_A2WAVE_CHANNEL_B64_HEADER } from '../../a2a/caller.js'
 import type { GatewayCaller } from '../../middleware/gateway-auth.js'
 import { logger } from '../logger.js'
 import {
-  RESERVED_CONTEXT_KEYS,
   buildChatAppChannel as _buildChatAppChannelRaw,
   buildDebugChannel as _buildDebugChannelRaw,
   buildDiscordChannel as _buildDiscordChannelRaw,
@@ -31,8 +30,10 @@ import {
   buildGatewayChannel as _buildGatewayChannelRaw,
   buildScheduleChannel as _buildScheduleChannelRaw,
   buildSlackChannel as _buildSlackChannelRaw,
+  buildTelegramChannel as _buildTelegramChannelRaw,
   decodeUpstreamChannelHeader,
   encodeChannelContextHeader,
+  RESERVED_CONTEXT_KEYS,
   stripReservedContextKeys,
 } from '../run-channel.js'
 
@@ -61,6 +62,10 @@ const buildSlackChannel: (
 const buildDiscordChannel: (
   ...a: Parameters<typeof _buildDiscordChannelRaw>
 ) => ReturnType<typeof _buildDiscordChannelRaw>['ctx'] = (...a) => _buildDiscordChannelRaw(...a).ctx
+const buildTelegramChannel: (
+  ...a: Parameters<typeof _buildTelegramChannelRaw>
+) => ReturnType<typeof _buildTelegramChannelRaw>['ctx'] = (...a) =>
+  _buildTelegramChannelRaw(...a).ctx
 
 function makeCtx(headers: Record<string, string> = {}, remoteAddress?: string): Context {
   return {
@@ -134,6 +139,46 @@ describe('native chat channel builders', () => {
       channel_info: { application_id: '123', channel_id: '456' },
     })
     if (ctx.channel_type === 'discord') expect(ctx.channel_info.guild_id).toBeUndefined()
+  })
+
+  it('builds a Telegram private channel with optional thread fields omitted', () => {
+    const ctx = buildTelegramChannel({
+      botId: '4242',
+      chatId: '555',
+      chatType: 'private',
+      messageId: '11',
+      senderUserId: '9',
+      senderName: 'Ada',
+    })
+
+    expect(runChannelContextSchema.parse(ctx)).toEqual(ctx)
+    expect(ctx).toMatchObject({
+      channel_type: 'telegram',
+      user_info: null,
+      display_name: 'Ada',
+      channel_info: { bot_id: '4242', chat_id: '555', chat_type: 'private', message_id: '11' },
+    })
+    if (ctx.channel_type === 'telegram') {
+      expect(ctx.channel_info.message_thread_id).toBeUndefined()
+    }
+  })
+
+  it('keeps the forum topic id for a Telegram supergroup message', () => {
+    const ctx = buildTelegramChannel({
+      botId: '4242',
+      chatId: '-1001',
+      chatType: 'supergroup',
+      messageId: '13',
+      messageThreadId: '77',
+      senderUserId: '9',
+    })
+
+    expect(runChannelContextSchema.parse(ctx)).toEqual(ctx)
+    // No sender name means no display_name key at all, rather than an empty string.
+    expect(ctx.display_name).toBeUndefined()
+    if (ctx.channel_type === 'telegram') {
+      expect(ctx.channel_info.message_thread_id).toBe('77')
+    }
   })
 })
 

--- a/apps/api/src/lib/__tests__/telegram-poll-loop.test.ts
+++ b/apps/api/src/lib/__tests__/telegram-poll-loop.test.ts
@@ -1,0 +1,127 @@
+import { createServer, type Server } from 'node:http'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+const reserved: Record<string, unknown>[] = []
+vi.mock('../native-chat-runner.js', () => ({
+  reserveNativeChatRun: async (input: Record<string, unknown>) => {
+    reserved.push(input)
+    return { status: 'ok', runId: 'run_x' }
+  },
+}))
+
+const { TelegramConnectionManager } = await import('../telegram-service.js')
+
+const sent: { chat_id: string; text: string; reply_parameters?: { message_id: number } }[] = []
+let served = false
+let server: Server
+let base: string
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    let body = ''
+    req.on('data', (c) => {
+      body += c
+    })
+    req.on('end', () => {
+      const method = req.url?.split('/').pop() ?? ''
+      const json = (o: unknown) => {
+        res.setHeader('content-type', 'application/json')
+        res.end(JSON.stringify(o))
+      }
+      if (method === 'getMe') return json({ ok: true, result: { id: 4242, username: 'fake_bot' } })
+      if (method === 'deleteWebhook') return json({ ok: true, result: true })
+      if (method === 'sendMessage') {
+        sent.push(JSON.parse(body))
+        return json({ ok: true, result: {} })
+      }
+      if (method === 'getUpdates') {
+        if (served) return json({ ok: true, result: [] })
+        served = true
+        return json({
+          ok: true,
+          result: [
+            {
+              update_id: 1,
+              message: {
+                message_id: 11,
+                chat: { id: 555, type: 'private' },
+                from: { id: 9, first_name: 'Ada' },
+                text: 'hello agent',
+              },
+            },
+            {
+              update_id: 2,
+              message: {
+                message_id: 12,
+                chat: { id: -100, type: 'supergroup' },
+                from: { id: 9, first_name: 'Ada' },
+                text: 'chatting',
+              },
+            },
+            {
+              update_id: 3,
+              message: {
+                message_id: 13,
+                chat: { id: -100, type: 'supergroup' },
+                from: { id: 9, first_name: 'Ada' },
+                text: '@fake_bot  do   the thing',
+                entities: [{ type: 'mention', offset: 0, length: 9 }],
+              },
+            },
+            {
+              update_id: 4,
+              message: {
+                message_id: 14,
+                chat: { id: 555, type: 'private' },
+                from: { id: 77, is_bot: true },
+                text: 'I am a bot',
+              },
+            },
+          ],
+        })
+      }
+      return json({ ok: false, description: `unexpected ${method}` })
+    })
+  })
+  await new Promise<void>((r) => server.listen(0, () => r()))
+  base = `http://127.0.0.1:${(server.address() as { port: number }).port}`
+})
+
+afterAll(() => server.close())
+
+describe('Telegram polling loop against a Bot API server', () => {
+  it('drives the whole receive -> trigger -> reply path', async () => {
+    const mgr = new TelegramConnectionManager()
+    await mgr.start('agt_fake', { botToken: '4242:secret', apiBaseUrl: base })
+    await vi.waitFor(() => expect(reserved.length).toBe(2), { timeout: 5_000 })
+
+    // Only the private message and the @mentioned group message start a run.
+    expect(reserved[0]?.intent).toBe('hello agent')
+    // The bot handle is stripped and whitespace collapsed.
+    expect(reserved[1]?.intent).toBe('do the thing')
+    expect(reserved[0]?.displayName).toBe('Ada')
+
+    // Event ids are chat-scoped, because Telegram message ids repeat across chats.
+    expect(reserved[0]?.eventId).toBe('telegram:4242:555:11')
+    expect(reserved[1]?.eventId).toBe('telegram:4242:-100:13')
+
+    const ctx = reserved[0]?.channel as {
+      channel_info: { chat_id: string; chat_type: string; message_id: string }
+    }
+    expect(ctx.channel_info).toMatchObject({
+      chat_id: '555',
+      chat_type: 'private',
+      message_id: '11',
+    })
+
+    // A long reply is split, addressed to the right chat, and quotes the original.
+    await mgr.sendRunResultByContext('agt_fake', ctx as never, 'a'.repeat(9_000), [])
+    expect(sent).toHaveLength(3)
+    expect(sent[0]?.chat_id).toBe('555')
+    expect(sent[0]?.reply_parameters?.message_id).toBe(11)
+    expect(sent.map((m) => m.text.length).reduce((a, b) => a + b, 0)).toBe(9_000)
+
+    await mgr.stop('agt_fake')
+    expect(mgr.isSocketOpen('agt_fake')).toBe(false)
+  })
+})

--- a/apps/api/src/lib/__tests__/telegram-service.test.ts
+++ b/apps/api/src/lib/__tests__/telegram-service.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildTelegramConversationId,
+  chunkTelegramText,
+  extractTelegramMessage,
+  extractTelegramNativeAttachments,
+  parseTelegramBotId,
+  shouldTriggerTelegramMessage,
+  stripTelegramBotMention,
+  type TelegramMessageSnapshot,
+  telegramApiBase,
+  telegramMessageText,
+  telegramSenderName,
+} from '../telegram-service.js'
+
+const config = {
+  groupTriggerOnMention: true,
+  groupTriggerOnNewMessage: false,
+}
+
+const BOT_ID = '4242'
+const BOT_USERNAME = 'a2wave_bot'
+
+function message(overrides: Partial<TelegramMessageSnapshot> = {}): TelegramMessageSnapshot {
+  return {
+    message_id: 7,
+    from: { id: 99, is_bot: false, first_name: 'Ada' },
+    chat: { id: -100200, type: 'supergroup' },
+    text: 'hello',
+    ...overrides,
+  }
+}
+
+describe('parseTelegramBotId', () => {
+  it('derives the bot id from the token prefix', () => {
+    expect(parseTelegramBotId('4242:AAH-secret')).toBe('4242')
+  })
+
+  it('rejects a token without a numeric bot id', () => {
+    expect(() => parseTelegramBotId('not-a-token')).toThrow(/numeric bot id/)
+  })
+})
+
+describe('telegramApiBase', () => {
+  it('falls back to the public Bot API and strips a trailing slash', () => {
+    expect(telegramApiBase({ apiBaseUrl: undefined })).toBe('https://api.telegram.org')
+    expect(telegramApiBase({ apiBaseUrl: 'https://tg.internal/' })).toBe('https://tg.internal')
+  })
+})
+
+describe('shouldTriggerTelegramMessage', () => {
+  it('always accepts human private messages', () => {
+    expect(
+      shouldTriggerTelegramMessage(
+        config,
+        message({ chat: { id: 99, type: 'private' } }),
+        BOT_ID,
+        BOT_USERNAME,
+      ),
+    ).toBe(true)
+  })
+
+  it('ignores messages authored by any bot, to prevent reply loops', () => {
+    expect(
+      shouldTriggerTelegramMessage(
+        config,
+        message({ chat: { id: 99, type: 'private' }, from: { id: 5, is_bot: true } }),
+        BOT_ID,
+        BOT_USERNAME,
+      ),
+    ).toBe(false)
+  })
+
+  it('ignores the bot talking to itself even when is_bot is absent', () => {
+    expect(
+      shouldTriggerTelegramMessage(
+        config,
+        message({ chat: { id: 99, type: 'private' }, from: { id: Number(BOT_ID) } }),
+        BOT_ID,
+        BOT_USERNAME,
+      ),
+    ).toBe(false)
+  })
+
+  it('requires an @mention in groups by default', () => {
+    expect(shouldTriggerTelegramMessage(config, message(), BOT_ID, BOT_USERNAME)).toBe(false)
+    expect(
+      shouldTriggerTelegramMessage(
+        config,
+        message({
+          text: `@${BOT_USERNAME} ship it`,
+          entities: [{ type: 'mention', offset: 0, length: BOT_USERNAME.length + 1 }],
+        }),
+        BOT_ID,
+        BOT_USERNAME,
+      ),
+    ).toBe(true)
+  })
+
+  it('does not fire on a mention of a different bot', () => {
+    expect(
+      shouldTriggerTelegramMessage(
+        config,
+        message({
+          text: '@someone_else ship it',
+          entities: [{ type: 'mention', offset: 0, length: 14 }],
+        }),
+        BOT_ID,
+        BOT_USERNAME,
+      ),
+    ).toBe(false)
+  })
+
+  it('treats a reply to the bot as addressing it', () => {
+    expect(
+      shouldTriggerTelegramMessage(
+        config,
+        message({ reply_to_message: { message_id: 1, from: { id: Number(BOT_ID) } } }),
+        BOT_ID,
+        BOT_USERNAME,
+      ),
+    ).toBe(true)
+  })
+
+  it('accepts every group message once groupTriggerOnNewMessage is on', () => {
+    expect(
+      shouldTriggerTelegramMessage(
+        { groupTriggerOnMention: false, groupTriggerOnNewMessage: true },
+        message(),
+        BOT_ID,
+        BOT_USERNAME,
+      ),
+    ).toBe(true)
+  })
+
+  it('recognises a mention carried by a media caption', () => {
+    expect(
+      shouldTriggerTelegramMessage(
+        config,
+        message({
+          text: undefined,
+          caption: `@${BOT_USERNAME} review this`,
+          caption_entities: [{ type: 'mention', offset: 0, length: BOT_USERNAME.length + 1 }],
+        }),
+        BOT_ID,
+        BOT_USERNAME,
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('stripTelegramBotMention', () => {
+  it('removes the bot handle and collapses whitespace', () => {
+    expect(stripTelegramBotMention(`@${BOT_USERNAME}  ship   it`, BOT_USERNAME)).toBe('ship it')
+  })
+
+  it('leaves other handles intact', () => {
+    expect(stripTelegramBotMention('@someone ship it', BOT_USERNAME)).toBe('@someone ship it')
+  })
+})
+
+describe('telegramMessageText', () => {
+  it('falls back to the caption so a media-only message still carries intent', () => {
+    expect(telegramMessageText(message({ text: undefined, caption: ' look ' }))).toBe('look')
+  })
+})
+
+describe('extractTelegramNativeAttachments', () => {
+  it('maps a document to a persistable descriptor without a download URL', () => {
+    const attachments = extractTelegramNativeAttachments(
+      message({
+        document: {
+          file_id: 'FILE1',
+          file_name: 'report.pdf',
+          mime_type: 'application/pdf',
+          file_size: 12,
+        },
+      }),
+    )
+    expect(attachments).toEqual([
+      {
+        source: 'telegram',
+        remoteId: 'FILE1',
+        name: 'report.pdf',
+        mimeType: 'application/pdf',
+        size: 12,
+      },
+    ])
+  })
+
+  it('keeps only the highest-resolution entry of a photo ladder', () => {
+    const attachments = extractTelegramNativeAttachments(
+      message({
+        photo: [
+          { file_id: 'SMALL', file_size: 1 },
+          { file_id: 'LARGE', file_size: 900 },
+        ],
+      }),
+    )
+    expect(attachments).toHaveLength(1)
+    expect(attachments[0]?.remoteId).toBe('LARGE')
+  })
+
+  it('returns nothing for a plain text message', () => {
+    expect(extractTelegramNativeAttachments(message())).toEqual([])
+  })
+})
+
+describe('buildTelegramConversationId', () => {
+  it('keys a private chat on the chat itself', () => {
+    expect(
+      buildTelegramConversationId(BOT_ID, {
+        chat: { id: 99, type: 'private' },
+        from: { id: 99 },
+      }),
+    ).toBe(`${BOT_ID}:99`)
+  })
+
+  it('separates two senders sharing one group', () => {
+    const base = { chat: { id: -100200, type: 'supergroup' as const } }
+    expect(buildTelegramConversationId(BOT_ID, { ...base, from: { id: 1 } })).not.toBe(
+      buildTelegramConversationId(BOT_ID, { ...base, from: { id: 2 } }),
+    )
+  })
+
+  it('separates forum topics within one supergroup', () => {
+    const base = { chat: { id: -100200, type: 'supergroup' as const }, from: { id: 1 } }
+    expect(buildTelegramConversationId(BOT_ID, { ...base, message_thread_id: 5 })).not.toBe(
+      buildTelegramConversationId(BOT_ID, { ...base, message_thread_id: 6 }),
+    )
+  })
+})
+
+describe('telegramSenderName', () => {
+  it('prefers the full name and falls back to the username', () => {
+    expect(telegramSenderName({ id: 1, first_name: 'Ada', last_name: 'Lovelace' })).toBe(
+      'Ada Lovelace',
+    )
+    expect(telegramSenderName({ id: 1, username: 'ada' })).toBe('ada')
+    expect(telegramSenderName(undefined)).toBeUndefined()
+  })
+})
+
+describe('extractTelegramMessage', () => {
+  it('reads both message and channel_post updates', () => {
+    expect(extractTelegramMessage({ update_id: 1, message: message() })?.message_id).toBe(7)
+    expect(extractTelegramMessage({ update_id: 1, channel_post: message() })?.message_id).toBe(7)
+    expect(extractTelegramMessage({ update_id: 1 })).toBeUndefined()
+  })
+})
+
+describe('chunkTelegramText', () => {
+  it('keeps a short reply in one piece', () => {
+    expect(chunkTelegramText('hi')).toEqual(['hi'])
+  })
+
+  it('splits a reply that would exceed the Telegram message limit', () => {
+    const chunks = chunkTelegramText('x'.repeat(9_000))
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks.every((chunk) => chunk.length <= 4_000)).toBe(true)
+    expect(chunks.join('')).toHaveLength(9_000)
+  })
+})

--- a/apps/api/src/lib/agent-export.ts
+++ b/apps/api/src/lib/agent-export.ts
@@ -40,6 +40,7 @@ export interface ExportedAgent {
   feishuConfig: Record<string, unknown> | null
   slackConfig?: Record<string, unknown> | null
   discordConfig?: Record<string, unknown> | null
+  telegramConfig?: Record<string, unknown> | null
   qqOfficialConfig?: Record<string, unknown> | null
   chatAppConfig?: Record<string, unknown> | null
   scheduleConfig: Record<string, unknown> | Array<Record<string, unknown>> | null
@@ -233,6 +234,9 @@ export function sanitizeAgent(agent: AgentRow): ExportedAgent {
   const sanitizedSlackConfig = agent.slackConfig
     ? { ...agent.slackConfig, appToken: '********', botToken: '********' }
     : null
+  const sanitizedTelegramConfig = agent.telegramConfig
+    ? { ...agent.telegramConfig, botToken: '********' }
+    : agent.telegramConfig
   const sanitizedDiscordConfig = agent.discordConfig
     ? { ...agent.discordConfig, botToken: '********' }
     : null
@@ -263,6 +267,7 @@ export function sanitizeAgent(agent: AgentRow): ExportedAgent {
     feishuConfig: sanitizedFeishuConfig,
     slackConfig: sanitizedSlackConfig,
     discordConfig: sanitizedDiscordConfig,
+    telegramConfig: sanitizedTelegramConfig,
     qqOfficialConfig: sanitizedQQOfficialConfig,
     // No masking pass: chat app config is presentation copy with no credentials.
     chatAppConfig: (agent.chatAppConfig as Record<string, unknown> | null) ?? null,

--- a/apps/api/src/lib/agent-import.ts
+++ b/apps/api/src/lib/agent-import.ts
@@ -893,6 +893,7 @@ export async function importAgentFromZip(
       (channel) =>
         channel !== 'slack' &&
         channel !== 'discord' &&
+        channel !== 'telegram' &&
         channel !== 'qq_official' &&
         !droppedGitChannels.has(channel),
     )
@@ -901,6 +902,9 @@ export async function importAgentFromZip(
     }
     if (exportedPublishChannels.includes('discord') || exportedAgent.discordConfig) {
       warnings.push('Discord credentials are not imported; reconfigure Discord before publishing')
+    }
+    if (exportedPublishChannels.includes('telegram') || exportedAgent.telegramConfig) {
+      warnings.push('Telegram credentials are not imported; reconfigure Telegram before publishing')
     }
     if (exportedPublishChannels.includes('qq_official') || exportedAgent.qqOfficialConfig) {
       warnings.push(
@@ -989,6 +993,7 @@ export async function importAgentFromZip(
         | 'feishu'
         | 'slack'
         | 'discord'
+        | 'telegram'
         | 'qq_official'
         | 'schedule'
         | 'oauth'
@@ -1020,6 +1025,7 @@ export async function importAgentFromZip(
       feishuConfig: exportedAgent.feishuConfig as (typeof agents.$inferInsert)['feishuConfig'],
       slackConfig: null,
       discordConfig: null,
+      telegramConfig: null,
       qqOfficialConfig: null,
       // Carries presentation copy only, so unlike Slack/Discord there is no
       // credential to strip and it round-trips intact.

--- a/apps/api/src/lib/graceful-shutdown.ts
+++ b/apps/api/src/lib/graceful-shutdown.ts
@@ -20,6 +20,7 @@ export interface GracefulShutdownDeps {
   stopFeishu: () => void
   stopSlack: () => void
   stopDiscord: () => void
+  stopTelegram: () => void
   stopQQOfficial: () => void
   stopSchedules: () => void
   /** Persist durable SCM lease releases emitted while children exit. */
@@ -65,6 +66,7 @@ export async function runGracefulShutdownSequence(deps: GracefulShutdownDeps): P
   safely(deps.stopFeishu, 'stopFeishu')
   safely(deps.stopSlack, 'stopSlack')
   safely(deps.stopDiscord, 'stopDiscord')
+  safely(deps.stopTelegram, 'stopTelegram')
   safely(deps.stopQQOfficial, 'stopQQOfficial')
   safely(deps.stopSchedules, 'stopSchedules')
   try {

--- a/apps/api/src/lib/native-chat-attachments.ts
+++ b/apps/api/src/lib/native-chat-attachments.ts
@@ -1,6 +1,6 @@
 import { extname } from 'node:path'
-import type { AttachmentRef, DiscordConfig, SlackConfig } from '@a2wave/shared'
-import { discordConfigSchema, slackConfigSchema } from '@a2wave/shared'
+import type { AttachmentRef, DiscordConfig, SlackConfig, TelegramConfig } from '@a2wave/shared'
+import { discordConfigSchema, slackConfigSchema, telegramConfigSchema } from '@a2wave/shared'
 import { WebClient } from '@slack/web-api'
 import { eq } from 'drizzle-orm'
 import { db } from '../db/client.js'
@@ -28,6 +28,18 @@ export type NativeChatAttachment =
       size?: number
     }
   | {
+      /**
+       * Telegram exposes a `file_id` that stays valid for the bot, and resolving
+       * it to bytes needs a `getFile` hop — so only the id is persisted, never the
+       * token-bearing download URL.
+       */
+      source: 'telegram'
+      remoteId: string
+      name: string
+      mimeType?: string
+      size?: number
+    }
+  | {
       source: 'qq_official'
       remoteUrl: string
       name: string
@@ -40,6 +52,7 @@ export type PersistedNativeChatAttachment = Exclude<NativeChatAttachment, { sour
 const FETCH_TIMEOUT_MS = 15_000
 const SLACK_FILE_HOSTS = new Set(['files.slack.com'])
 const DISCORD_FILE_HOSTS = new Set(['cdn.discordapp.com', 'media.discordapp.net'])
+export const TELEGRAM_DEFAULT_API_BASE = 'https://api.telegram.org'
 
 function isAllowedExtension(name: string, allowed: Set<string>): boolean {
   const extension = extname(name).replace(/^\./, '').toLowerCase()
@@ -196,6 +209,83 @@ async function resolveDiscordAttachment(
   }
 }
 
+async function resolveTelegramAttachment(
+  descriptor: Extract<NativeChatAttachment, { source: 'telegram' }>,
+  config: TelegramConfig,
+  maxBytes: number,
+): Promise<{ bytes: Buffer; name: string; mimeType: string }> {
+  const normalized = telegramConfigSchema.parse(config)
+  const apiBase = (normalized.apiBaseUrl ?? TELEGRAM_DEFAULT_API_BASE).replace(/\/+$/, '')
+  const validateHop = (hop: string): void => {
+    const parsed = assertSafeStrictUrl(hop)
+    if (parsed.protocol !== 'https:' && !apiBase.startsWith('http://')) {
+      throw new Error('Telegram file URL must use HTTPS')
+    }
+    if (parsed.origin !== new URL(apiBase).origin) {
+      throw new Error('Telegram file URL is not on the configured Bot API host')
+    }
+  }
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  let filePath: string
+  let remoteSize: number | undefined
+  try {
+    const getFileUrl = `${apiBase}/bot${normalized.botToken}/getFile?file_id=${encodeURIComponent(
+      descriptor.remoteId,
+    )}`
+    const response = await safeFetch(getFileUrl, {
+      signal: controller.signal,
+      maxRedirects: 0,
+      validateHop,
+    })
+    if (!response.ok) throw new Error(`Telegram getFile returned HTTP ${response.status}`)
+    const payload = (await response.json()) as {
+      ok?: boolean
+      result?: { file_path?: string; file_size?: number }
+    }
+    if (!payload.ok || !payload.result?.file_path) {
+      throw new Error('Telegram getFile did not return a file path')
+    }
+    filePath = payload.result.file_path
+    remoteSize = payload.result.file_size
+  } finally {
+    clearTimeout(timer)
+  }
+
+  const size = remoteSize ?? descriptor.size
+  if (size != null && size > maxBytes) {
+    throw new Error('Telegram attachment exceeds configured size limit')
+  }
+
+  const downloadController = new AbortController()
+  const downloadTimer = setTimeout(() => downloadController.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const downloadUrl = `${apiBase}/file/bot${normalized.botToken}/${filePath
+      .split('/')
+      .map(encodeURIComponent)
+      .join('/')}`
+    const response = await safeFetch(downloadUrl, {
+      signal: downloadController.signal,
+      maxRedirects: 0,
+      validateHop,
+    })
+    if (!response.ok) {
+      throw new Error(`Telegram attachment download returned HTTP ${response.status}`)
+    }
+    return {
+      bytes: await readBodyWithLimit(response, maxBytes),
+      name: descriptor.name,
+      mimeType:
+        descriptor.mimeType ??
+        response.headers.get('content-type')?.split(';')[0]?.trim() ??
+        'application/octet-stream',
+    }
+  } finally {
+    clearTimeout(downloadTimer)
+  }
+}
+
 async function resolveQQOfficialAttachment(
   descriptor: Extract<NativeChatAttachment, { source: 'qq_official' }>,
   maxBytes: number,
@@ -243,7 +333,11 @@ export async function resolveNativeChatAttachments(
   const capped = descriptors.slice(0, (await settings).maxFilesPerRequest)
   const agent = (
     await db
-      .select({ slackConfig: agents.slackConfig, discordConfig: agents.discordConfig })
+      .select({
+        slackConfig: agents.slackConfig,
+        discordConfig: agents.discordConfig,
+        telegramConfig: agents.telegramConfig,
+      })
       .from(agents)
       .where(eq(agents.id, agentId))
       .limit(1)
@@ -274,7 +368,13 @@ export async function resolveNativeChatAttachments(
                 agent.discordConfig as DiscordConfig,
                 (await settings).maxFileSizeBytes,
               )
-            : await resolveQQOfficialAttachment(descriptor, (await settings).maxFileSizeBytes)
+            : descriptor.source === 'telegram'
+              ? await resolveTelegramAttachment(
+                  descriptor,
+                  agent.telegramConfig as TelegramConfig,
+                  (await settings).maxFileSizeBytes,
+                )
+              : await resolveQQOfficialAttachment(descriptor, (await settings).maxFileSizeBytes)
       if (!isAllowedExtension(resolved.name, (await settings).allowedExtensions)) {
         throw new Error('Resolved attachment extension is not allowed')
       }

--- a/apps/api/src/lib/native-chat-channel.ts
+++ b/apps/api/src/lib/native-chat-channel.ts
@@ -1,4 +1,4 @@
-export const NATIVE_CHAT_CHANNELS = ['slack', 'discord', 'qq_official'] as const
+export const NATIVE_CHAT_CHANNELS = ['slack', 'discord', 'telegram', 'qq_official'] as const
 
 export type NativeChatSource = (typeof NATIVE_CHAT_CHANNELS)[number]
 

--- a/apps/api/src/lib/native-chat-runner.ts
+++ b/apps/api/src/lib/native-chat-runner.ts
@@ -3,6 +3,7 @@ import type {
   RunChannelContextDiscord,
   RunChannelContextQQOfficial,
   RunChannelContextSlack,
+  RunChannelContextTelegram,
 } from '@a2wave/shared'
 import { and, eq } from 'drizzle-orm'
 import { db } from '../db/client.js'
@@ -26,7 +27,11 @@ export interface ReserveNativeChatRunInput {
   eventId: string
   conversationId: string
   intent: string
-  channel: RunChannelContextSlack | RunChannelContextDiscord | RunChannelContextQQOfficial
+  channel:
+    | RunChannelContextSlack
+    | RunChannelContextDiscord
+    | RunChannelContextTelegram
+    | RunChannelContextQQOfficial
   displayName?: string | null
   /** Force this durable turn to start a new provider conversation. */
   resetSession?: boolean

--- a/apps/api/src/lib/run-channel.ts
+++ b/apps/api/src/lib/run-channel.ts
@@ -167,6 +167,7 @@ export function buildGatewayChannel(c: Context, opts: BuildGatewayChannelOpts): 
       upstream.channel_type === 'feishu' ||
       upstream.channel_type === 'slack' ||
       upstream.channel_type === 'discord' ||
+      upstream.channel_type === 'telegram' ||
       upstream.channel_type === 'qq_official' ||
       upstream.channel_type === 'debug' ||
       upstream.channel_type === 'chat_app' ||
@@ -500,6 +501,38 @@ export function buildDiscordChannel(opts: BuildDiscordChannelOpts): ChannelBuild
         chat_type: opts.chatType,
         message_id: opts.messageId,
         ...(opts.threadId ? { thread_id: opts.threadId } : {}),
+        sender_user_id: opts.senderUserId,
+      },
+      user_info: null,
+      ...(displayName ? { display_name: displayName } : {}),
+    },
+    displayName,
+  }
+}
+
+// ── Telegram ─────────────────────────────────────────────────────────────────
+
+export interface BuildTelegramChannelOpts {
+  botId: string
+  chatId: string
+  chatType: 'private' | 'group' | 'supergroup' | 'channel'
+  messageId: string
+  messageThreadId?: string
+  senderUserId: string
+  senderName?: string
+}
+
+export function buildTelegramChannel(opts: BuildTelegramChannelOpts): ChannelBuildResult {
+  const displayName = opts.senderName?.trim() || null
+  return {
+    ctx: {
+      channel_type: 'telegram',
+      channel_info: {
+        bot_id: opts.botId,
+        chat_id: opts.chatId,
+        chat_type: opts.chatType,
+        message_id: opts.messageId,
+        ...(opts.messageThreadId ? { message_thread_id: opts.messageThreadId } : {}),
         sender_user_id: opts.senderUserId,
       },
       user_info: null,

--- a/apps/api/src/lib/run-lifecycle.ts
+++ b/apps/api/src/lib/run-lifecycle.ts
@@ -4,6 +4,7 @@ import {
   type RunChannelContextDiscord,
   type RunChannelContextQQOfficial,
   type RunChannelContextSlack,
+  type RunChannelContextTelegram,
 } from '@a2wave/shared'
 /**
  * Run lifecycle helpers — centralize the repeated pattern of:
@@ -336,11 +337,13 @@ function sendNativeChatReplyByContext(
   const channel = context?.channel as
     | RunChannelContextSlack
     | RunChannelContextDiscord
+    | RunChannelContextTelegram
     | RunChannelContextQQOfficial
     | undefined
   if (
     channel?.channel_type !== 'slack' &&
     channel?.channel_type !== 'discord' &&
+    channel?.channel_type !== 'telegram' &&
     channel?.channel_type !== 'qq_official'
   )
     return
@@ -354,14 +357,23 @@ function sendNativeChatReplyByContext(
         ? import('./discord-service.js').then(({ discordConnectionManager }) =>
             discordConnectionManager.sendRunResultByContext(agentId, channel, replyText, artifacts),
           )
-        : import('./qq-official-service.js').then(({ qqOfficialConnectionManager }) =>
-            qqOfficialConnectionManager.sendRunResultByContext(
-              agentId,
-              channel,
-              replyText,
-              artifacts,
-            ),
-          )
+        : channel.channel_type === 'telegram'
+          ? import('./telegram-service.js').then(({ telegramConnectionManager }) =>
+              telegramConnectionManager.sendRunResultByContext(
+                agentId,
+                channel,
+                replyText,
+                artifacts,
+              ),
+            )
+          : import('./qq-official-service.js').then(({ qqOfficialConnectionManager }) =>
+              qqOfficialConnectionManager.sendRunResultByContext(
+                agentId,
+                channel,
+                replyText,
+                artifacts,
+              ),
+            )
   void send.catch((err) =>
     logger.warn(
       { err, runId, agentId, channel: channel.channel_type },

--- a/apps/api/src/lib/telegram-service.ts
+++ b/apps/api/src/lib/telegram-service.ts
@@ -1,0 +1,552 @@
+import {
+  type RunChannelContextTelegram,
+  type TelegramConfig,
+  telegramConfigSchema,
+} from '@a2wave/shared'
+import { eq } from 'drizzle-orm'
+import { db } from '../db/client.js'
+import { agents } from '../db/schema.js'
+import { buildArtifactLinkLinesSync } from './artifact-links.js'
+import type { RegisteredArtifact } from './artifact-storage.js'
+import { logger } from './logger.js'
+import { prepareNativeArtifactUpload } from './native-chat-artifacts.js'
+import type { NativeChatAttachment } from './native-chat-attachments.js'
+import { TELEGRAM_DEFAULT_API_BASE } from './native-chat-attachments.js'
+import { reserveNativeChatRun } from './native-chat-runner.js'
+import { appendNativeArtifactDownloadSection, prepareNativeChatText } from './native-chat-text.js'
+import { buildTelegramChannel } from './run-channel.js'
+
+type NormalizedTelegramConfig = ReturnType<typeof telegramConfigSchema.parse>
+
+/** Telegram rejects `sendMessage` bodies over 4096 UTF-16 code units. */
+const TELEGRAM_TEXT_LIMIT = 4_000
+/** Long-poll window. Telegram holds the request open until an update or timeout. */
+const TELEGRAM_POLL_TIMEOUT_SECONDS = 30
+const TELEGRAM_POLL_ERROR_BACKOFF_MS = 3_000
+
+export interface TelegramUserSnapshot {
+  id: number
+  is_bot?: boolean
+  username?: string
+  first_name?: string
+  last_name?: string
+}
+
+export interface TelegramDocumentSnapshot {
+  file_id: string
+  file_unique_id?: string
+  file_name?: string
+  mime_type?: string
+  file_size?: number
+}
+
+export interface TelegramMessageSnapshot {
+  message_id: number
+  message_thread_id?: number
+  from?: TelegramUserSnapshot
+  chat: { id: number; type: 'private' | 'group' | 'supergroup' | 'channel' }
+  date?: number
+  text?: string
+  caption?: string
+  entities?: { type: string; offset: number; length: number }[]
+  caption_entities?: { type: string; offset: number; length: number }[]
+  reply_to_message?: { message_id: number; from?: TelegramUserSnapshot }
+  document?: TelegramDocumentSnapshot
+  photo?: TelegramDocumentSnapshot[]
+  video?: TelegramDocumentSnapshot & { file_name?: string }
+  audio?: TelegramDocumentSnapshot & { file_name?: string }
+  voice?: TelegramDocumentSnapshot
+}
+
+export interface TelegramUpdate {
+  update_id: number
+  message?: TelegramMessageSnapshot
+  channel_post?: TelegramMessageSnapshot
+}
+
+interface TelegramConnection {
+  config: NormalizedTelegramConfig
+  botId: string
+  botUsername?: string
+  abort: AbortController
+  polling: boolean
+  offset: number
+}
+
+/**
+ * The numeric prefix of `<bot_id>:<secret>` is the bot's own user id. Deriving it
+ * from the token means a config save needs no extra `getMe` round trip to know
+ * which bot it is addressing, and it gives the channel a stable identity key.
+ */
+export function parseTelegramBotId(botToken: string): string {
+  const botId = botToken.split(':')[0]?.trim()
+  if (!botId || !/^\d+$/.test(botId)) {
+    throw new Error('Telegram bot token must start with a numeric bot id')
+  }
+  return botId
+}
+
+export function telegramApiBase(config: Pick<NormalizedTelegramConfig, 'apiBaseUrl'>): string {
+  return (config.apiBaseUrl ?? TELEGRAM_DEFAULT_API_BASE).replace(/\/+$/, '')
+}
+
+function canReuseTelegramConnection(
+  current: Pick<NormalizedTelegramConfig, 'botToken' | 'apiBaseUrl'>,
+  next: Pick<NormalizedTelegramConfig, 'botToken' | 'apiBaseUrl'>,
+  isPolling: boolean,
+): boolean {
+  return isPolling && current.botToken === next.botToken && current.apiBaseUrl === next.apiBaseUrl
+}
+
+export function extractTelegramMessage(
+  update: TelegramUpdate,
+): TelegramMessageSnapshot | undefined {
+  return update.message ?? update.channel_post
+}
+
+/**
+ * Telegram spreads the user-authored text across `text` (plain messages) and
+ * `caption` (messages carrying media), so a caption-only upload still reads as
+ * an intent rather than an empty prompt.
+ */
+export function telegramMessageText(message: TelegramMessageSnapshot): string {
+  return (message.text ?? message.caption ?? '').trim()
+}
+
+/**
+ * Photos arrive as an ascending ladder of the same image; the last entry is the
+ * highest resolution, which is the one worth handing to the Agent.
+ */
+export function extractTelegramNativeAttachments(
+  message: TelegramMessageSnapshot,
+): Extract<NativeChatAttachment, { source: 'telegram' }>[] {
+  const attachments: Extract<NativeChatAttachment, { source: 'telegram' }>[] = []
+  const push = (file: TelegramDocumentSnapshot | undefined, fallbackName: string): void => {
+    if (!file?.file_id) return
+    attachments.push({
+      source: 'telegram' as const,
+      remoteId: file.file_id,
+      name: file.file_name ?? fallbackName,
+      ...(file.mime_type ? { mimeType: file.mime_type } : {}),
+      ...(file.file_size != null ? { size: file.file_size } : {}),
+    })
+  }
+  push(message.document, `document-${message.message_id}`)
+  const largestPhoto = message.photo?.[message.photo.length - 1]
+  push(largestPhoto, `photo-${message.message_id}.jpg`)
+  push(message.video, `video-${message.message_id}.mp4`)
+  push(message.audio, `audio-${message.message_id}.mp3`)
+  push(message.voice, `voice-${message.message_id}.ogg`)
+  return attachments
+}
+
+/**
+ * A group trigger fires on an explicit address to the bot: an `@username`
+ * mention, or a reply to one of the bot's own messages. Private chats are always
+ * addressed to the bot, so they need no mention.
+ */
+export function shouldTriggerTelegramMessage(
+  config: Pick<NormalizedTelegramConfig, 'groupTriggerOnMention' | 'groupTriggerOnNewMessage'>,
+  message: TelegramMessageSnapshot,
+  botId: string,
+  botUsername?: string,
+): boolean {
+  if (message.from?.is_bot) return false
+  if (message.from && String(message.from.id) === botId) return false
+  if (message.chat.type === 'private') return true
+
+  const text = message.text ?? message.caption ?? ''
+  const entities = message.entities ?? message.caption_entities ?? []
+  const isMentioned = botUsername
+    ? entities.some(
+        (entity) =>
+          entity.type === 'mention' &&
+          text.slice(entity.offset, entity.offset + entity.length).toLowerCase() ===
+            `@${botUsername.toLowerCase()}`,
+      )
+    : false
+  const isReplyToBot = String(message.reply_to_message?.from?.id ?? '') === botId
+  return (
+    (config.groupTriggerOnMention && (isMentioned || isReplyToBot)) ||
+    config.groupTriggerOnNewMessage
+  )
+}
+
+export function stripTelegramBotMention(text: string, botUsername?: string): string {
+  if (!botUsername) return text.trim()
+  return text
+    .replace(new RegExp(`@${escapeRegExp(botUsername)}\\b`, 'gi'), '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
+ * Private chats key on the chat itself; groups key on chat + sender so two
+ * colleagues talking to the same bot in one group keep separate sessions, which
+ * matches how the Discord channel scopes a guild conversation.
+ */
+export function buildTelegramConversationId(
+  botId: string,
+  message: Pick<TelegramMessageSnapshot, 'chat' | 'from' | 'message_thread_id'>,
+): string {
+  if (message.chat.type === 'private') return `${botId}:${message.chat.id}`
+  const thread = message.message_thread_id != null ? `:${message.message_thread_id}` : ''
+  return `${message.chat.id}${thread}:${message.from?.id ?? 'unknown'}`
+}
+
+export function telegramSenderName(from?: TelegramUserSnapshot): string | undefined {
+  if (!from) return undefined
+  const full = [from.first_name, from.last_name].filter(Boolean).join(' ').trim()
+  return full || from.username || undefined
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function chunkTelegramText(text: string): string[] {
+  if (text.length <= TELEGRAM_TEXT_LIMIT) return [text]
+  const chunks: string[] = []
+  for (let offset = 0; offset < text.length; offset += TELEGRAM_TEXT_LIMIT) {
+    chunks.push(text.slice(offset, offset + TELEGRAM_TEXT_LIMIT))
+  }
+  return chunks
+}
+
+export class TelegramConnectionManager {
+  private readonly connections = new Map<string, TelegramConnection>()
+  private readonly botHolders = new Map<string, string>()
+
+  private async callApi<T>(
+    connection: Pick<TelegramConnection, 'config'>,
+    method: string,
+    body: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const url = `${telegramApiBase(connection.config)}/bot${connection.config.botToken}/${method}`
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      ...(signal ? { signal } : {}),
+    })
+    const payload = (await response.json().catch(() => null)) as {
+      ok?: boolean
+      result?: T
+      description?: string
+    } | null
+    if (!response.ok || !payload?.ok) {
+      throw new Error(
+        `Telegram ${method} failed: HTTP ${response.status}${
+          payload?.description ? ` ${payload.description}` : ''
+        }`,
+      )
+    }
+    return payload.result as T
+  }
+
+  async start(agentId: string, rawConfig: TelegramConfig | Record<string, unknown>): Promise<void> {
+    const config = telegramConfigSchema.parse(rawConfig)
+    const botId = parseTelegramBotId(config.botToken)
+    const holder = this.botHolders.get(botId)
+    if (holder && holder !== agentId) {
+      throw new Error(`Telegram bot ${botId} is already connected by Agent ${holder}`)
+    }
+
+    const previous = this.connections.get(agentId)
+    if (previous && canReuseTelegramConnection(previous.config, config, previous.polling)) {
+      previous.config = config
+      this.botHolders.set(botId, agentId)
+      return
+    }
+    if (previous) this.teardown(agentId, previous)
+    // Reserve synchronously before the first await so concurrent starters cannot both pass.
+    this.botHolders.set(botId, agentId)
+
+    const connection: TelegramConnection = {
+      config,
+      botId,
+      abort: new AbortController(),
+      polling: false,
+      offset: 0,
+    }
+    this.connections.set(agentId, connection)
+
+    try {
+      const me = await this.callApi<{ id: number; username?: string }>(connection, 'getMe', {})
+      if (String(me.id) !== botId) {
+        throw new Error('Telegram bot token does not match the derived bot id')
+      }
+      connection.botUsername = me.username
+      // getUpdates and a registered webhook are mutually exclusive; drop any stale
+      // webhook so a bot previously wired elsewhere can be polled here.
+      await this.callApi(connection, 'deleteWebhook', { drop_pending_updates: false }).catch(
+        (error) => logger.warn({ error, agentId }, 'Telegram deleteWebhook failed'),
+      )
+      connection.polling = true
+      void this.pollLoop(agentId, connection)
+    } catch (error) {
+      this.teardown(agentId, connection)
+      throw error
+    }
+  }
+
+  private teardown(agentId: string, connection: TelegramConnection): void {
+    connection.polling = false
+    connection.abort.abort()
+    this.connections.delete(agentId)
+    if (this.botHolders.get(connection.botId) === agentId) this.botHolders.delete(connection.botId)
+  }
+
+  private async pollLoop(agentId: string, connection: TelegramConnection): Promise<void> {
+    while (connection.polling && this.connections.get(agentId) === connection) {
+      try {
+        const updates = await this.callApi<TelegramUpdate[]>(
+          connection,
+          'getUpdates',
+          {
+            offset: connection.offset,
+            timeout: TELEGRAM_POLL_TIMEOUT_SECONDS,
+            allowed_updates: ['message', 'channel_post'],
+          },
+          connection.abort.signal,
+        )
+        for (const update of updates) {
+          // Advance past the update before handling it: acknowledging first keeps a
+          // message that throws from being redelivered forever and wedging the loop.
+          connection.offset = Math.max(connection.offset, update.update_id + 1)
+          await this.handleUpdate(agentId, connection, update).catch((error) =>
+            logger.error(
+              { error, agentId, updateId: update.update_id },
+              'Telegram update handler failed unexpectedly',
+            ),
+          )
+        }
+      } catch (error) {
+        if (!connection.polling || connection.abort.signal.aborted) return
+        logger.error({ error, agentId }, 'Telegram long poll failed')
+        await new Promise((resolve) => setTimeout(resolve, TELEGRAM_POLL_ERROR_BACKOFF_MS))
+      }
+    }
+  }
+
+  private async handleUpdate(
+    agentId: string,
+    connection: TelegramConnection,
+    update: TelegramUpdate,
+  ): Promise<void> {
+    const message = extractTelegramMessage(update)
+    if (!message) return
+    if (
+      !shouldTriggerTelegramMessage(
+        connection.config,
+        message,
+        connection.botId,
+        connection.botUsername,
+      )
+    ) {
+      return
+    }
+
+    const nativeAttachments = extractTelegramNativeAttachments(message)
+    const textIntent = stripTelegramBotMention(telegramMessageText(message), connection.botUsername)
+    if (!textIntent && nativeAttachments.length === 0) return
+    const intent = textIntent || 'Please review the attached files.'
+    const { ctx, displayName } = buildTelegramChannel({
+      botId: connection.botId,
+      chatId: String(message.chat.id),
+      chatType: message.chat.type,
+      messageId: String(message.message_id),
+      ...(message.message_thread_id != null
+        ? { messageThreadId: String(message.message_thread_id) }
+        : {}),
+      senderUserId: String(message.from?.id ?? message.chat.id),
+      ...(telegramSenderName(message.from)
+        ? { senderName: telegramSenderName(message.from) as string }
+        : {}),
+    })
+    const result = await reserveNativeChatRun({
+      agentId,
+      source: 'telegram',
+      eventId: `telegram:${connection.botId}:${message.chat.id}:${message.message_id}`,
+      conversationId: buildTelegramConversationId(connection.botId, message),
+      intent,
+      channel: ctx as RunChannelContextTelegram,
+      displayName,
+      nativeAttachments,
+    })
+    if (result.status === 'queue_full') {
+      await this.replyPlainText(connection, message, 'Agent queue is full.').catch((error) =>
+        logger.warn({ error, agentId }, 'Failed to send Telegram queue reply'),
+      )
+    } else if (result.status === 'scheduling_failed') {
+      await this.replyPlainText(
+        connection,
+        message,
+        'Agent could not schedule this message.',
+      ).catch((error) =>
+        logger.warn({ error, agentId }, 'Failed to send Telegram scheduling failure reply'),
+      )
+    }
+  }
+
+  private async replyPlainText(
+    connection: TelegramConnection,
+    message: TelegramMessageSnapshot,
+    text: string,
+  ): Promise<void> {
+    await this.callApi(connection, 'sendMessage', {
+      chat_id: message.chat.id,
+      text,
+      reply_parameters: { message_id: message.message_id, allow_sending_without_reply: true },
+      ...(message.message_thread_id != null
+        ? { message_thread_id: message.message_thread_id }
+        : {}),
+    })
+  }
+
+  async sendMessageByContext(
+    agentId: string,
+    context: RunChannelContextTelegram,
+    text: string,
+  ): Promise<void> {
+    await this.sendRunResultByContext(agentId, context, text, [])
+  }
+
+  async sendRunResultByContext(
+    agentId: string,
+    context: RunChannelContextTelegram,
+    text: string,
+    artifacts: RegisteredArtifact[],
+  ): Promise<void> {
+    const connection = this.connections.get(agentId)
+    if (!connection) throw new Error('Telegram connection is unavailable')
+    const info = context.channel_info
+    const replyMode =
+      info.chat_type === 'private'
+        ? connection.config.privateReplyMode
+        : connection.config.groupReplyMode
+    if (replyMode === 'none') return
+
+    const threadFields: Record<string, number> =
+      info.message_thread_id != null ? { message_thread_id: Number(info.message_thread_id) } : {}
+    const replyFields =
+      replyMode === 'reply'
+        ? {
+            reply_parameters: {
+              message_id: Number(info.message_id),
+              allow_sending_without_reply: true,
+            },
+          }
+        : {}
+
+    const sendText = async (chunk: string): Promise<void> => {
+      await this.callApi(connection, 'sendMessage', {
+        chat_id: info.chat_id,
+        text: chunk,
+        ...threadFields,
+        ...replyFields,
+      })
+    }
+
+    const uploadArtifacts = connection.config.sendArtifactsAsFile && artifacts.length > 0
+    const preparedText = prepareNativeChatText(text, uploadArtifacts)
+    if (preparedText) {
+      for (const chunk of chunkTelegramText(preparedText)) await sendText(chunk)
+    }
+    if (!connection.config.sendArtifactsAsFile) return
+
+    const failedArtifacts: RegisteredArtifact[] = []
+    for (const artifact of artifacts) {
+      try {
+        const upload = prepareNativeArtifactUpload(artifact)
+        if (!upload) {
+          failedArtifacts.push(artifact)
+          continue
+        }
+        await this.sendDocument(connection, info, upload, threadFields)
+      } catch (error) {
+        failedArtifacts.push(artifact)
+        logger.warn(
+          { error, agentId, artifactId: artifact.id, filename: artifact.filename },
+          'Failed to upload artifact to Telegram',
+        )
+      }
+    }
+    if (failedArtifacts.length > 0) {
+      const fallback = appendNativeArtifactDownloadSection(
+        '⚠️ Some artifacts could not be uploaded.',
+        await buildArtifactLinkLinesSync(failedArtifacts),
+      )
+      for (const chunk of chunkTelegramText(fallback)) await sendText(chunk)
+    }
+  }
+
+  private async sendDocument(
+    connection: TelegramConnection,
+    info: RunChannelContextTelegram['channel_info'],
+    upload: { filename: string; data: string | Buffer },
+    threadFields: Record<string, number>,
+  ): Promise<void> {
+    const { readFile } = await import('node:fs/promises')
+    const bytes = typeof upload.data === 'string' ? await readFile(upload.data) : upload.data
+    const form = new FormData()
+    form.append('chat_id', info.chat_id)
+    for (const [key, value] of Object.entries(threadFields)) form.append(key, String(value))
+    form.append('document', new Blob([new Uint8Array(bytes)]), upload.filename)
+
+    const url = `${telegramApiBase(connection.config)}/bot${connection.config.botToken}/sendDocument`
+    const response = await fetch(url, { method: 'POST', body: form })
+    const payload = (await response.json().catch(() => null)) as {
+      ok?: boolean
+      description?: string
+    } | null
+    if (!response.ok || !payload?.ok) {
+      throw new Error(
+        `Telegram sendDocument failed: HTTP ${response.status}${
+          payload?.description ? ` ${payload.description}` : ''
+        }`,
+      )
+    }
+  }
+
+  async stop(agentId: string): Promise<void> {
+    const connection = this.connections.get(agentId)
+    if (!connection) return
+    this.teardown(agentId, connection)
+  }
+
+  stopAll(): void {
+    for (const agentId of [...this.connections.keys()]) void this.stop(agentId)
+  }
+
+  isRegistered(agentId: string): boolean {
+    return this.connections.has(agentId)
+  }
+
+  isSocketOpen(agentId: string): boolean {
+    return this.connections.get(agentId)?.polling ?? false
+  }
+
+  getConnectionStatuses(): Array<{ agentId: string; socketOpen: boolean }> {
+    return [...this.connections.entries()].map(([agentId, value]) => ({
+      agentId,
+      socketOpen: value.polling,
+    }))
+  }
+
+  async restoreConnections(): Promise<void> {
+    const published = (
+      await db.select().from(agents).where(eq(agents.publishStatus, 'published'))
+    ).filter((agent) => (agent.publishChannels ?? []).includes('telegram') && agent.telegramConfig)
+    for (const agent of published) {
+      try {
+        await this.start(agent.id, agent.telegramConfig as TelegramConfig)
+      } catch (error) {
+        logger.error({ error, agentId: agent.id }, 'Failed to restore Telegram connection')
+      }
+    }
+  }
+}
+
+export const telegramConnectionManager = new TelegramConnectionManager()

--- a/apps/api/src/routes/__tests__/agents-secret-redaction-cases.ts
+++ b/apps/api/src/routes/__tests__/agents-secret-redaction-cases.ts
@@ -59,7 +59,7 @@ export function registerAgentSecretRedactionTests({
   })
 
   describe('maskAgentSecrets — native chat token redaction', () => {
-    it('masks Slack and Discord tokens outside the editable detail response', async () => {
+    it('masks Slack, Discord and Telegram tokens outside the editable detail response', async () => {
       const { maskAgentSecrets } = await import('../agents.js')
       const agent = {
         ...SAMPLE_AGENT,
@@ -69,6 +69,7 @@ export function registerAgentSecretRedactionTests({
           botToken: 'xoxb-secret',
         },
         discordConfig: { applicationId: 'D123', botToken: 'discord-secret' },
+        telegramConfig: { botToken: 'telegram-secret' },
       }
 
       const typedAgent = agent as unknown as Exclude<
@@ -79,10 +80,12 @@ export function registerAgentSecretRedactionTests({
       expect(masked.slackConfig?.appToken).toBe('********')
       expect(masked.slackConfig?.botToken).toBe('********')
       expect(masked.discordConfig?.botToken).toBe('********')
+      expect(masked.telegramConfig?.botToken).toBe('********')
 
       const revealed = maskAgentSecrets(typedAgent, { revealNativeChatSecrets: true })
       expect(revealed.slackConfig?.appToken).toBe('xapp-secret')
       expect(revealed.discordConfig?.botToken).toBe('discord-secret')
+      expect(revealed.telegramConfig?.botToken).toBe('telegram-secret')
     })
   })
 

--- a/apps/api/src/routes/agent-channel-config.ts
+++ b/apps/api/src/routes/agent-channel-config.ts
@@ -1,0 +1,288 @@
+/**
+ * PATCH /agents/:id/channels/:channel — save one channel's config on its own.
+ *
+ * Extracted from agents.ts, which had grown past the 3000-line gate. This route
+ * is the natural seam: it owns a self-contained registry (schema + column +
+ * live-connection restart per channel) that nothing else in agents.ts reads, so
+ * moving it leaves the publish path untouched.
+ *
+ * Mounted onto the agents router by agents.ts rather than exporting its own Hono
+ * instance, so the `/agents` prefix and middleware stack stay declared in one place.
+ */
+
+import {
+  chatAppConfigSchema,
+  discordConfigSchema,
+  ghTriggerConfigSchema,
+  glabTriggerConfigSchema,
+  qqOfficialConfigSchema,
+  scheduleConfigSchema,
+  slackConfigSchema,
+  telegramConfigSchema,
+} from '@a2wave/shared'
+import { eq } from 'drizzle-orm'
+import type { Hono } from 'hono'
+import { z } from 'zod'
+import { db } from '../db/client.js'
+import { agents } from '../db/schema.js'
+import { requireAgentWrite } from '../lib/agent-access.js'
+import { logAudit } from '../lib/audit.js'
+import { discordConnectionManager } from '../lib/discord-service.js'
+import { feishuConnectionManager, normalizeFeishuConfig } from '../lib/feishu-service.js'
+import { gitTriggerManager } from '../lib/git-trigger-manager.js'
+import { logger } from '../lib/logger.js'
+import { qqOfficialConnectionManager } from '../lib/qq-official-service.js'
+import type { ScheduleConfigInput } from '../lib/schedule-trigger.js'
+import { scheduleTriggerManager } from '../lib/schedule-trigger.js'
+import { slackConnectionManager } from '../lib/slack-service.js'
+import { telegramConnectionManager } from '../lib/telegram-service.js'
+import { maskAgentSecrets } from './agent-secret-masking.js'
+import { feishuConfigBodySchema } from './publish-feishu-config.js'
+
+/** Placeholder echoed back instead of a stored credential. */
+const MASKED_SECRET = '********'
+
+/**
+ * 每个渠道各自的 config body。刻意不复用 publishBodySchema——它对 authType /
+ * channels / ipWhitelist / description 都带 .default()，一旦复用，只想存飞书凭据
+ * 的请求会把 publishChannels 静默重置成 ['api']（等于关掉其它所有渠道），并顺手
+ * 轮换掉 endpointApiKey。
+ */
+const channelConfigSchemas = {
+  feishu: feishuConfigBodySchema,
+  slack: slackConfigSchema,
+  discord: discordConfigSchema,
+  telegram: telegramConfigSchema,
+  qq_official: qqOfficialConfigSchema,
+  chat_app: chatAppConfigSchema,
+  schedule: scheduleConfigSchema,
+  // Provider-bound, so a mismatched config is a 400 from schema validation
+  // itself rather than something this route has to remember to check.
+  glab: glabTriggerConfigSchema,
+  gh: ghTriggerConfigSchema,
+} as const
+
+type ConfigurableChannel = keyof typeof channelConfigSchemas
+
+/** config 值写到 agents 表的哪一列。 */
+const CHANNEL_CONFIG_COLUMN: Record<ConfigurableChannel, string> = {
+  feishu: 'feishuConfig',
+  slack: 'slackConfig',
+  discord: 'discordConfig',
+  telegram: 'telegramConfig',
+  qq_official: 'qqOfficialConfig',
+  chat_app: 'chatAppConfig',
+  schedule: 'scheduleConfig',
+  glab: 'glabConfig',
+  gh: 'ghConfig',
+}
+
+function isConfigurableChannel(value: string): value is ConfigurableChannel {
+  return Object.hasOwn(channelConfigSchemas, value)
+}
+
+/**
+ * PATCH /agents/:id/channels/:channel - 只保存单个渠道的配置。
+ *
+ * 与 POST /:id/publish 的关键区别：**配置 ≠ 发布**。publish 会把 Agent 置为
+ * published、戳 publishedAt、轮换 API Key，并按 channels 数组重启所有渠道的长连接；
+ * 而在卡片上点「配置」保存凭据不应触发其中任何一项——draft 仍是 draft，直到用户显式
+ * 点「发布」。启用与否由 publishChannels 决定，不归这个接口管，所以「配置了但不启用」
+ * 是完全合法的状态。
+ *
+ * 副作用也收窄到单个渠道：只有当 Agent 已发布**且**该渠道已在 publishChannels 中时，
+ * 才重启它自己的连接。改飞书配置不会顺带把 Slack / Discord 的在线 socket 打断——
+ * 这正是整份 publish payload 做不到的。
+ */
+export function registerAgentChannelConfigRoute(app: Hono): void {
+  app.patch('/:id/channels/:channel', async (c) => {
+    const { id, channel } = c.req.param()
+
+    if (!isConfigurableChannel(channel)) {
+      return c.json(
+        { error: `Channel '${channel}' has no saveable config.`, code: 'UNKNOWN_CHANNEL' },
+        400,
+      )
+    }
+
+    const body = await c.req.json().catch(() => ({}))
+    const parsed = z.object({ config: channelConfigSchemas[channel] }).safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: parsed.error.flatten() }, 400)
+    }
+
+    const { agent } = await requireAgentWrite(c, id)
+    const column = CHANNEL_CONFIG_COLUMN[channel]
+
+    /**
+     * 脱敏哨兵回填：前端从不拿到明文凭据，未修改的字段会原样回传 '********'。
+     *
+     * 关键在于「无可回填的原值」必须报错，而不是把哨兵当成密钥写进去——那会让该字段
+     * 读回来就已经是脱敏值，看着像已配置，实则每次调用都鉴权失败，且之后每次保存都会
+     * 把哨兵再「还原」一遍，用户无法自行修复。草稿 Agent 正是这种「库里还没有原值」的
+     * 状态，而配置弹窗恰恰是它录入凭据的主要入口。
+     */
+    const restoreSecret = (submitted: string | undefined, stored: string | undefined | null) => {
+      if (submitted !== MASKED_SECRET) return { ok: true as const, value: submitted }
+      if (!stored) return { ok: false as const, value: undefined }
+      return { ok: true as const, value: stored }
+    }
+
+    const maskedWithoutStored = (field: string) =>
+      c.json(
+        {
+          error: `${field} was sent masked but no stored value exists to restore.`,
+          code: 'MASKED_SECRET_WITHOUT_STORED_VALUE',
+        },
+        400,
+      )
+
+    let config: unknown = parsed.data.config
+    if (channel === 'feishu') {
+      const next = normalizeFeishuConfig(config as Record<string, unknown>)
+      const secret = restoreSecret(next.appSecret, agent.feishuConfig?.appSecret)
+      if (!secret.ok) return maskedWithoutStored('appSecret')
+      config = { ...next, appSecret: secret.value }
+    } else if (channel === 'slack') {
+      const next = config as { appToken?: string; botToken?: string }
+      const appToken = restoreSecret(next.appToken, agent.slackConfig?.appToken)
+      if (!appToken.ok) return maskedWithoutStored('appToken')
+      const botToken = restoreSecret(next.botToken, agent.slackConfig?.botToken)
+      if (!botToken.ok) return maskedWithoutStored('botToken')
+      config = { ...next, appToken: appToken.value, botToken: botToken.value }
+    } else if (channel === 'discord') {
+      const next = config as { botToken?: string }
+      const botToken = restoreSecret(next.botToken, agent.discordConfig?.botToken)
+      if (!botToken.ok) return maskedWithoutStored('botToken')
+      config = { ...next, botToken: botToken.value }
+    } else if (channel === 'telegram') {
+      const next = config as { botToken?: string }
+      const botToken = restoreSecret(next.botToken, agent.telegramConfig?.botToken)
+      if (!botToken.ok) return maskedWithoutStored('botToken')
+      config = { ...next, botToken: botToken.value }
+    } else if (channel === 'qq_official') {
+      const next = config as { appSecret?: string }
+      const appSecret = restoreSecret(next.appSecret, agent.qqOfficialConfig?.appSecret)
+      if (!appSecret.ok) return maskedWithoutStored('appSecret')
+      config = { ...next, appSecret: appSecret.value }
+    }
+
+    // 只有「已发布 + 该渠道已启用」才让改动即时生效；draft 或未启用时仅落库。
+    const isLive =
+      agent.publishStatus === 'published' && (agent.publishChannels ?? []).includes(channel)
+
+    /**
+     * 线上渠道不允许把凭据存成空值。
+     *
+     * 连接管理器的 start() 是「先 stop 再校验」：凭据为空时它已经把旧连接拆了才 return，
+     * 而本路由仍会返回 200、前端显示「保存成功」。于是管理员只要在已上线渠道的配置弹窗里
+     * 清空 App ID 保存，就会把正常在线的机器人静默下线，同时把无效配置写进库。
+     *
+     * 草稿 / 未启用的渠道不受此限制——编辑途中清空字段是正常操作，且没有连接可破坏。
+     */
+    if (isLive) {
+      const required: Record<string, string | undefined> =
+        channel === 'feishu'
+          ? {
+              appId: (config as { appId?: string }).appId,
+              appSecret: (config as { appSecret?: string }).appSecret,
+            }
+          : channel === 'slack'
+            ? {
+                appId: (config as { appId?: string }).appId,
+                appToken: (config as { appToken?: string }).appToken,
+                botToken: (config as { botToken?: string }).botToken,
+              }
+            : channel === 'discord'
+              ? {
+                  applicationId: (config as { applicationId?: string }).applicationId,
+                  botToken: (config as { botToken?: string }).botToken,
+                }
+              : channel === 'telegram'
+                ? { botToken: (config as { botToken?: string }).botToken }
+                : channel === 'qq_official'
+                  ? {
+                      appId: (config as { appId?: string }).appId,
+                      appSecret: (config as { appSecret?: string }).appSecret,
+                    }
+                  : {}
+      const blank = Object.entries(required).find(([, value]) => !value?.trim())
+      if (blank) {
+        return c.json(
+          {
+            error: `${blank[0]} cannot be empty while the ${channel} channel is live. Disable the channel first.`,
+            code: 'LIVE_CHANNEL_REQUIRES_CREDENTIALS',
+          },
+          400,
+        )
+      }
+    }
+
+    const updated = (
+      await db
+        .update(agents)
+        .set({ [column]: config, updatedAt: new Date() })
+        .where(eq(agents.id, id))
+        .returning()
+    )[0]
+    if (isLive) {
+      if (channel === 'feishu') {
+        feishuConnectionManager
+          .start(id, config as Parameters<typeof feishuConnectionManager.start>[1])
+          .catch((err) =>
+            logger.error(
+              { err, agentId: id },
+              'Failed to restart Feishu connection on config save',
+            ),
+          )
+      } else if (channel === 'slack') {
+        slackConnectionManager
+          .start(id, config as Parameters<typeof slackConnectionManager.start>[1])
+          .catch((err) =>
+            logger.error({ err, agentId: id }, 'Failed to restart Slack connection on config save'),
+          )
+      } else if (channel === 'discord') {
+        discordConnectionManager
+          .start(id, config as Parameters<typeof discordConnectionManager.start>[1])
+          .catch((err) =>
+            logger.error(
+              { err, agentId: id },
+              'Failed to restart Discord connection on config save',
+            ),
+          )
+      } else if (channel === 'telegram') {
+        telegramConnectionManager
+          .start(id, config as Parameters<typeof telegramConnectionManager.start>[1])
+          .catch((err) =>
+            logger.error(
+              { err, agentId: id },
+              'Failed to restart Telegram connection on config save',
+            ),
+          )
+      } else if (channel === 'qq_official') {
+        qqOfficialConnectionManager
+          .start(id, config as Parameters<typeof qqOfficialConnectionManager.start>[1])
+          .catch((err) =>
+            logger.error(
+              { err, agentId: id },
+              'Failed to restart QQ Official connection on config save',
+            ),
+          )
+      } else if (channel === 'schedule') {
+        scheduleTriggerManager.start(id, config as ScheduleConfigInput)
+      } else if (channel === 'glab' || channel === 'gh') {
+        gitTriggerManager.start(id, channel, config)
+      }
+    }
+
+    logAudit(c, {
+      action: 'agent.publish_channel',
+      resource: 'agent',
+      resourceId: id,
+      // 只记渠道名——config 里有凭据，details 会原样展示给每个管理员。
+      details: { channel },
+    })
+
+    return c.json({ data: maskAgentSecrets(updated) })
+  })
+}

--- a/apps/api/src/routes/agent-secret-masking.ts
+++ b/apps/api/src/routes/agent-secret-masking.ts
@@ -70,6 +70,13 @@ export function maskAgentSecrets<T extends AgentRow | undefined>(
       discordConfig: { ...discord, botToken: MASKED_SECRET },
     }
   }
+  const telegram = masked.telegramConfig
+  if (!opts?.revealNativeChatSecrets && telegram?.botToken) {
+    masked = {
+      ...masked,
+      telegramConfig: { ...telegram, botToken: MASKED_SECRET },
+    }
+  }
   const qqOfficial = masked.qqOfficialConfig
   if (!opts?.revealNativeChatSecrets && qqOfficial?.appSecret) {
     masked = {

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -16,6 +16,7 @@ import {
   qqOfficialConfigSchema,
   scheduleConfigSchema,
   slackConfigSchema,
+  telegramConfigSchema,
   updateAgentInput,
   worktreeCallParamsSchema,
 } from '@a2wave/shared'
@@ -127,6 +128,7 @@ import { scheduleTriggerManager } from '../lib/schedule-trigger.js'
 import { withScmPathMutation } from '../lib/scm-path-plan.js'
 import { canAgentOwnerUseSkill, canNonAdminUseSkill } from '../lib/skill-access.js'
 import { slackConnectionManager } from '../lib/slack-service.js'
+import { telegramConnectionManager } from '../lib/telegram-service.js'
 import {
   boundaryBucketSql,
   bucketCount,
@@ -140,6 +142,7 @@ import {
 import { runTokenSelect, stepTokenSelect, toTokenTotals } from '../lib/token-stats.js'
 import { isAdmin } from '../middleware/auth-middleware.js'
 import type { WorkerTaskPayload } from '../worker/index.js'
+import { registerAgentChannelConfigRoute } from './agent-channel-config.js'
 import {
   filterBindableMcpIdsForClone,
   projectBindableSkillReferencesForClone,
@@ -374,6 +377,7 @@ app.get('/chat-connections', (c) => {
     data: {
       slack: slackConnectionManager.getConnectionStatuses(),
       discord: discordConnectionManager.getConnectionStatuses(),
+      telegram: telegramConnectionManager.getConnectionStatuses(),
       qqOfficial: qqOfficialConnectionManager.getConnectionStatuses(),
     },
     meta: { scope: 'current_api_process' },
@@ -1311,6 +1315,16 @@ app.patch('/:id', async (c) => {
       ),
     }
   }
+  let telegramConfigToSave = parsed.data.telegramConfig
+  if (telegramConfigToSave) {
+    telegramConfigToSave = {
+      ...telegramConfigToSave,
+      botToken: resolveMaskedChannelSecret(
+        telegramConfigToSave.botToken,
+        existing.telegramConfig?.botToken,
+      ),
+    }
+  }
   let qqOfficialConfigToSave = parsed.data.qqOfficialConfig
   if (qqOfficialConfigToSave) {
     qqOfficialConfigToSave = {
@@ -1393,6 +1407,7 @@ app.patch('/:id', async (c) => {
     feishuConfig: feishuConfigToSave,
     slackConfig: slackConfigToSave,
     discordConfig: discordConfigToSave,
+    telegramConfig: telegramConfigToSave,
     qqOfficialConfig: qqOfficialConfigToSave,
     a2aRouteTargets: a2aRouteTargetsToSave.value,
     ...providerCredentialFields,
@@ -1514,6 +1529,7 @@ const publishBodySchema = z.object({
   feishuConfig: feishuConfigBodySchema.nullable().optional(),
   slackConfig: slackConfigSchema.nullable().optional(),
   discordConfig: discordConfigSchema.nullable().optional(),
+  telegramConfig: telegramConfigSchema.nullable().optional(),
   qqOfficialConfig: qqOfficialConfigSchema.nullable().optional(),
   chatAppConfig: chatAppConfigSchema.nullable().optional(),
   scheduleConfig: scheduleConfigSchema.nullable().optional(),
@@ -1554,6 +1570,7 @@ app.post('/:id/publish', async (c) => {
     feishuConfig,
     slackConfig,
     discordConfig,
+    telegramConfig,
     qqOfficialConfig,
     chatAppConfig,
     scheduleConfig,
@@ -1726,6 +1743,16 @@ app.post('/:id/publish', async (c) => {
       400,
     )
   }
+  if (telegramConfig !== undefined) {
+    let resolvedTelegramConfig = telegramConfig
+    if (resolvedTelegramConfig?.botToken === '********' && agent.telegramConfig?.botToken) {
+      resolvedTelegramConfig = {
+        ...resolvedTelegramConfig,
+        botToken: agent.telegramConfig.botToken,
+      }
+    }
+    updatePayload.telegramConfig = resolvedTelegramConfig
+  }
   const effectiveDiscordConfig = (
     updatePayload.discordConfig === undefined ? agent.discordConfig : updatePayload.discordConfig
   ) as { applicationId?: string; botToken?: string } | null | undefined
@@ -1737,6 +1764,18 @@ app.post('/:id/publish', async (c) => {
       {
         error: 'Discord channel requires applicationId and botToken.',
         code: 'DISCORD_CONFIG_REQUIRED',
+      },
+      400,
+    )
+  }
+  const effectiveTelegramConfig = (
+    updatePayload.telegramConfig === undefined ? agent.telegramConfig : updatePayload.telegramConfig
+  ) as { botToken?: string } | null | undefined
+  if (channels.includes('telegram') && !effectiveTelegramConfig?.botToken) {
+    return c.json(
+      {
+        error: 'Telegram channel requires botToken.',
+        code: 'TELEGRAM_CONFIG_REQUIRED',
       },
       400,
     )
@@ -1815,6 +1854,16 @@ app.post('/:id/publish', async (c) => {
       )
   } else if (!channels.includes('discord')) {
     void discordConnectionManager.stop(id)
+    void telegramConnectionManager.stop(id)
+  }
+  if (!isStopped && channels.includes('telegram') && effectiveTelegramConfig) {
+    telegramConnectionManager
+      .start(id, effectiveTelegramConfig as Parameters<typeof telegramConnectionManager.start>[1])
+      .catch((err) =>
+        logger.error({ err, agentId: id }, 'Failed to start Telegram connection on publish'),
+      )
+  } else if (!channels.includes('telegram')) {
+    void telegramConnectionManager.stop(id)
   }
   syncQQOfficialConnectionAfterPublish(id, isStopped, channels, preparedQQOfficialConfig.effective)
 
@@ -1836,224 +1885,7 @@ app.post('/:id/publish', async (c) => {
   return c.json({ data: maskAgentSecrets(updated) })
 })
 
-/**
- * 每个渠道各自的 config body。刻意不复用 publishBodySchema——它对 authType /
- * channels / ipWhitelist / description 都带 .default()，一旦复用，只想存飞书凭据
- * 的请求会把 publishChannels 静默重置成 ['api']（等于关掉其它所有渠道），并顺手
- * 轮换掉 endpointApiKey。
- */
-const channelConfigSchemas = {
-  feishu: feishuConfigBodySchema,
-  slack: slackConfigSchema,
-  discord: discordConfigSchema,
-  qq_official: qqOfficialConfigSchema,
-  chat_app: chatAppConfigSchema,
-  schedule: scheduleConfigSchema,
-  // Provider-bound, so a mismatched config is a 400 from schema validation
-  // itself rather than something this route has to remember to check.
-  glab: glabTriggerConfigSchema,
-  gh: ghTriggerConfigSchema,
-} as const
-
-type ConfigurableChannel = keyof typeof channelConfigSchemas
-
-/** config 值写到 agents 表的哪一列。 */
-const CHANNEL_CONFIG_COLUMN: Record<ConfigurableChannel, string> = {
-  feishu: 'feishuConfig',
-  slack: 'slackConfig',
-  discord: 'discordConfig',
-  qq_official: 'qqOfficialConfig',
-  chat_app: 'chatAppConfig',
-  schedule: 'scheduleConfig',
-  glab: 'glabConfig',
-  gh: 'ghConfig',
-}
-
-function isConfigurableChannel(value: string): value is ConfigurableChannel {
-  return Object.hasOwn(channelConfigSchemas, value)
-}
-
-/**
- * PATCH /agents/:id/channels/:channel - 只保存单个渠道的配置。
- *
- * 与 POST /:id/publish 的关键区别：**配置 ≠ 发布**。publish 会把 Agent 置为
- * published、戳 publishedAt、轮换 API Key，并按 channels 数组重启所有渠道的长连接；
- * 而在卡片上点「配置」保存凭据不应触发其中任何一项——draft 仍是 draft，直到用户显式
- * 点「发布」。启用与否由 publishChannels 决定，不归这个接口管，所以「配置了但不启用」
- * 是完全合法的状态。
- *
- * 副作用也收窄到单个渠道：只有当 Agent 已发布**且**该渠道已在 publishChannels 中时，
- * 才重启它自己的连接。改飞书配置不会顺带把 Slack / Discord 的在线 socket 打断——
- * 这正是整份 publish payload 做不到的。
- */
-app.patch('/:id/channels/:channel', async (c) => {
-  const { id, channel } = c.req.param()
-
-  if (!isConfigurableChannel(channel)) {
-    return c.json(
-      { error: `Channel '${channel}' has no saveable config.`, code: 'UNKNOWN_CHANNEL' },
-      400,
-    )
-  }
-
-  const body = await c.req.json().catch(() => ({}))
-  const parsed = z.object({ config: channelConfigSchemas[channel] }).safeParse(body)
-  if (!parsed.success) {
-    return c.json({ error: parsed.error.flatten() }, 400)
-  }
-
-  const { agent } = await requireAgentWrite(c, id)
-  const column = CHANNEL_CONFIG_COLUMN[channel]
-
-  /**
-   * 脱敏哨兵回填：前端从不拿到明文凭据，未修改的字段会原样回传 '********'。
-   *
-   * 关键在于「无可回填的原值」必须报错，而不是把哨兵当成密钥写进去——那会让该字段
-   * 读回来就已经是脱敏值，看着像已配置，实则每次调用都鉴权失败，且之后每次保存都会
-   * 把哨兵再「还原」一遍，用户无法自行修复。草稿 Agent 正是这种「库里还没有原值」的
-   * 状态，而配置弹窗恰恰是它录入凭据的主要入口。
-   */
-  const restoreSecret = (submitted: string | undefined, stored: string | undefined | null) => {
-    if (submitted !== MASKED_SECRET) return { ok: true as const, value: submitted }
-    if (!stored) return { ok: false as const, value: undefined }
-    return { ok: true as const, value: stored }
-  }
-
-  const maskedWithoutStored = (field: string) =>
-    c.json(
-      {
-        error: `${field} was sent masked but no stored value exists to restore.`,
-        code: 'MASKED_SECRET_WITHOUT_STORED_VALUE',
-      },
-      400,
-    )
-
-  let config: unknown = parsed.data.config
-  if (channel === 'feishu') {
-    const next = normalizeFeishuConfig(config as Record<string, unknown>)
-    const secret = restoreSecret(next.appSecret, agent.feishuConfig?.appSecret)
-    if (!secret.ok) return maskedWithoutStored('appSecret')
-    config = { ...next, appSecret: secret.value }
-  } else if (channel === 'slack') {
-    const next = config as { appToken?: string; botToken?: string }
-    const appToken = restoreSecret(next.appToken, agent.slackConfig?.appToken)
-    if (!appToken.ok) return maskedWithoutStored('appToken')
-    const botToken = restoreSecret(next.botToken, agent.slackConfig?.botToken)
-    if (!botToken.ok) return maskedWithoutStored('botToken')
-    config = { ...next, appToken: appToken.value, botToken: botToken.value }
-  } else if (channel === 'discord') {
-    const next = config as { botToken?: string }
-    const botToken = restoreSecret(next.botToken, agent.discordConfig?.botToken)
-    if (!botToken.ok) return maskedWithoutStored('botToken')
-    config = { ...next, botToken: botToken.value }
-  } else if (channel === 'qq_official') {
-    const next = config as { appSecret?: string }
-    const appSecret = restoreSecret(next.appSecret, agent.qqOfficialConfig?.appSecret)
-    if (!appSecret.ok) return maskedWithoutStored('appSecret')
-    config = { ...next, appSecret: appSecret.value }
-  }
-
-  // 只有「已发布 + 该渠道已启用」才让改动即时生效；draft 或未启用时仅落库。
-  const isLive =
-    agent.publishStatus === 'published' && (agent.publishChannels ?? []).includes(channel)
-
-  /**
-   * 线上渠道不允许把凭据存成空值。
-   *
-   * 连接管理器的 start() 是「先 stop 再校验」：凭据为空时它已经把旧连接拆了才 return，
-   * 而本路由仍会返回 200、前端显示「保存成功」。于是管理员只要在已上线渠道的配置弹窗里
-   * 清空 App ID 保存，就会把正常在线的机器人静默下线，同时把无效配置写进库。
-   *
-   * 草稿 / 未启用的渠道不受此限制——编辑途中清空字段是正常操作，且没有连接可破坏。
-   */
-  if (isLive) {
-    const required: Record<string, string | undefined> =
-      channel === 'feishu'
-        ? {
-            appId: (config as { appId?: string }).appId,
-            appSecret: (config as { appSecret?: string }).appSecret,
-          }
-        : channel === 'slack'
-          ? {
-              appId: (config as { appId?: string }).appId,
-              appToken: (config as { appToken?: string }).appToken,
-              botToken: (config as { botToken?: string }).botToken,
-            }
-          : channel === 'discord'
-            ? {
-                applicationId: (config as { applicationId?: string }).applicationId,
-                botToken: (config as { botToken?: string }).botToken,
-              }
-            : channel === 'qq_official'
-              ? {
-                  appId: (config as { appId?: string }).appId,
-                  appSecret: (config as { appSecret?: string }).appSecret,
-                }
-              : {}
-    const blank = Object.entries(required).find(([, value]) => !value?.trim())
-    if (blank) {
-      return c.json(
-        {
-          error: `${blank[0]} cannot be empty while the ${channel} channel is live. Disable the channel first.`,
-          code: 'LIVE_CHANNEL_REQUIRES_CREDENTIALS',
-        },
-        400,
-      )
-    }
-  }
-
-  const updated = (
-    await db
-      .update(agents)
-      .set({ [column]: config, updatedAt: new Date() })
-      .where(eq(agents.id, id))
-      .returning()
-  )[0]
-  if (isLive) {
-    if (channel === 'feishu') {
-      feishuConnectionManager
-        .start(id, config as Parameters<typeof feishuConnectionManager.start>[1])
-        .catch((err) =>
-          logger.error({ err, agentId: id }, 'Failed to restart Feishu connection on config save'),
-        )
-    } else if (channel === 'slack') {
-      slackConnectionManager
-        .start(id, config as Parameters<typeof slackConnectionManager.start>[1])
-        .catch((err) =>
-          logger.error({ err, agentId: id }, 'Failed to restart Slack connection on config save'),
-        )
-    } else if (channel === 'discord') {
-      discordConnectionManager
-        .start(id, config as Parameters<typeof discordConnectionManager.start>[1])
-        .catch((err) =>
-          logger.error({ err, agentId: id }, 'Failed to restart Discord connection on config save'),
-        )
-    } else if (channel === 'qq_official') {
-      qqOfficialConnectionManager
-        .start(id, config as Parameters<typeof qqOfficialConnectionManager.start>[1])
-        .catch((err) =>
-          logger.error(
-            { err, agentId: id },
-            'Failed to restart QQ Official connection on config save',
-          ),
-        )
-    } else if (channel === 'schedule') {
-      scheduleTriggerManager.start(id, config as ScheduleConfigInput)
-    } else if (channel === 'glab' || channel === 'gh') {
-      gitTriggerManager.start(id, channel, config)
-    }
-  }
-
-  logAudit(c, {
-    action: 'agent.publish_channel',
-    resource: 'agent',
-    resourceId: id,
-    // 只记渠道名——config 里有凭据，details 会原样展示给每个管理员。
-    details: { channel },
-  })
-
-  return c.json({ data: maskAgentSecrets(updated) })
-})
+registerAgentChannelConfigRoute(app)
 
 /** POST /agents/:id/stop - 停止已发布的 Agent */
 app.post('/:id/stop', async (c) => {
@@ -2071,6 +1903,7 @@ app.post('/:id/stop', async (c) => {
   feishuConnectionManager.stop(id)
   void slackConnectionManager.stop(id)
   void discordConnectionManager.stop(id)
+  void telegramConnectionManager.stop(id)
   void qqOfficialConnectionManager.stop(id)
   scheduleTriggerManager.stop(id)
   gitTriggerManager.stopAgent(id)
@@ -2118,6 +1951,13 @@ app.post('/:id/resume', async (c) => {
       await slackConnectionManager.start(id, updated.slackConfig)
     } catch (err) {
       logger.error({ err, agentId: id }, 'Failed to start Slack connection on resume')
+    }
+  }
+  if (resumedChannels.includes('telegram') && updated?.telegramConfig) {
+    try {
+      await telegramConnectionManager.start(id, updated.telegramConfig)
+    } catch (err) {
+      logger.error({ err, agentId: id }, 'Failed to start Telegram connection on resume')
     }
   }
   if (resumedChannels.includes('discord') && updated?.discordConfig) {
@@ -2221,6 +2061,7 @@ app.post('/:id/clone', async (c) => {
           feishuConfig: null,
           slackConfig: null,
           discordConfig: null,
+          telegramConfig: null,
           qqOfficialConfig: null,
           scheduleConfig: null,
           glabConfig: null,
@@ -2963,6 +2804,7 @@ app.delete('/:id', async (c) => {
   feishuConnectionManager.stop(id)
   void slackConnectionManager.stop(id)
   void discordConnectionManager.stop(id)
+  void telegramConnectionManager.stop(id)
   void qqOfficialConnectionManager.stop(id)
   scheduleTriggerManager.stop(id)
   gitTriggerManager.stopAgent(id)

--- a/apps/api/src/test/factories.ts
+++ b/apps/api/src/test/factories.ts
@@ -54,6 +54,7 @@ export interface TestAgent {
   feishuConfig: unknown | null
   slackConfig: unknown | null
   discordConfig: unknown | null
+  telegramConfig: unknown | null
   chatAppConfig: {
     displayName?: string
     welcomeMessage?: string
@@ -106,6 +107,7 @@ export function createTestAgent(overrides: Partial<TestAgent> = {}): TestAgent {
     feishuConfig: null,
     slackConfig: null,
     discordConfig: null,
+    telegramConfig: null,
     chatAppConfig: null,
     scheduleConfig: null,
     publishedAt: null,

--- a/apps/cli/src/commands/channels.ts
+++ b/apps/cli/src/commands/channels.ts
@@ -14,6 +14,7 @@ const CONFIGURABLE_CHANNELS = [
   'feishu',
   'slack',
   'discord',
+  'telegram',
   'chat_app',
   'schedule',
   'glab',

--- a/apps/cli/src/generated/schemas.json
+++ b/apps/cli/src/generated/schemas.json
@@ -7,6 +7,7 @@
       "feishu",
       "slack",
       "discord",
+      "telegram",
       "qq_official",
       "schedule",
       "oauth",

--- a/apps/cli/src/lib/agent-yaml.ts
+++ b/apps/cli/src/lib/agent-yaml.ts
@@ -157,6 +157,7 @@ export const PUBLISH_CHANNELS = [
   'feishu',
   'slack',
   'discord',
+  'telegram',
   'qq_official',
   'schedule',
   'oauth',

--- a/apps/cli/src/lib/schema.ts
+++ b/apps/cli/src/lib/schema.ts
@@ -70,6 +70,7 @@ const ENUM_FLAGS: Record<string, { values: string[]; descriptions?: Record<strin
       feishu: 'Feishu bot; needs feishuConfig',
       slack: 'Slack bot; needs slackConfig',
       discord: 'Discord bot; needs discordConfig',
+      telegram: 'Telegram bot; needs telegramConfig',
       qq_official: 'QQ Official bot; credentials must already be configured',
       schedule: 'Cron trigger; fires unconditionally, needs scheduleConfig',
       oauth: 'IDaaS-authenticated gateway invocation',

--- a/apps/web/src/components/run-caller-prefix.tsx
+++ b/apps/web/src/components/run-caller-prefix.tsx
@@ -14,6 +14,7 @@ export const SOURCE_LABEL: Record<RunTriggerSource, string> = {
   feishu: 'runs.sourceFeishu',
   slack: 'runs.sourceSlack',
   discord: 'runs.sourceDiscord',
+  telegram: 'runs.sourceTelegram',
   qq_official: 'runs.sourceQQOfficial',
   a2a: 'runs.sourceA2a',
   schedule: 'runs.sourceSchedule',

--- a/apps/web/src/content/manual/en/12-triggers.md
+++ b/apps/web/src/content/manual/en/12-triggers.md
@@ -1,6 +1,6 @@
 # Trigger Methods
 
-a2wave currently provides **eleven publish channels**: REST API, OAuth, A2A protocol, Feishu, Slack, Discord, QQ Official Bot, scheduled trigger, chat page, GitLab trigger, and GitHub trigger. A single Agent can enable multiple at once.
+a2wave currently provides **twelve publish channels**: REST API, OAuth, A2A protocol, Feishu, Slack, Discord, Telegram, QQ Official Bot, scheduled trigger, chat page, GitLab trigger, and GitHub trigger. A single Agent can enable multiple at once.
 
 ## Managing channels on the Channels tab
 
@@ -22,7 +22,7 @@ Once configured, click **Publish / Update Channels** at the bottom of the page t
 
 ### Connection status for chat channels
 
-Feishu, Slack, Discord, and QQ Official Bot each hold their own **long connection** to the platform, so their cards show a live status labelled with the protocol each one speaks: **WebSocket**, **Socket Mode**, **Gateway**, and **Official WebSocket**, respectively.
+Feishu, Slack, Discord, and QQ Official Bot each hold their own **long connection** to the platform, so their cards show a live status labelled with the protocol each one speaks: **WebSocket**, **Socket Mode**, **Gateway**, and **Official WebSocket**, respectively. Telegram instead keeps an outbound **Long Polling** loop, and its card reports that loop's live state the same way.
 
 | Status | Meaning |
 |--------|---------|
@@ -244,7 +244,25 @@ Discord Attachments are downloaded under the platform-wide attachment policy and
 
 ---
 
-## 5. QQ Official Bot
+## 5. Telegram
+
+Open the Telegram card's **Configure** dialog on the Channels tab and provide the **Bot Token** issued by [@BotFather](https://t.me/BotFather). There is no separate application id — the bot identity is the numeric prefix of the token itself.
+
+a2wave consumes Telegram updates through **long polling** (`getUpdates`), so the deployment needs no public HTTPS ingress and no callback URL. Saving the config registers the bot and clears any webhook previously set on it, because Telegram allows either a webhook or long polling, never both.
+
+Group messages trigger on **@mention or a reply to the bot** by default, with an option to trigger on every new group message. Replies can reference the original message, send a new message, or be disabled. Private chats always trigger. Agent sessions are maintained per user within a group, and supergroup forum topics are isolated by their topic id.
+
+> [!IMPORTANT]
+> “Trigger on every new group message” requires **Group Privacy to be disabled**: send `/setprivacy` to @BotFather and choose *Disable*. While Group Privacy is on, Telegram only delivers messages that @mention or reply to the bot, so the option has no effect. Messages sent by bots do not trigger the Agent, preventing reply loops.
+
+> [!WARNING]
+> Within one API process, a Telegram bot can be held by only one Agent's polling loop. Use separate bots for multiple Agents.
+
+Telegram documents, photos, videos, audio, and voice messages are downloaded under the platform-wide attachment policy and provided to the Agent; an attachment-only message can also trigger a run. For a photo, only the highest-resolution version is used. Agent artifacts are uploaded directly to the original conversation as documents by default. Successful uploads do not repeat the download section; an a2wave download link is sent only as a fallback when an upload fails. Execution-sandbox links in Agent output are not exposed to external chat channels. Direct file delivery can be disabled in the Telegram channel settings. Replies longer than the Telegram message limit are split across several messages. Inline keyboards and buttons are not sent.
+
+---
+
+## 6. QQ Official Bot
 
 This channel uses Tencent QQ's **official WebSocket Gateway only**. It does not use NapCat or OneBot and requires no public callback URL.
 
@@ -266,7 +284,7 @@ Replies may reference the original message, send a new message, or be disabled. 
 
 ---
 
-## 6. Chat page
+## 7. Chat page
 
 Publish an Agent as a shareable chat page: its profile, status and creator on the left, a full conversation window on the right. Good for handing an Agent straight to a colleague without teaching them the console first.
 
@@ -300,7 +318,7 @@ Every conversation is written to run history with the source marked `Chat Page`,
 
 ---
 
-## 7. A2A Protocol
+## 8. A2A Protocol
 
 A2A (Agent-to-Agent) lets external Agent systems discover and invoke this platform's Agents, and lets this platform's Agents route to standards-compliant remote A2A services. The platform supports **A2A 1.0 JSON-RPC** and remains compatible with **A2A 0.3 JSON-RPC**.
 
@@ -370,7 +388,7 @@ When the parent Run is canceled or reaches its timeout, the router sends `Cancel
 
 ---
 
-## 8. Scheduled trigger
+## 9. Scheduled trigger
 
 Have an Agent automatically create and execute Runs at specified times on a Cron schedule (e.g. daily code review, weekly reports, inspections). Open the Schedule Trigger card's **Configure** dialog on the Channels tab:
 
@@ -394,7 +412,7 @@ Notes: minute-level precision; each Agent can be configured with multiple schedu
 
 ## Attachments (images and files)
 
-When messaging an Agent you can include images and documents. Feishu, Slack, Discord, and QQ Official Bot automatically recognize images/files in a message; API, OAuth, and the Agent test UI use a **two-step upload**, while A2A uses protocol-native parts.
+When messaging an Agent you can include images and documents. Feishu, Slack, Discord, Telegram, and QQ Official Bot automatically recognize images/files in a message; API, OAuth, and the Agent test UI use a **two-step upload**, while A2A uses protocol-native parts.
 
 **Two-step upload (API / OAuth / test UI)**
 
@@ -447,6 +465,7 @@ curl -X POST ".../api/gateway/<agentId>/invoke" -H "Authorization: Bearer <key>"
 | Feishu not receiving messages | App long connection is occupied | Give each Agent its own separate Feishu app; check diagnostics |
 | Slack not receiving messages | Socket Mode, event subscriptions, or scopes are missing | Check the `xapp`/`xoxb` tokens, events, and scopes; use one app per Agent |
 | Discord not receiving messages | Message Content Intent or bot permissions are missing | Check the intent, invite permissions, and Application ID; use one app per Agent |
+| Telegram not receiving group messages | Group Privacy is enabled, so Telegram withholds them | Send `/setprivacy` to @BotFather and disable it, or trigger by @mention / reply instead |
 | Schedule not triggering | schedule channel not included / cron wrong | Confirm the publish channel and cron expression |
 
 ## Related

--- a/apps/web/src/content/manual/zh/12-triggers.md
+++ b/apps/web/src/content/manual/zh/12-triggers.md
@@ -1,6 +1,6 @@
 # 触发方式
 
-a2wave 当前提供 **十一种发布渠道**：REST API、OAuth 授权、A2A 协议、飞书、Slack、Discord、QQ 官方机器人、定时触发、对话网页、GitLab 触发、GitHub 触发。一个 Agent 可同时启用多种。
+a2wave 当前提供 **十二种发布渠道**：REST API、OAuth 授权、A2A 协议、飞书、Slack、Discord、Telegram、QQ 官方机器人、定时触发、对话网页、GitLab 触发、GitHub 触发。一个 Agent 可同时启用多种。
 
 ## 在「渠道」页管理渠道
 
@@ -22,7 +22,7 @@ a2wave 当前提供 **十一种发布渠道**：REST API、OAuth 授权、A2A �
 
 ### 即时通讯渠道的连接状态
 
-飞书、Slack、Discord、QQ 官方机器人各自与平台维持一条**长连接**，因此它们的卡片上会显示实时连接状态，标出各自的协议：飞书是 **WebSocket**、Slack 是 **Socket Mode**、Discord 是 **Gateway**、QQ 是 **官方 WebSocket**。
+飞书、Slack、Discord、QQ 官方机器人各自与平台维持一条**长连接**，因此它们的卡片上会显示实时连接状态，标出各自的协议：飞书是 **WebSocket**、Slack 是 **Socket Mode**、Discord 是 **Gateway**、QQ 是 **官方 WebSocket**。Telegram 则维持一条出站的**长轮询**循环，其卡片同样以这种方式展示该循环的实时状态。
 
 | 状态 | 含义 |
 |------|------|
@@ -238,7 +238,25 @@ Discord Attachments 会按平台统一附件策略下载并交给 Agent；仅发
 
 ---
 
-## 5. QQ 官方机器人
+## 5. Telegram
+
+在「渠道」页打开 Telegram 卡片的**配置**弹窗，填入 [@BotFather](https://t.me/BotFather) 签发的 **Bot Token**。Telegram 没有独立的 Application ID——Bot 身份就是 Token 冒号前的那串数字。
+
+a2wave 通过**长轮询**（`getUpdates`）拉取 Telegram 更新，因此部署侧**无需公网 HTTPS 入口，也不需要回调地址**。保存配置时会注册该 Bot 并清除它此前设置过的 webhook——Telegram 规定 webhook 与长轮询只能二选一。
+
+群组消息默认在**被 @ 或被回复**时触发，也可选择群内所有新消息都触发。回复方式可选择回复原消息、发送新消息或不回复。私聊始终触发。群内按用户维护各自的 Agent 会话；超级群的话题（Forum Topic）按话题 ID 相互隔离。
+
+> [!IMPORTANT]
+> 「群内所有新消息均触发」要求**关闭 Group Privacy**：向 @BotFather 发送 `/setprivacy` 并选择 *Disable*。Group Privacy 开启时，Telegram 只会下发 @ 机器人或回复机器人的消息，该选项不会生效。Bot 发出的消息不会触发 Agent，以避免回复循环。
+
+> [!WARNING]
+> 在同一个 API 进程内，一个 Telegram Bot 只能被一个 Agent 的轮询循环持有。多个 Agent 请各自使用独立的 Bot。
+
+Telegram 的文档、图片、视频、音频与语音消息会按平台附件策略下载并提供给 Agent；仅含附件、没有文字的消息同样可以触发运行。图片只取分辨率最高的那一档。Agent 产物默认以文件形式直接上传回原会话；上传成功时不再附下载区块，仅在上传失败时回退发送 a2wave 下载链接。Agent 输出中的执行沙箱链接不会外发到聊天渠道。可在 Telegram 渠道设置中关闭直接发送文件。超过 Telegram 单条消息长度上限的回复会自动拆分成多条发送。不发送 Inline Keyboard 与按钮。
+
+---
+
+## 6. QQ 官方机器人
 
 本渠道只接入腾讯 QQ 的**官方 WebSocket Gateway**，不使用 NapCat、OneBot，也不要求公网回调地址。
 
@@ -260,7 +278,7 @@ QQ 单聊按“机器人 + 用户”维护会话。距离上一条用户消息�
 
 ---
 
-## 6. 对话网页
+## 7. 对话网页
 
 把 Agent 发布成一个可分享的对话页面：左侧展示 Agent 的介绍、状态与创建者，右侧是完整的对话窗口。适合把一个 Agent 直接交给同事使用，不用教他们怎么用控制台。
 
@@ -294,7 +312,7 @@ https://<你的域名>/agents/<agentId>/chat_app
 
 ---
 
-## 7. A2A 协议
+## 8. A2A 协议
 
 A2A（Agent-to-Agent）让外部 Agent 系统能发现并调用本平台 Agent，也让本平台 Agent 路由到符合标准的远程 A2A 服务。当前支持 **A2A 1.0 JSON-RPC**，并兼容 **A2A 0.3 JSON-RPC**。
 
@@ -364,7 +382,7 @@ A2A 路由不再附加固定 5 分钟执行截止。有效执行时长继承**�
 
 ---
 
-## 8. 定时触发
+## 9. 定时触发
 
 让 Agent 按 Cron 在指定时间自动创建并执行 Run（如每日代码审查、周报、巡检）。在「渠道」页的「定时触发」卡片点「配置」：
 
@@ -386,7 +404,7 @@ A2A 路由不再附加固定 5 分钟执行截止。有效执行时长继承**�
 
 ---
 
-## 9. Git 仓库触发（GitLab / GitHub）
+## 10. Git 仓库触发（GitLab / GitHub）
 
 让 Agent 在**仓库真正发生变化时**才运行——比如有人提了新 MR、往 MR 里推了新提交、或在 MR 下留了评论。
 
@@ -491,7 +509,7 @@ environment:
 
 ## 附件（图片与文件）
 
-给 Agent 发消息时可以带图片和文档。飞书、Slack、Discord 与 QQ 官方机器人渠道会自动识别消息里的图片/文件；API、OAuth 与 Agent 测试界面走**两步上传**，A2A 使用协议原生分片。
+给 Agent 发消息时可以带图片和文档。飞书、Slack、Discord、Telegram 与 QQ 官方机器人渠道会自动识别消息里的图片/文件；API、OAuth 与 Agent 测试界面走**两步上传**，A2A 使用协议原生分片。
 
 **两步上传（API / OAuth / 测试界面）**
 
@@ -544,6 +562,7 @@ curl -X POST ".../api/gateway/<agentId>/invoke" -H "Authorization: Bearer <key>"
 | 飞书收不到消息 | App 长连接被占用 | 多 Agent 各用独立飞书应用；看诊断 |
 | Slack 收不到消息 | Socket Mode、事件订阅或权限未开启 | 检查 `xapp`/`xoxb` token、事件与 scopes；每个 Agent 使用独立 App |
 | Discord 收不到消息 | Message Content Intent 或 Bot 权限未开启 | 检查 Intent、邀请权限与 Application ID；每个 Agent 使用独立 App |
+| Telegram 收不到群消息 | Group Privacy 开启，Telegram 不下发 | 向 @BotFather 发送 `/setprivacy` 关闭；或改用 @ 机器人 / 回复机器人触发 |
 | 定时不触发 | 未包含 schedule 渠道 / cron 错 | 确认发布渠道与 cron 表达式 |
 
 ## 相关

--- a/apps/web/src/hooks/use-agents.ts
+++ b/apps/web/src/hooks/use-agents.ts
@@ -35,6 +35,7 @@ const CONNECTION_QUERY_KEYS = [FEISHU_CONNECTIONS_QUERY_KEY, CHAT_CONNECTIONS_QU
 export type ChatConnectionsResponse = {
   slack: FeishuConnectionRow[]
   discord: FeishuConnectionRow[]
+  telegram: FeishuConnectionRow[]
   qqOfficial: FeishuConnectionRow[]
 }
 
@@ -63,6 +64,7 @@ export function useChatConnections(options?: { enabled?: boolean }) {
     select: (res) => ({
       slack: toSocketMap(res.data?.slack),
       discord: toSocketMap(res.data?.discord),
+      telegram: toSocketMap(res.data?.telegram),
       qq_official: toSocketMap(res.data?.qqOfficial),
       meta: res.meta,
     }),
@@ -95,6 +97,7 @@ export function useNativeChatConnections(options?: { enabled?: boolean }): {
     feishu: feishu.isError,
     slack: chat.isError,
     discord: chat.isError,
+    telegram: chat.isError,
     qq_official: chat.isError,
   }
   // A query still in flight has no data yet; a failed one never will. Both are
@@ -104,6 +107,7 @@ export function useNativeChatConnections(options?: { enabled?: boolean }): {
     feishu: feishu.data?.byId ?? new Map(),
     slack: chat.data?.slack ?? new Map(),
     discord: chat.data?.discord ?? new Map(),
+    telegram: chat.data?.telegram ?? new Map(),
     qq_official: chat.data?.qq_official ?? new Map(),
   }
   return {
@@ -283,6 +287,15 @@ export type DiscordPublishConfig = {
   sendArtifactsAsFile: boolean
 }
 
+export type TelegramPublishConfig = {
+  botToken: string
+  groupTriggerOnMention: boolean
+  groupTriggerOnNewMessage: boolean
+  groupReplyMode: 'reply' | 'new' | 'none'
+  privateReplyMode: 'reply' | 'new' | 'none'
+  sendArtifactsAsFile: boolean
+}
+
 export type QQOfficialPublishConfig = {
   appId: string
   appSecret: string
@@ -323,6 +336,7 @@ export type PublishConfig = {
   feishuConfig?: FeishuPublishConfig | null
   slackConfig?: SlackPublishConfig | null
   discordConfig?: DiscordPublishConfig | null
+  telegramConfig?: TelegramPublishConfig | null
   qqOfficialConfig?: QQOfficialPublishConfig | null
   chatAppConfig?: ChatAppPublishConfig | null
   scheduleConfig?: SchedulePublishConfig | SchedulePublishConfig[] | null
@@ -356,6 +370,7 @@ export function usePublishAgent() {
         ...(config.feishuConfig !== undefined && { feishuConfig: config.feishuConfig }),
         ...(config.slackConfig !== undefined && { slackConfig: config.slackConfig }),
         ...(config.discordConfig !== undefined && { discordConfig: config.discordConfig }),
+        ...(config.telegramConfig !== undefined && { telegramConfig: config.telegramConfig }),
         ...(config.qqOfficialConfig !== undefined && {
           qqOfficialConfig: config.qqOfficialConfig,
         }),
@@ -385,6 +400,7 @@ export type ConfigurableChannel =
   | 'feishu'
   | 'slack'
   | 'discord'
+  | 'telegram'
   | 'qq_official'
   | 'chat_app'
   | 'schedule'
@@ -400,6 +416,7 @@ export type SaveChannelConfigVars =
   | { id: string; channel: 'feishu'; config: FeishuPublishConfig }
   | { id: string; channel: 'slack'; config: SlackPublishConfig }
   | { id: string; channel: 'discord'; config: DiscordPublishConfig }
+  | { id: string; channel: 'telegram'; config: TelegramPublishConfig }
   | { id: string; channel: 'qq_official'; config: QQOfficialPublishConfig }
   | { id: string; channel: 'chat_app'; config: ChatAppPublishConfig }
   | { id: string; channel: 'schedule'; config: SchedulePublishConfig | SchedulePublishConfig[] }

--- a/apps/web/src/lib/__tests__/channel-connection-ui.test.ts
+++ b/apps/web/src/lib/__tests__/channel-connection-ui.test.ts
@@ -10,11 +10,12 @@ const emptyMaps: ChatConnectionMaps = {
   feishu: new Map(),
   slack: new Map(),
   discord: new Map(),
+  telegram: new Map(),
   qq_official: new Map(),
 }
 
 function maps(
-  channel: 'feishu' | 'slack' | 'discord' | 'qq_official',
+  channel: 'feishu' | 'slack' | 'discord' | 'telegram' | 'qq_official',
   entries: [string, boolean][],
 ) {
   return { ...emptyMaps, [channel]: new Map(entries) }
@@ -124,6 +125,7 @@ describe('resolveChannelConnectionUi', () => {
       feishu: new Map([['a1', true]]),
       slack: new Map(),
       discord: new Map(),
+      telegram: new Map(),
       qq_official: new Map(),
     }
     expect(resolve({ channel: 'slack', connections })).toBe('absent')

--- a/apps/web/src/lib/channel-connection-ui.ts
+++ b/apps/web/src/lib/channel-connection-ui.ts
@@ -11,7 +11,7 @@
 import type { ChannelKey } from '@/pages/agent-detail/publish/channel-registry'
 
 /** Channels this module knows how to report a connection for. */
-export type ConnectedChannelKey = 'feishu' | 'slack' | 'discord' | 'qq_official'
+export type ConnectedChannelKey = 'feishu' | 'slack' | 'discord' | 'telegram' | 'qq_official'
 
 export type ChannelConnectionUiKind =
   | 'loading'
@@ -31,7 +31,13 @@ export type ChannelConnectionUiKind =
  * arrives over inbound HTTP it gets `kind: 'webhook'` and no socket status.
  */
 export interface ChannelTransport {
-  kind: 'socket'
+  /**
+   * `socket` holds a long-lived connection the vendor pushes down; `polling`
+   * keeps a repeating long-poll request outbound. Both surface the same
+   * "is it live right now" pill, but conflating them would make the Telegram
+   * card claim a socket it never opens.
+   */
+  kind: 'socket' | 'polling'
   /** i18n key naming the protocol, e.g. "WebSocket" / "Socket Mode". */
   labelKey: string
   /** i18n key for the one-line explanation shown in the status tooltip. */
@@ -54,6 +60,11 @@ export const CHANNEL_TRANSPORTS: Record<ConnectedChannelKey, ChannelTransport> =
     labelKey: 'agentPublish.transportDiscordGateway',
     hintKey: 'agentPublish.transportDiscordGatewayHint',
   },
+  telegram: {
+    kind: 'polling',
+    labelKey: 'agentPublish.transportTelegramPolling',
+    hintKey: 'agentPublish.transportTelegramPollingHint',
+  },
   qq_official: {
     kind: 'socket',
     labelKey: 'agentPublish.transportQQOfficialGateway',
@@ -71,6 +82,7 @@ export function isConnectedChannel(channel: string): channel is ConnectedChannel
     channel === 'feishu' ||
     channel === 'slack' ||
     channel === 'discord' ||
+    channel === 'telegram' ||
     channel === 'qq_official'
   )
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -923,7 +923,8 @@
     "tokenCoverageNote": "Total = input + output + reasoning + cache read + cache write. Claude Code, Codex, OpenCode, and Pi report official token fields. Cursor, Qoder, Trae, and Kimi Code may not report tokens. A displayed 0 can mean no usage was reported, not zero consumption.",
     "tokenCoverageDetails": "View coverage details",
     "sourceGlab": "GitLab trigger",
-    "sourceGh": "GitHub trigger"
+    "sourceGh": "GitHub trigger",
+    "sourceTelegram": "Telegram"
   },
   "settings": {
     "title": "Settings",
@@ -1863,7 +1864,25 @@
     "gitTriggerEventRequired": "Select at least one trigger event",
     "gitTriggerIntentRequired": "Enter a trigger prompt",
     "gitTriggerIntervalInvalid": "Poll interval must be between 30 and 600 seconds",
-    "oauthEnvIncompleteSettings": "The current OIDC channel configuration is incomplete (empty audience allowlist). Complete it in Settings → Enterprise Login; editing environment variables will have no effect."
+    "oauthEnvIncompleteSettings": "The current OIDC channel configuration is incomplete (empty audience allowlist). Complete it in Settings → Enterprise Login; editing environment variables will have no effect.",
+    "telegramChannelEnabled": "Enable Telegram channel",
+    "telegramChannelDesc": "Receive and reply to messages through the Telegram Bot API.",
+    "telegramSetupTitle": "Telegram bot setup",
+    "telegramSetupHelp": "Create a bot with @BotFather and paste its token. To trigger on every group message, send /setprivacy to @BotFather and disable Group Privacy; otherwise the bot only sees messages that @mention or reply to it.",
+    "telegramBotToken": "Bot Token",
+    "telegramBotTokenPlaceholder": "Enter Telegram Bot Token (123456:ABC-DEF...)",
+    "telegramGroupSection": "Group messages",
+    "telegramPrivateSection": "Private chats",
+    "telegramTriggerOnMention": "Trigger on @mention or reply to the bot",
+    "telegramTriggerOnNewMessage": "Trigger on every new group message",
+    "telegramTriggerOnNewMessageHint": "Requires Group Privacy to be disabled via @BotFather, otherwise Telegram never delivers these messages. Only human messages are processed; bot messages are ignored to prevent loops.",
+    "telegramReply": "Reply to the original message",
+    "telegramConfigRequired": "Bot Token is required when Telegram is enabled.",
+    "telegramSendArtifactsAsFileHelp": "Upload artifacts directly to Telegram as documents. When off, only a2wave download links are sent.",
+    "channelTelegram": "Telegram",
+    "cardDescTelegram": "Chat with the Agent in Telegram groups and private chats.",
+    "transportTelegramPolling": "Long Polling",
+    "transportTelegramPollingHint": "This instance polls the Telegram Bot API itself; no public callback URL is needed."
   },
   "agentRoute": {
     "tabTitle": "Route",

--- a/apps/web/src/locales/zh.json
+++ b/apps/web/src/locales/zh.json
@@ -923,7 +923,8 @@
     "tokenCoverageNote": "总量 = 输入 + 输出 + 推理 + 缓存读取 + 缓存写入。Claude Code、Codex、OpenCode、Pi 提供官方 Token 字段。Cursor、Qoder、Trae、Kimi Code 可能不返回 Token。显示 0 可能表示未上报，并不代表实际消耗为零。",
     "tokenCoverageDetails": "查看范围说明",
     "sourceGlab": "GitLab 触发",
-    "sourceGh": "GitHub 触发"
+    "sourceGh": "GitHub 触发",
+    "sourceTelegram": "Telegram"
   },
   "settings": {
     "title": "设置",
@@ -1863,7 +1864,25 @@
     "gitTriggerEventRequired": "请至少选择一个触发事件",
     "gitTriggerIntentRequired": "请填写触发提示词",
     "gitTriggerIntervalInvalid": "轮询周期需在 30–600 秒之间",
-    "oauthEnvIncompleteSettings": "当前 OIDC 渠道配置不完整（受众白名单为空）。请到「设置 → 企业登录」补全，改环境变量不会生效。"
+    "oauthEnvIncompleteSettings": "当前 OIDC 渠道配置不完整（受众白名单为空）。请到「设置 → 企业登录」补全，改环境变量不会生效。",
+    "telegramChannelEnabled": "启用 Telegram 渠道",
+    "telegramChannelDesc": "通过 Telegram Bot API 接收消息并回复。",
+    "telegramSetupTitle": "Telegram 机器人设置",
+    "telegramSetupHelp": "在 @BotFather 创建 Bot 并填入 Token。若需群内所有消息都触发，需向 @BotFather 发送 /setprivacy 关闭 Group Privacy；否则 Bot 只能收到 @ 它或回复它的消息。",
+    "telegramBotToken": "Bot Token",
+    "telegramBotTokenPlaceholder": "输入 Telegram Bot Token（123456:ABC-DEF...）",
+    "telegramGroupSection": "群组消息",
+    "telegramPrivateSection": "私聊",
+    "telegramTriggerOnMention": "被 @ 或被回复时触发",
+    "telegramTriggerOnNewMessage": "群内所有新消息均触发",
+    "telegramTriggerOnNewMessageHint": "需通过 @BotFather 关闭 Group Privacy，否则 Telegram 根本不会下发这些消息；仅处理人工消息，Bot 消息会被忽略以避免循环。",
+    "telegramReply": "回复原消息",
+    "telegramConfigRequired": "启用 Telegram 时必须填写 Bot Token。",
+    "telegramSendArtifactsAsFileHelp": "开启后以文件形式直接上传产物到 Telegram。关闭时仅发送 a2wave 下载链接。",
+    "channelTelegram": "Telegram",
+    "cardDescTelegram": "在 Telegram 群组或私聊中与 Agent 对话。",
+    "transportTelegramPolling": "长轮询",
+    "transportTelegramPollingHint": "Telegram Bot API 长轮询由本实例主动发起，无需公网回调地址。"
   },
   "agentRoute": {
     "tabTitle": "路由",

--- a/apps/web/src/pages/agent-detail/publish-tab.tsx
+++ b/apps/web/src/pages/agent-detail/publish-tab.tsx
@@ -30,6 +30,7 @@ import type {
   SaveChannelConfigVars,
   SchedulePublishConfig,
   SlackPublishConfig,
+  TelegramPublishConfig,
 } from '@/hooks/use-agents'
 import {
   fetchGitTriggerCliStatus,
@@ -76,6 +77,7 @@ import {
 import { OauthAllowedEmails } from './publish/oauth-allowed-emails'
 import { QQOfficialChannelSection } from './publish/qq-official-channel-section'
 import { ScheduleChannelSection } from './publish/schedule-channel-section'
+import { TelegramChannelSection } from './publish/telegram-channel-section'
 
 /** Local draft shape for one git-trigger channel's form state. */
 interface GitTriggerDraft {
@@ -390,6 +392,7 @@ export function PublishTab({
   const [feishuEnabled, setFeishuEnabled] = useState(() => channelInitiallyOn('feishu'))
   const [slackEnabled, setSlackEnabled] = useState(() => channelInitiallyOn('slack'))
   const [discordEnabled, setDiscordEnabled] = useState(() => channelInitiallyOn('discord'))
+  const [telegramEnabled, setTelegramEnabled] = useState(() => channelInitiallyOn('telegram'))
   const [qqOfficialEnabled, setQQOfficialEnabled] = useState(() =>
     channelInitiallyOn('qq_official'),
   )
@@ -483,6 +486,20 @@ export function PublishTab({
   )
   const [discordDmReplyMode, setDiscordDmReplyMode] = useState<'reply' | 'none'>('reply')
   const [discordSendArtifactsAsFile, setDiscordSendArtifactsAsFile] = useState(true)
+
+  // Telegram config state
+  const [telegramBotToken, setTelegramBotToken] = useState(
+    () => agent?.telegramConfig?.botToken ?? '',
+  )
+  const [telegramGroupTriggerOnMention, setTelegramGroupTriggerOnMention] = useState(true)
+  const [telegramGroupTriggerOnNewMessage, setTelegramGroupTriggerOnNewMessage] = useState(false)
+  const [telegramGroupReplyMode, setTelegramGroupReplyMode] = useState<'reply' | 'new' | 'none'>(
+    'reply',
+  )
+  const [telegramPrivateReplyMode, setTelegramPrivateReplyMode] = useState<
+    'reply' | 'new' | 'none'
+  >('reply')
+  const [telegramSendArtifactsAsFile, setTelegramSendArtifactsAsFile] = useState(true)
 
   // QQ Official WebSocket Gateway config state.
   const [qqOfficialAppId, setQQOfficialAppId] = useState(() => agent?.qqOfficialConfig?.appId ?? '')
@@ -661,6 +678,7 @@ export function PublishTab({
     feishu: !!agent?.feishuConfig,
     slack: !!agent?.slackConfig,
     discord: !!agent?.discordConfig,
+    telegram: !!agent?.telegramConfig,
     qq_official: !!agent?.qqOfficialConfig,
   }
 
@@ -671,6 +689,7 @@ export function PublishTab({
     persistedChannelConfigured.feishu ||
     persistedChannelConfigured.slack ||
     persistedChannelConfigured.discord ||
+    persistedChannelConfigured.telegram ||
     persistedChannelConfigured.qq_official ||
     !!agent?.publishChannels?.some(isConnectedChannel)
   const {
@@ -778,6 +797,7 @@ export function PublishTab({
       setFeishuEnabled(channels.includes('feishu'))
       setSlackEnabled(channels.includes('slack'))
       setDiscordEnabled(channels.includes('discord'))
+      setTelegramEnabled(channels.includes('telegram'))
       setQQOfficialEnabled(channels.includes('qq_official'))
       setScheduleEnabled(channels.includes('schedule'))
       setScheduleRunAsOwner(Boolean(agent.scheduleRunAsOwner))
@@ -869,6 +889,16 @@ export function PublishTab({
         setDiscordSendArtifactsAsFile(savedDiscord.sendArtifactsAsFile ?? true)
       }
 
+      const savedTelegram = agent.telegramConfig
+      if (savedTelegram) {
+        setTelegramBotToken(savedTelegram.botToken)
+        setTelegramGroupTriggerOnMention(savedTelegram.groupTriggerOnMention)
+        setTelegramGroupTriggerOnNewMessage(savedTelegram.groupTriggerOnNewMessage)
+        setTelegramGroupReplyMode(savedTelegram.groupReplyMode)
+        setTelegramPrivateReplyMode(savedTelegram.privateReplyMode)
+        setTelegramSendArtifactsAsFile(savedTelegram.sendArtifactsAsFile ?? true)
+      }
+
       const savedQQOfficial = agent.qqOfficialConfig
       setQQOfficialAppId(savedQQOfficial?.appId ?? '')
       setQQOfficialAppSecret(savedQQOfficial?.appSecret ?? '')
@@ -920,6 +950,7 @@ export function PublishTab({
     feishuEnabled: (v) => setFeishuEnabled(v as boolean),
     slackEnabled: (v) => setSlackEnabled(v as boolean),
     discordEnabled: (v) => setDiscordEnabled(v as boolean),
+    telegramEnabled: (v) => setTelegramEnabled(v as boolean),
     qqOfficialEnabled: (v) => setQQOfficialEnabled(v as boolean),
     chatAppEnabled: (v) => setChatAppEnabled(v as boolean),
     chatAppDisplayName: (v) => setChatAppDisplayName(v as string),
@@ -969,6 +1000,11 @@ export function PublishTab({
     discordGuildTriggerOnNewMessage: (v) => setDiscordGuildTriggerOnNewMessage(v as boolean),
     discordGuildReplyMode: (v) => setDiscordGuildReplyMode(v as 'reply' | 'new' | 'none'),
     discordDmReplyMode: (v) => setDiscordDmReplyMode(v as 'reply' | 'none'),
+    telegramGroupTriggerOnMention: (v) => setTelegramGroupTriggerOnMention(v as boolean),
+    telegramGroupTriggerOnNewMessage: (v) => setTelegramGroupTriggerOnNewMessage(v as boolean),
+    telegramGroupReplyMode: (v) => setTelegramGroupReplyMode(v as 'reply' | 'new' | 'none'),
+    telegramPrivateReplyMode: (v) => setTelegramPrivateReplyMode(v as 'reply' | 'new' | 'none'),
+    telegramSendArtifactsAsFile: (v) => setTelegramSendArtifactsAsFile(v as boolean),
     qqOfficialAppId: (v) => setQQOfficialAppId(v as string),
     qqGroupTriggerOnAt: (v) => setQQGroupTriggerOnAt(v as boolean),
     qqGroupReplyMode: (v) => setQQGroupReplyMode(v as 'reply' | 'new' | 'none'),
@@ -1008,6 +1044,7 @@ export function PublishTab({
     feishuEnabled,
     slackEnabled,
     discordEnabled,
+    telegramEnabled,
     qqOfficialEnabled,
     chatAppEnabled,
     chatAppDisplayName,
@@ -1055,6 +1092,11 @@ export function PublishTab({
     discordGuildTriggerOnNewMessage,
     discordGuildReplyMode,
     discordDmReplyMode,
+    telegramGroupTriggerOnMention,
+    telegramGroupTriggerOnNewMessage,
+    telegramGroupReplyMode,
+    telegramPrivateReplyMode,
+    telegramSendArtifactsAsFile,
     qqOfficialAppId,
     qqGroupTriggerOnAt,
     qqGroupReplyMode,
@@ -1123,6 +1165,7 @@ export function PublishTab({
     if (feishuEnabled) channels.push('feishu')
     if (slackEnabled) channels.push('slack')
     if (discordEnabled) channels.push('discord')
+    if (telegramEnabled) channels.push('telegram')
     if (qqOfficialEnabled) channels.push('qq_official')
     if (scheduleEnabled) channels.push('schedule')
     if (oauthEnabled) channels.push('oauth')
@@ -1202,6 +1245,15 @@ export function PublishTab({
     sendArtifactsAsFile: slackSendArtifactsAsFile,
   })
 
+  const buildTelegramConfig = (): TelegramPublishConfig => ({
+    botToken: telegramBotToken,
+    groupTriggerOnMention: telegramGroupTriggerOnMention,
+    groupTriggerOnNewMessage: telegramGroupTriggerOnNewMessage,
+    groupReplyMode: telegramGroupReplyMode,
+    privateReplyMode: telegramPrivateReplyMode,
+    sendArtifactsAsFile: telegramSendArtifactsAsFile,
+  })
+
   const buildDiscordConfig = (): DiscordPublishConfig => ({
     applicationId: discordApplicationId,
     botToken: discordBotToken,
@@ -1239,6 +1291,8 @@ export function PublishTab({
         return buildSlackConfig()
       case 'discord':
         return buildDiscordConfig()
+      case 'telegram':
+        return buildTelegramConfig()
       case 'qq_official':
         return buildQQOfficialConfig()
       case 'chat_app':
@@ -1270,6 +1324,7 @@ export function PublishTab({
     feishu: feishuEnabled,
     slack: slackEnabled,
     discord: discordEnabled,
+    telegram: telegramEnabled,
     qq_official: qqOfficialEnabled,
     schedule: scheduleEnabled,
     chat_app: chatAppEnabled,
@@ -1286,6 +1341,7 @@ export function PublishTab({
     slackBotToken,
     discordApplicationId,
     discordBotToken,
+    telegramBotToken,
     qqOfficialAppId,
     qqOfficialAppSecret,
     oauthAccessMode,
@@ -1313,6 +1369,8 @@ export function PublishTab({
         return setSlackEnabled(value)
       case 'discord':
         return setDiscordEnabled(value)
+      case 'telegram':
+        return setTelegramEnabled(value)
       case 'qq_official':
         return setQQOfficialEnabled(value)
       case 'schedule':
@@ -1405,6 +1463,9 @@ export function PublishTab({
     const discordConfig: DiscordPublishConfig | undefined = discordEnabled
       ? buildDiscordConfig()
       : undefined
+    const telegramConfig: TelegramPublishConfig | undefined = telegramEnabled
+      ? buildTelegramConfig()
+      : undefined
     const qqOfficialConfig: QQOfficialPublishConfig | undefined = qqOfficialEnabled
       ? buildQQOfficialConfig()
       : undefined
@@ -1442,6 +1503,7 @@ export function PublishTab({
       feishuConfig,
       slackConfig,
       discordConfig,
+      telegramConfig,
       qqOfficialConfig,
       chatAppConfig,
       scheduleConfig,
@@ -1897,6 +1959,26 @@ export function PublishTab({
           onDmReplyModeChange={setDiscordDmReplyMode}
           sendArtifactsAsFile={discordSendArtifactsAsFile}
           onSendArtifactsAsFileChange={setDiscordSendArtifactsAsFile}
+        />
+      ),
+    },
+    {
+      key: 'telegram',
+      label: 'Telegram',
+      children: (
+        <TelegramChannelSection
+          botToken={telegramBotToken}
+          onBotTokenChange={setTelegramBotToken}
+          groupTriggerOnMention={telegramGroupTriggerOnMention}
+          onGroupTriggerOnMentionChange={setTelegramGroupTriggerOnMention}
+          groupTriggerOnNewMessage={telegramGroupTriggerOnNewMessage}
+          onGroupTriggerOnNewMessageChange={setTelegramGroupTriggerOnNewMessage}
+          groupReplyMode={telegramGroupReplyMode}
+          onGroupReplyModeChange={setTelegramGroupReplyMode}
+          privateReplyMode={telegramPrivateReplyMode}
+          onPrivateReplyModeChange={setTelegramPrivateReplyMode}
+          sendArtifactsAsFile={telegramSendArtifactsAsFile}
+          onSendArtifactsAsFileChange={setTelegramSendArtifactsAsFile}
         />
       ),
     },

--- a/apps/web/src/pages/agent-detail/publish/__tests__/channel-readiness.test.ts
+++ b/apps/web/src/pages/agent-detail/publish/__tests__/channel-readiness.test.ts
@@ -11,6 +11,7 @@ function input(overrides: Partial<ChannelReadinessInput> = {}): ChannelReadiness
     slackBotToken: '',
     discordApplicationId: '',
     discordBotToken: '',
+    telegramBotToken: '',
     qqOfficialAppId: '',
     qqOfficialAppSecret: '',
     oauthAccessMode: 'all_idaas_users',

--- a/apps/web/src/pages/agent-detail/publish/__tests__/channel-registry.test.ts
+++ b/apps/web/src/pages/agent-detail/publish/__tests__/channel-registry.test.ts
@@ -17,9 +17,9 @@ function lookup(bundle: Record<string, unknown>, dotted: string): unknown {
 }
 
 describe('channel registry', () => {
-  it('covers all eleven publish channels exactly once', () => {
-    expect(CHANNEL_REGISTRY).toHaveLength(11)
-    expect(new Set(CHANNEL_REGISTRY.map((c) => c.key)).size).toBe(11)
+  it('covers all twelve publish channels exactly once', () => {
+    expect(CHANNEL_REGISTRY).toHaveLength(12)
+    expect(new Set(CHANNEL_REGISTRY.map((c) => c.key)).size).toBe(12)
     expect([...VALID_PUBLISH_TABS].sort()).toEqual(
       [
         'a2a',
@@ -33,6 +33,7 @@ describe('channel registry', () => {
         'qq_official',
         'schedule',
         'slack',
+        'telegram',
       ].sort(),
     )
   })

--- a/apps/web/src/pages/agent-detail/publish/__tests__/git-trigger-readiness.test.ts
+++ b/apps/web/src/pages/agent-detail/publish/__tests__/git-trigger-readiness.test.ts
@@ -18,6 +18,7 @@ function baseInput(overrides: Partial<ChannelReadinessInput> = {}): ChannelReadi
     slackBotToken: '',
     discordApplicationId: '',
     discordBotToken: '',
+    telegramBotToken: '',
     qqOfficialAppId: '',
     qqOfficialAppSecret: '',
     oauthAccessMode: 'all_idaas_users',

--- a/apps/web/src/pages/agent-detail/publish/channel-readiness.ts
+++ b/apps/web/src/pages/agent-detail/publish/channel-readiness.ts
@@ -27,6 +27,7 @@ export interface ChannelReadinessInput {
   slackBotToken: string
   discordApplicationId: string
   discordBotToken: string
+  telegramBotToken: string
   qqOfficialAppId: string
   qqOfficialAppSecret: string
   oauthAccessMode: 'all_idaas_users' | 'specified_users'
@@ -83,6 +84,9 @@ export function getChannelBlockReason(
       return input.discordApplicationId && input.discordBotToken
         ? null
         : 'agentPublish.discordConfigRequired'
+
+    case 'telegram':
+      return input.telegramBotToken ? null : 'agentPublish.telegramConfigRequired'
 
     case 'qq_official':
       return input.qqOfficialAppId && input.qqOfficialAppSecret

--- a/apps/web/src/pages/agent-detail/publish/channel-registry.ts
+++ b/apps/web/src/pages/agent-detail/publish/channel-registry.ts
@@ -18,6 +18,7 @@ import {
   KeyRound,
   MessagesSquare,
   Network,
+  Send,
   Slack,
 } from 'lucide-react'
 
@@ -29,6 +30,7 @@ export type ChannelKey =
   | 'feishu'
   | 'slack'
   | 'discord'
+  | 'telegram'
   | 'qq_official'
   | 'schedule'
   | 'chat_app'
@@ -118,6 +120,14 @@ export const CHANNEL_REGISTRY: readonly ChannelMeta[] = [
     switchLabelKey: 'agentPublish.discordChannelEnabled',
   },
   {
+    key: 'telegram',
+    category: 'chatbot',
+    icon: Send,
+    titleKey: 'agentPublish.channelTelegram',
+    descKey: 'agentPublish.cardDescTelegram',
+    switchLabelKey: 'agentPublish.telegramChannelEnabled',
+  },
+  {
     key: 'qq_official',
     category: 'chatbot',
     icon: Bot,
@@ -178,6 +188,7 @@ const CONFIGURABLE_CHANNELS = [
   'feishu',
   'slack',
   'discord',
+  'telegram',
   'qq_official',
   'chat_app',
   'schedule',

--- a/apps/web/src/pages/agent-detail/publish/telegram-channel-section.tsx
+++ b/apps/web/src/pages/agent-detail/publish/telegram-channel-section.tsx
@@ -1,0 +1,131 @@
+/**
+ * Publish tab → Telegram channel section.
+ *
+ * Mirrors the Discord section's fully-controlled shape: all state is owned by
+ * the parent so `handlePublish` can still assemble one atomic publish payload.
+ *
+ * Telegram has no separate application id — the bot identity is the numeric
+ * prefix of the token itself — so the credential block is a single field.
+ */
+
+import { Checkbox, Radio, Switch } from 'antd'
+import { useTranslation } from 'react-i18next'
+import { Label } from '@/components/ui/label'
+
+export type TelegramGroupReplyMode = 'reply' | 'new' | 'none'
+export type TelegramPrivateReplyMode = 'reply' | 'new' | 'none'
+
+export interface TelegramChannelSectionProps {
+  botToken: string
+  onBotTokenChange: (value: string) => void
+  groupTriggerOnMention: boolean
+  onGroupTriggerOnMentionChange: (value: boolean) => void
+  groupTriggerOnNewMessage: boolean
+  onGroupTriggerOnNewMessageChange: (value: boolean) => void
+  groupReplyMode: TelegramGroupReplyMode
+  onGroupReplyModeChange: (value: TelegramGroupReplyMode) => void
+  privateReplyMode: TelegramPrivateReplyMode
+  onPrivateReplyModeChange: (value: TelegramPrivateReplyMode) => void
+  sendArtifactsAsFile: boolean
+  onSendArtifactsAsFileChange: (value: boolean) => void
+}
+
+export function TelegramChannelSection({
+  botToken: telegramBotToken,
+  onBotTokenChange: setTelegramBotToken,
+  groupTriggerOnMention: telegramGroupTriggerOnMention,
+  onGroupTriggerOnMentionChange: setTelegramGroupTriggerOnMention,
+  groupTriggerOnNewMessage: telegramGroupTriggerOnNewMessage,
+  onGroupTriggerOnNewMessageChange: setTelegramGroupTriggerOnNewMessage,
+  groupReplyMode: telegramGroupReplyMode,
+  onGroupReplyModeChange: setTelegramGroupReplyMode,
+  privateReplyMode: telegramPrivateReplyMode,
+  onPrivateReplyModeChange: setTelegramPrivateReplyMode,
+  sendArtifactsAsFile: telegramSendArtifactsAsFile,
+  onSendArtifactsAsFileChange: setTelegramSendArtifactsAsFile,
+}: TelegramChannelSectionProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-5">
+      <div className="info-panel space-y-1 px-3 py-2.5 text-sm text-muted-foreground">
+        <p className="font-medium text-foreground">{t('agentPublish.telegramSetupTitle')}</p>
+        <p>{t('agentPublish.telegramSetupHelp')}</p>
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="telegram-bot-token" required>
+          {t('agentPublish.telegramBotToken')}
+        </Label>
+        <input
+          id="telegram-bot-token"
+          type="password"
+          value={telegramBotToken}
+          onChange={(event) => setTelegramBotToken(event.target.value)}
+          placeholder={t('agentPublish.telegramBotTokenPlaceholder')}
+          className="rounded-md border border-border bg-background px-3 py-2 font-mono text-sm outline-none focus:border-primary"
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-3 rounded-lg bg-muted/40 px-4 py-3">
+          <Label className="font-semibold">{t('agentPublish.telegramGroupSection')}</Label>
+          <div className="flex flex-col gap-1.5">
+            <Checkbox
+              checked={telegramGroupTriggerOnMention}
+              onChange={(event) => setTelegramGroupTriggerOnMention(event.target.checked)}
+            >
+              {t('agentPublish.telegramTriggerOnMention')}
+            </Checkbox>
+            <div>
+              <Checkbox
+                checked={telegramGroupTriggerOnNewMessage}
+                onChange={(event) => setTelegramGroupTriggerOnNewMessage(event.target.checked)}
+              >
+                {t('agentPublish.telegramTriggerOnNewMessage')}
+              </Checkbox>
+              <p className="mt-1 pl-6 text-xs text-muted-foreground">
+                {t('agentPublish.telegramTriggerOnNewMessageHint')}
+              </p>
+            </div>
+          </div>
+          <Radio.Group
+            value={telegramGroupReplyMode}
+            onChange={(event) => setTelegramGroupReplyMode(event.target.value)}
+            className="flex flex-col gap-1.5"
+          >
+            <Radio value="reply">{t('agentPublish.telegramReply')}</Radio>
+            <Radio value="new">{t('agentPublish.nativeReplyNew')}</Radio>
+            <Radio value="none">{t('agentPublish.nativeReplyNone')}</Radio>
+          </Radio.Group>
+        </div>
+        <div className="space-y-3 rounded-lg bg-muted/40 px-4 py-3">
+          <Label className="font-semibold">{t('agentPublish.telegramPrivateSection')}</Label>
+          <p className="text-xs text-muted-foreground">
+            {t('agentPublish.nativeDmAlwaysTriggers')}
+          </p>
+          <Radio.Group
+            value={telegramPrivateReplyMode}
+            onChange={(event) => setTelegramPrivateReplyMode(event.target.value)}
+            className="flex flex-col gap-1.5"
+          >
+            <Radio value="reply">{t('agentPublish.telegramReply')}</Radio>
+            <Radio value="new">{t('agentPublish.nativeReplyNew')}</Radio>
+            <Radio value="none">{t('agentPublish.nativeReplyNone')}</Radio>
+          </Radio.Group>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between rounded-lg bg-muted/40 px-4 py-3">
+        <div>
+          <Label className="text-sm font-medium">
+            {t('agentPublish.nativeSendArtifactsAsFile')}
+          </Label>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {t('agentPublish.telegramSendArtifactsAsFileHelp')}
+          </p>
+        </div>
+        <Switch checked={telegramSendArtifactsAsFile} onChange={setTelegramSendArtifactsAsFile} />
+      </div>
+    </div>
+  )
+}

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -116,7 +116,7 @@ Treat them as existing implementation debt, not as precedent for a new channel o
 authorization to expand anonymous access. Retiring them requires a separate,
 migration-compatible product and code change.
 
-Current: API / OAuth / A2A / Feishu / Slack / Discord / schedule / chat page / GitLab
+Current: API / OAuth / A2A / Feishu / Slack / Discord / Telegram / schedule / chat page / GitLab
 trigger (`glab`) / GitHub trigger (`gh`).
 
 Recorded boundary decisions are retained because they explain why the current
@@ -124,7 +124,7 @@ channels fit the product rather than merely listing that they exist:
 
 | Channel | Decision |
 | :--- | :--- |
-| Slack / Discord | Approved by the maintainers as native authenticated chat channels. |
+| Slack / Discord / Telegram | Approved by the maintainers as native authenticated chat channels. |
 | Chat page (`chat_app`) | Approved as a first-party, session-authenticated surface; every turn creates a Run with `trigger_source = 'chat_app'`. |
 | GitLab / GitHub triggers | Approved as inbound polling triggers. They expose no new internet endpoint, keep forge credentials in the vendor CLI, attribute fired Runs to the Agent owner, and audit them through `agent.git_trigger`. |
 
@@ -142,7 +142,7 @@ features or reviewing requirements.
 
 | Principle | Description |
 | :--- | :--- |
-| **One process, one App, one connection** | Within a single API process, a given Feishu / Slack / Discord App ID may hold only **one** active connection. |
+| **One process, one App, one connection** | Within a single API process, a given Feishu / Slack / Discord App ID (or Telegram bot id) may hold only **one** active connection. |
 | **No connection sharing** | Each connected Agent uses its own provider client. Never promise "one physical connection multiplexed across Agents" as a product capability — the semantics are **slot mutual exclusion**. |
 | **First come, first served** | With several published Agents on the same App ID, the first to connect holds the slot; the rest must not connect, and **must not preempt the incumbent**. The slot frees only when the incumbent unpublishes or stops. |
 | **One bot per Agent (recommended)** | Agents that must connect independently to the same platform each need their own provider app and credentials. |
@@ -153,7 +153,7 @@ only**. Requirements that contradict these principles — Agents sharing one pro
 app while both receive messages, or a later starter preempting the incumbent — are not
 included in the product plan.
 
-Feishu files, Slack Files, and Discord Attachments may be downloaded into the Run's
+Feishu files, Slack Files, Discord Attachments, and Telegram files may be downloaded into the Run's
 local attachment context. Provider URLs are restricted to the platform allowlists;
 the shared attachment policy enforces size and extension limits, and temporary files
 are cleaned up after processing.

--- a/docs/agent/api-permissions.md
+++ b/docs/agent/api-permissions.md
@@ -20,7 +20,7 @@ ACL.
     are only offered resources the *owner* can execute.
 - **Run** — `runs.userId` records *who triggered it*, and channels without a
   logged-in user disagree: Feishu / gateway API key / OAuth leave it NULL;
-  A2A / schedule / Slack / Discord stamp the agent owner. Read access therefore
+  A2A / schedule / Slack / Discord / Telegram stamp the agent owner. Read access therefore
   comes from `getRunReadFilter`: admin sees all; everyone else sees runs of agents
   they can read **plus** runs they triggered. **Mutations are stricter than
   reads** — `cancel` / `execute` / `rerun` need write on the run

--- a/e2e/tests/agents/telegram-publish.spec.ts
+++ b/e2e/tests/agents/telegram-publish.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from '@playwright/test'
+import { createAgent, deleteAgentAs, getAdminToken } from '../../utils/api-helpers'
+import { loginAsAdmin } from '../../utils/auth'
+import { AGENT_ROUTES, API_BASE } from '../../utils/test-constants'
+
+/**
+ * Telegram is the only chat channel whose credential block is a single field —
+ * the bot identity is the numeric prefix of the token itself, so there is no
+ * separate application id to enter. This spec locks in that the card can be
+ * configured, enabled and published from the UI alone.
+ */
+test.describe('Telegram publishing', () => {
+  let agentId = ''
+  let token = ''
+
+  // A syntactically valid token that no real bot owns: the publish route stores
+  // it without contacting Telegram, and the polling loop's getMe failure is
+  // logged rather than surfaced, so the UI flow stays deterministic offline.
+  const BOT_TOKEN = '123456789:e2e-telegram-token-not-a-real-secret'
+
+  test.beforeEach(async ({ page }) => {
+    token = await getAdminToken()
+    agentId = (await createAgent(token, `telegram-e2e-${Date.now()}`)).id
+    await loginAsAdmin(page)
+  })
+
+  test.afterEach(async () => {
+    if (!agentId) return
+    await fetch(`${API_BASE}/api/agents/${agentId}/stop`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    }).catch(() => undefined)
+    await deleteAgentAs(token, agentId)
+    agentId = ''
+  })
+
+  test('saves the bot token and publishes the Telegram channel', async ({ page }) => {
+    await page.goto(AGENT_ROUTES.publishTab(agentId, 'telegram'))
+
+    // Group and private sections both render; Telegram has no "channel" scene
+    // of the kind QQ exposes, so no third reply mode should appear.
+    // `exact` matters: the card's own description also contains 「私聊」, so a
+    // substring match resolves to two nodes and trips strict mode.
+    await expect(page.getByText('群组消息', { exact: true })).toBeVisible()
+    await expect(page.getByText('私聊', { exact: true })).toBeVisible()
+
+    const enable = page.getByRole('switch', { name: /启用 Telegram 渠道/ })
+    // Readiness gate: with no token saved the switch must stay disabled.
+    await expect(enable).toBeDisabled()
+
+    await page.getByLabel('Bot Token').fill(BOT_TOKEN)
+    await page.getByRole('button', { name: '保存', exact: true }).click()
+    await expect(page.getByText('渠道配置已保存')).toBeVisible()
+
+    await expect(enable).toBeEnabled()
+    await enable.click()
+    await page.locator('[data-tour="publish-btn"]').click()
+
+    await expect
+      .poll(async () => {
+        const response = await fetch(`${API_BASE}/api/agents/${agentId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        const body = (await response.json()) as {
+          data: { publishChannels?: string[]; telegramConfig?: { botToken?: string } }
+        }
+        return {
+          enabled: body.data.publishChannels?.includes('telegram'),
+          // Owner/editor deliberately get the plaintext token back so the edit
+          // form can prefill — the same contract Feishu/Slack/Discord/QQ use.
+          // Masking for viewers is covered by the API unit tests.
+          storedToken: body.data.telegramConfig?.botToken,
+        }
+      })
+      .toEqual({ enabled: true, storedToken: BOT_TOKEN })
+  })
+
+  test('refuses to publish Telegram without a bot token', async ({ page }) => {
+    const response = await fetch(`${API_BASE}/api/agents/${agentId}/publish`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ channels: ['api', 'telegram'] }),
+    })
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as { code?: string }
+    expect(body.code).toBe('TELEGRAM_CONFIG_REQUIRED')
+
+    // The rejected publish must not have flipped the channel on.
+    await page.goto(AGENT_ROUTES.publishTab(agentId, 'telegram'))
+    await expect(page.getByRole('switch', { name: /启用 Telegram 渠道/ })).not.toBeChecked()
+  })
+})

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -42,6 +42,7 @@ export const publishChannelEnum = z.enum([
   'feishu',
   'slack',
   'discord',
+  'telegram',
   'qq_official',
   'schedule',
   'oauth',
@@ -244,6 +245,28 @@ export const discordConfigSchema = z.object({
 })
 export type DiscordConfig = z.input<typeof discordConfigSchema>
 
+/**
+ * Telegram Bot configuration.
+ *
+ * a2wave consumes updates through long polling (`getUpdates`) rather than
+ * webhooks, so a private deployment needs no public HTTPS ingress — matching how
+ * the Slack / Discord / QQ gateways already reach out rather than being called.
+ */
+export const telegramConfigSchema = z.object({
+  /** `<bot_id>:<secret>` issued by @BotFather. The bot id prefix identifies the bot. */
+  botToken: z.string().min(1),
+  /** Trigger in groups only when the bot is @-mentioned or replied to. */
+  groupTriggerOnMention: z.boolean().default(true),
+  /** Trigger on every group message. Requires BotFather group privacy to be disabled. */
+  groupTriggerOnNewMessage: z.boolean().default(false),
+  groupReplyMode: z.enum(['reply', 'new', 'none']).default('reply'),
+  privateReplyMode: z.enum(['reply', 'new', 'none']).default('reply'),
+  sendArtifactsAsFile: z.boolean().default(true),
+  /** Optional custom Bot API base, for self-hosted Bot API servers or a proxy. */
+  apiBaseUrl: z.string().url().optional(),
+})
+export type TelegramConfig = z.input<typeof telegramConfigSchema>
+
 /** QQ Official Bot configuration using Tencent's public WebSocket Gateway. */
 export const qqOfficialConfigSchema = z.object({
   appId: z.string().trim().min(1),
@@ -412,6 +435,7 @@ export const agentSchema = z.object({
   feishuConfig: feishuConfigSchema.nullable().optional(),
   slackConfig: slackConfigSchema.nullable().optional(),
   discordConfig: discordConfigSchema.nullable().optional(),
+  telegramConfig: telegramConfigSchema.nullable().optional(),
   qqOfficialConfig: qqOfficialConfigSchema.nullable().optional(),
   chatAppConfig: chatAppConfigSchema.nullable().optional(),
   scheduleConfig: scheduleConfigSchema.nullable().optional(),
@@ -483,6 +507,7 @@ export const createAgentInput = z.object({
   feishuConfig: feishuConfigSchema.nullable().optional(),
   slackConfig: slackConfigSchema.nullable().optional(),
   discordConfig: discordConfigSchema.nullable().optional(),
+  telegramConfig: telegramConfigSchema.nullable().optional(),
   qqOfficialConfig: qqOfficialConfigSchema.nullable().optional(),
   chatAppConfig: chatAppConfigSchema.nullable().optional(),
   scheduleConfig: scheduleConfigSchema.nullable().optional(),

--- a/packages/shared/src/schemas/run-channel.ts
+++ b/packages/shared/src/schemas/run-channel.ts
@@ -116,6 +116,25 @@ export const discordChannelInfoSchema = z.object({
 })
 export type DiscordChannelInfo = z.infer<typeof discordChannelInfoSchema>
 
+// ── Channel info: Telegram ───────────────────────────────────────────────────
+//
+// `chat_id` is the reply address for every scene (private / group / supergroup /
+// channel), and `message_id` is scoped to that chat rather than being globally
+// unique — so both are required to address a reply. `message_thread_id` carries a
+// supergroup forum topic, which behaves like a Discord thread.
+export const telegramChannelInfoSchema = z.object({
+  /** Numeric bot id parsed from the token prefix — the Telegram analogue of application_id. */
+  bot_id: z.string().min(1),
+  /** Signed int64 rendered as a string: negative for groups/supergroups/channels. */
+  chat_id: z.string().min(1),
+  chat_type: z.enum(['private', 'group', 'supergroup', 'channel']),
+  message_id: z.string().min(1),
+  /** Forum topic id inside a supergroup, when the message came from one. */
+  message_thread_id: z.string().min(1).optional(),
+  sender_user_id: z.string().min(1),
+})
+export type TelegramChannelInfo = z.infer<typeof telegramChannelInfoSchema>
+
 // ── Channel info: QQ Official ────────────────────────────────────────────────
 const qqOfficialChannelInfoBase = {
   app_id: z.string().min(1),
@@ -230,6 +249,12 @@ export const runChannelContextSchema = z.discriminatedUnion('channel_type', [
     display_name: z.string().min(1).optional(),
   }),
   z.object({
+    channel_type: z.literal('telegram'),
+    channel_info: telegramChannelInfoSchema,
+    user_info: userInfoSchema.nullable(),
+    display_name: z.string().min(1).optional(),
+  }),
+  z.object({
     channel_type: z.literal('qq_official'),
     channel_info: qqOfficialChannelInfoSchema,
     user_info: userInfoSchema.nullable(),
@@ -280,6 +305,7 @@ export type RunChannelContextA2A = Extract<RunChannelContext, { channel_type: 'a
 export type RunChannelContextFeishu = Extract<RunChannelContext, { channel_type: 'feishu' }>
 export type RunChannelContextSlack = Extract<RunChannelContext, { channel_type: 'slack' }>
 export type RunChannelContextDiscord = Extract<RunChannelContext, { channel_type: 'discord' }>
+export type RunChannelContextTelegram = Extract<RunChannelContext, { channel_type: 'telegram' }>
 export type RunChannelContextQQOfficial = Extract<
   RunChannelContext,
   { channel_type: 'qq_official' }

--- a/packages/shared/src/schemas/run.ts
+++ b/packages/shared/src/schemas/run.ts
@@ -29,6 +29,7 @@ export const runTriggerSourceEnum = z.enum([
   'feishu',
   'slack',
   'discord',
+  'telegram',
   'qq_official',
   'a2a',
   'schedule',


### PR DESCRIPTION
## Summary

Adds **Telegram** as a first-class native chat channel, at parity with Discord rather than as a minimal bridge: group and private triggers, attachments in both directions, artifact upload, per-conversation sessions, publish/stop/resume, and restart recovery.

Updates arrive over **long polling** (`getUpdates`) instead of webhooks. Telegram permits only one of the two per bot, and polling keeps the deployment story identical to the existing channels — the instance reaches out, so no public HTTPS ingress or callback URL is needed and private deployments work unchanged. Registering a bot therefore clears any webhook previously set on it.

Channel-specific decisions worth reviewing:

- **No separate application id** — the bot identity is the numeric prefix of the token. `start()` verifies it against `getMe` before polling begins, so a wrong token fails closed with no leaked registration.
- **Chat-scoped event ids** (`telegram:<bot>:<chat>:<message>`) because Telegram message ids repeat across chats; a global id would collide in the redelivery-dedup index.
- **Group triggers accept an @mention *or* a reply to the bot**, which is how users actually address one. Triggering on every group message additionally requires Group Privacy disabled via @BotFather — the UI says so, since otherwise the option silently does nothing.
- **Attachments persist only the `file_id`**; bytes are resolved later via `getFile`, keeping the token-bearing download URL out of the database. For a photo ladder only the highest-resolution entry is kept.
- **Long replies are split**, not truncated.

**No new runtime dependency.** The Bot API is plain HTTPS JSON and long polling is an offset-cursor loop, so this follows the QQ channel's precedent (also SDK-free) of using platform primitives directly. Swapping in `grammy` later would only touch the transport layer.

### Incidental refactor

Adding the channel pushed `routes/agents.ts` past the 3000-line gate. The self-contained `PATCH /agents/:id/channels/:channel` route moved to `routes/agent-channel-config.ts` — it owns a registry nothing else in `agents.ts` reads, so the publish path is untouched and `agents.ts` drops to 2832 lines. No behavior change; covered by the existing 173 route tests.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore

## Testing checklist

- [x] `pnpm lint` passes — 0 errors, 752 warnings (unchanged from `main`)
- [x] `pnpm typecheck` passes — shared / api / web / cli all green
- [x] `pnpm test` passes — api 6,571 · web 1,034 · cli 1,131 · shared 267, 0 failures
- [x] E2E updated/run — new `e2e/tests/agents/telegram-publish.spec.ts`, 2 passing
- [x] User-facing docs, i18n copy (`zh.json` **and** `en.json`), and the in-app manual updated

New tests: `telegram-service.test.ts` (trigger gating, mention stripping, attachment mapping, session isolation, chunking), `telegram-poll-loop.test.ts` (drives the full receive → trigger → reply path against a local Bot API server), plus Telegram cases added to `run-channel`, `agents-secret-redaction`, `channel-registry`, `channel-connection-ui`, and `graceful-shutdown`.

Also verified against the **real** Telegram Bot API: bot-id derivation matching `getMe`, `deleteWebhook`, a genuinely held long poll, and 401 fail-closed on a bad secret. A live bot delivered messages into a published Agent and received the reply back.

## Cross-cutting change matrix

- [x] Create / import / bootstrap paths checked — import strips Telegram credentials fail-closed and warns, matching Slack/Discord/QQ
- [x] PATCH / enable-disable / cancellation paths checked — publish, per-channel config save, stop, resume all start/stop the polling loop
- [x] DELETE / cleanup / audit paths checked — audit records the channel name only, never the config
- [x] Startup recovery and upgrade compatibility checked — `restoreConnections()` reattaches published Telegram agents; the column is additive and nullable
- [ ] Git and P4 behavior checked where applicable — not applicable
- [x] SQLite and PostgreSQL behavior checked where applicable — parallel migrations (`0119` / `0017`), schema-parity gate green
- [ ] Named volume, default bind, explicit bind, and macOS bind behavior checked — not applicable
- [x] Failure recovery and operator remediation are documented — manual covers the Group Privacy trap and the one-bot-one-Agent constraint; both language troubleshooting tables updated

## AI assistance disclosure

- [x] This change was substantially AI-generated. If checked, I confirm I understand the code and have tested it myself (see CONTRIBUTING.md).

## Additional notes

Secrets are masked for viewers and revealed to owner/editor for form prefill, matching the existing native-chat contract; a test for that was missing for Slack/Discord's Telegram sibling and is now added.

Follow-up worth considering: the `agents.ts` extraction leaves further natural seams (publish vs. binding vs. chat), if the file grows again.
