### PR TITLE
fix(web): theme-correct status colors, and make the token chart readable

### DIFF
--- a/apps/web/src/components/cli-tokens-card.tsx
+++ b/apps/web/src/components/cli-tokens-card.tsx
@@ -349,7 +349,9 @@ function CreateTokenDialog({
             </div>
 
             {error && (
-              <div className="rounded-lg bg-red-50 px-3 py-2.5 text-sm text-red-600">{error}</div>
+              <div className="rounded-lg bg-destructive-subtle px-3 py-2.5 text-sm text-destructive">
+                {error}
+              </div>
             )}
           </div>
         )}

--- a/apps/web/src/components/scm/scm-source-form.tsx
+++ b/apps/web/src/components/scm/scm-source-form.tsx
@@ -680,7 +680,7 @@ export function ScmSourceForm({ sourceId, onSaved, onDeleted }: Props) {
               <span
                 className={`inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium ${
                   source.type === 'git'
-                    ? 'border-orange-200/80 bg-orange-50 text-orange-700'
+                    ? 'border-warning/30 bg-warning-subtle text-warning'
                     : 'border-blue-200/80 bg-blue-50 text-blue-700'
                 }`}
               >
@@ -1438,9 +1438,9 @@ export function ScmSourceForm({ sourceId, onSaved, onDeleted }: Props) {
                   })
                 }
                 const cleanupStyles: Record<string, string> = {
-                  ephemeral: 'border-red-200 bg-red-50 text-red-700',
+                  ephemeral: 'border-destructive/30 bg-destructive-subtle text-destructive',
                   ttl: 'border-blue-200 bg-blue-50 text-blue-700',
-                  persistent: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+                  persistent: 'border-success/30 bg-success-subtle text-success',
                 }
                 const cleanupLabel = ws.cleanup
                   ? t(`scmSources.workspaces.cleanup.${ws.cleanup}`)
@@ -1491,7 +1491,7 @@ export function ScmSourceForm({ sourceId, onSaved, onDeleted }: Props) {
                             {ws.name}
                           </span>
                           {ws.occupied ? (
-                            <span className="inline-flex items-center rounded-md border border-orange-200 bg-orange-50 px-1.5 py-0.5 text-xs font-medium text-orange-700">
+                            <span className="inline-flex items-center rounded-md border border-warning/30 bg-warning-subtle px-1.5 py-0.5 text-xs font-medium text-warning">
                               {t('scmSources.workspaces.occupied')}
                             </span>
                           ) : (

--- a/apps/web/src/components/sso-methods-card.tsx
+++ b/apps/web/src/components/sso-methods-card.tsx
@@ -7,6 +7,12 @@
  * client_secret 只在用户输入时随 PATCH 提交（明文，服务端加密）；读接口不回明文，
  * 占位符按 clientSecretSet 提示「已设置（留空保持不变）」。
  */
+
+import { useQuery } from '@tanstack/react-query'
+import { Check, Copy, Globe, KeyRound, Loader2, ShieldHalf, X } from 'lucide-react'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
 import {
   AlertDialog,
   AlertDialogContent,
@@ -30,18 +36,13 @@ import {
 } from '@/hooks/use-settings'
 import { api } from '@/lib/api'
 import {
-  type OidcFormValues,
-  type SamlFormValues,
   buildOidcConfig,
   buildSamlConfig,
+  type OidcFormValues,
   parseOidcConfig,
   parseSamlConfig,
+  type SamlFormValues,
 } from '@/lib/sso-config-form'
-import { useQuery } from '@tanstack/react-query'
-import { Check, Copy, Globe, KeyRound, Loader2, ShieldHalf, X } from 'lucide-react'
-import { type ReactNode, useEffect, useRef, useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { useSearchParams } from 'react-router-dom'
 
 type MethodKey = 'oidc' | 'saml'
 
@@ -77,7 +78,7 @@ function CopyField({ label, value }: { label: string; value: string }) {
           aria-label="copy"
         >
           {copied ? (
-            <Check className="h-3.5 w-3.5 text-emerald-500" />
+            <Check className="h-3.5 w-3.5 text-success" />
           ) : (
             <Copy className="h-3.5 w-3.5" />
           )}
@@ -155,7 +156,7 @@ function CallbackUrlField({
           aria-label="copy"
         >
           {copied ? (
-            <Check className="h-3.5 w-3.5 text-emerald-500" />
+            <Check className="h-3.5 w-3.5 text-success" />
           ) : (
             <Copy className="h-3.5 w-3.5" />
           )}

--- a/apps/web/src/components/stat-card.tsx
+++ b/apps/web/src/components/stat-card.tsx
@@ -1,14 +1,14 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Skeleton } from '@/components/ui/skeleton'
 import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 
 interface StatCardProps {
   /** Card title (already translated). */
   title: ReactNode
   /** Icon node, e.g. `<Activity className="h-4 w-4 text-interactive-foreground" />`. */
   icon: ReactNode
-  /** Tailwind classes for the icon tile background, e.g. `bg-emerald-50`. */
+  /** Tailwind classes for the icon tile background, e.g. `bg-success-subtle`. */
   iconTileClass: string
   /** Main metric value. */
   value: ReactNode

--- a/apps/web/src/components/sync-status-badge.tsx
+++ b/apps/web/src/components/sync-status-badge.tsx
@@ -1,10 +1,10 @@
 import { useTranslation } from 'react-i18next'
 
 const syncStatusColors = {
-  synced: 'bg-emerald-500',
-  syncing: 'bg-amber-500 animate-pulse',
-  error: 'bg-red-500',
-  idle: 'bg-gray-400',
+  synced: 'bg-success',
+  syncing: 'bg-warning animate-pulse',
+  error: 'bg-destructive',
+  idle: 'bg-muted-foreground/50',
 } as const
 
 const syncStatusLabelKeys = {

--- a/apps/web/src/components/unsaved-changes-dialog.tsx
+++ b/apps/web/src/components/unsaved-changes-dialog.tsx
@@ -32,7 +32,7 @@ export function UnsavedChangesDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <AlertTriangle className="h-4 w-4 text-amber-500 shrink-0" />
+            <AlertTriangle className="h-4 w-4 text-warning shrink-0" />
             {t('common.unsavedTitle')}
           </DialogTitle>
           <DialogDescription>{t('common.unsavedDesc')}</DialogDescription>

--- a/apps/web/src/components/user-menu.tsx
+++ b/apps/web/src/components/user-menu.tsx
@@ -240,7 +240,7 @@ export function UserMenu({ collapsed = false }: { collapsed?: boolean }) {
           }}
         >
           <ShieldCheck
-            className={`h-3.5 w-3.5 shrink-0 ${user.idaasBound ? 'text-emerald-500' : ''}`}
+            className={`h-3.5 w-3.5 shrink-0 ${user.idaasBound ? 'text-success' : ''}`}
           />
           <span className="flex-1 text-left whitespace-nowrap">
             {user.idaasBound ? t('auth.idaasBound') : t('auth.bindIdaas')}
@@ -451,11 +451,11 @@ function ChangePasswordDialog({
   const PolicyItem = ({ ok, label }: { ok: boolean; label: string }) => (
     <div className="flex items-center gap-1.5 text-xs">
       {ok ? (
-        <Check className="h-3.5 w-3.5 text-emerald-500" />
+        <Check className="h-3.5 w-3.5 text-success" />
       ) : (
         <X className="h-3.5 w-3.5 text-muted-foreground/40" />
       )}
-      <span className={ok ? 'text-emerald-600' : 'text-muted-foreground'}>{label}</span>
+      <span className={ok ? 'text-success' : 'text-muted-foreground'}>{label}</span>
     </div>
   )
 
@@ -515,7 +515,9 @@ function ChangePasswordDialog({
           )}
 
           {error && (
-            <div className="rounded-lg bg-red-50 px-3 py-2.5 text-sm text-red-600">{error}</div>
+            <div className="rounded-lg bg-destructive-subtle px-3 py-2.5 text-sm text-destructive">
+              {error}
+            </div>
           )}
         </div>
 

--- a/apps/web/src/pages/agent-detail/__tests__/chart-theme.test.ts
+++ b/apps/web/src/pages/agent-detail/__tests__/chart-theme.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { SERIES_COLORS } from '../chart-theme'
+
+/**
+ * The token chart stacks Input on Output, so the two fills sit edge to edge. When
+ * both resolved to indigo (`primary` and `interactive-foreground` are one shade
+ * apart — normal-vision OKLab dE 12.3, below the 15 floor) the stack read as a
+ * single band, and a 16x difference between the series was invisible.
+ */
+describe('SERIES_COLORS', () => {
+  it('gives the two stacked token series different colors', () => {
+    expect(SERIES_COLORS.tokenInput).not.toBe(SERIES_COLORS.tokenOutput)
+  })
+
+  it('draws them from the dedicated categorical pair, not from brand/status roles', () => {
+    // `primary` is a brand fill (a bright lime in Neo Yellow, invisible on a light
+    // plot surface) and the status roles are reserved — neither is a series color.
+    for (const key of ['tokenInput', 'tokenOutput'] as const) {
+      expect(SERIES_COLORS[key]).toMatch(/^var\(--color-chart-series-\d\)$/)
+    }
+  })
+})
+
+describe('chart series tokens', () => {
+  // vitest runs with cwd at apps/web; import.meta.url is not a file: URL here.
+  const css = readFileSync(resolve(process.cwd(), 'src/styles/globals.css'), 'utf-8')
+
+  it('defines both slots in every theme block', () => {
+    // One theme missing the pair would fall back to an inherited value and ship a
+    // chart that is only broken under that theme — the exact bug this replaced.
+    const themeBlocks = css.match(/html\[data-theme="[\w-]+"\]\s*\{/g) ?? []
+    const slot1 = css.match(/--color-chart-series-1:/g) ?? []
+    const slot2 = css.match(/--color-chart-series-2:/g) ?? []
+
+    // Every named theme, plus the default :root block.
+    expect(slot1).toHaveLength(themeBlocks.length + 1)
+    expect(slot2).toHaveLength(slot1.length)
+  })
+})

--- a/apps/web/src/pages/agent-detail/__tests__/overview-trends.test.tsx
+++ b/apps/web/src/pages/agent-detail/__tests__/overview-trends.test.tsx
@@ -48,11 +48,21 @@ vi.mock('recharts', () => {
         data-has-dot-renderer={String(typeof dot === 'function')}
       />
     ),
-    Area: ({ dataKey }: { dataKey?: string }) => <div data-testid="area" data-key={dataKey} />,
+    Area: ({ dataKey, stackId }: { dataKey?: string; stackId?: string }) => (
+      <div data-testid="area" data-key={dataKey} data-stack-id={stackId ?? ''} />
+    ),
     CartesianGrid: () => <div data-testid="grid" />,
     XAxis: () => <div data-testid="x-axis" />,
     YAxis: () => <div data-testid="y-axis" />,
-    Tooltip: () => <div data-testid="tooltip" />,
+    // Renders `content` in the active state so tests can assert what the tooltip
+    // actually paints, not just that a Tooltip element exists.
+    Tooltip: ({ content }: { content?: (p: unknown) => ReactNode }) => (
+      <div data-testid="tooltip">
+        {typeof content === 'function'
+          ? content({ active: true, label: '01-01', payload: [] })
+          : null}
+      </div>
+    ),
   }
 })
 
@@ -137,6 +147,32 @@ describe('<OverviewTrends />', () => {
     // the value but computes no bar geometry from it, so the chart silently
     // renders empty <g> wrappers.
     expect(keys).toEqual(['completed', 'failed', 'running', 'queued', 'pending', 'cancelled'])
+  })
+
+  it('plots token input and output unstacked, each measured from zero', () => {
+    mockResult({ data: POPULATED })
+    renderWithProviders(<OverviewTrends agentId="agt_1" />)
+    const areas = screen.getAllByTestId('area')
+    const tokens = areas.filter((el) =>
+      ['tokenInput', 'tokenOutput'].includes(el.getAttribute('data-key') ?? ''),
+    )
+    expect(tokens).toHaveLength(2)
+    // Stacked, output ran a few percent of input and became a 0.5-3px band riding
+    // on the input line: unreadable, and its upper edge read as a second series
+    // shadowing the first. Each line must start from zero.
+    for (const el of tokens) {
+      expect(el.getAttribute('data-stack-id')).toBe('')
+    }
+  })
+
+  it('gives the tooltip an opaque surface', () => {
+    mockResult({ data: POPULATED })
+    renderWithProviders(<OverviewTrends agentId="agt_1" />)
+    // `bg-popover` has no backing token, so it rendered no fill and chart marks
+    // showed through the text. The tooltip sits over the plot and must be opaque.
+    const tooltip = screen.getAllByTestId('tooltip')[0]
+    expect(tooltip.innerHTML).toContain('bg-card')
+    expect(tooltip.innerHTML).not.toContain('bg-popover')
   })
 
   it('flattens nested series onto the row handed to each chart', () => {

--- a/apps/web/src/pages/agent-detail/chart-theme.ts
+++ b/apps/web/src/pages/agent-detail/chart-theme.ts
@@ -53,11 +53,21 @@ export const RUN_STATUS_LABEL_KEYS: Record<RunStatusKey, string> = {
   cancelled: 'dashboard.statusCancelled',
 }
 
-/** Single-series lines. The card title names the metric, so no legend needed. */
+/**
+ * Chart series colors.
+ *
+ * Input/Output use the dedicated categorical pair rather than
+ * `primary` / `interactive-foreground`: those two are one shade apart (normal-vision
+ * OKLab dE 12.3, below the 15 floor), which is why the stacked token areas read as a
+ * single band. Slots are assigned in fixed order and never cycled.
+ *
+ * `duration` keeps `warning` because it is a lone series — no adjacent hue to separate
+ * from — and the amber reads as "time/attention" rather than as a status here.
+ */
 export const SERIES_COLORS = {
-  askers: 'var(--color-primary)',
-  tokenInput: 'var(--color-primary)',
-  tokenOutput: 'var(--color-interactive-foreground)',
+  askers: 'var(--color-chart-series-1)',
+  tokenInput: 'var(--color-chart-series-1)',
+  tokenOutput: 'var(--color-chart-series-2)',
   duration: 'var(--color-warning)',
 } as const
 

--- a/apps/web/src/pages/agent-detail/evaluation/task-detail.tsx
+++ b/apps/web/src/pages/agent-detail/evaluation/task-detail.tsx
@@ -114,7 +114,7 @@ export function TaskDetail({ agentId, taskId, canWrite, onBack }: TaskDetailProp
           <Stat
             label={t('agentEvaluation.task.passed')}
             value={summary?.passed ?? 0}
-            tone={summary?.passed ? 'text-emerald-600' : undefined}
+            tone={summary?.passed ? 'text-success' : undefined}
           />
           <Stat
             label={t('agentEvaluation.task.failed')}
@@ -296,8 +296,8 @@ function ExecutionProgress({
  */
 function passRateTone(rate: number | null): string {
   if (rate == null) return 'text-muted-foreground'
-  if (rate >= 0.9) return 'text-emerald-600'
-  if (rate >= 0.6) return 'text-amber-600'
+  if (rate >= 0.9) return 'text-success'
+  if (rate >= 0.6) return 'text-warning'
   return 'text-destructive'
 }
 
@@ -361,7 +361,7 @@ function SnapshotRow({ label, value }: { label: string; value: string }) {
 type VerdictValue = 'pass' | 'fail' | 'unreviewed'
 
 const VERDICT_DOT_CLASS: Record<VerdictValue, string> = {
-  pass: 'bg-emerald-600',
+  pass: 'bg-success',
   fail: 'bg-destructive',
   unreviewed: 'bg-border',
 }
@@ -481,7 +481,7 @@ function ResultCard({
           >
             <VerdictButton
               active={verdict === 'pass'}
-              activeClass="bg-emerald-50 text-emerald-700"
+              activeClass="bg-success-subtle text-success"
               disabled={review.isPending}
               onClick={() => review.mutate({ resultId: result.id, verdict: 'pass' })}
             >
@@ -491,7 +491,7 @@ function ResultCard({
             <div className="w-px bg-border/60" />
             <VerdictButton
               active={verdict === 'fail'}
-              activeClass="bg-red-50 text-red-700"
+              activeClass="bg-destructive-subtle text-destructive"
               disabled={review.isPending}
               onClick={() => review.mutate({ resultId: result.id, verdict: 'fail' })}
             >

--- a/apps/web/src/pages/agent-detail/evaluation/tasks-tab.tsx
+++ b/apps/web/src/pages/agent-detail/evaluation/tasks-tab.tsx
@@ -191,7 +191,7 @@ function TaskRow({
           </span>
           <TaskStatusBadge status={task.status} />
           {delta && (
-            <span className="inline-flex items-center gap-1 text-xs text-amber-600">
+            <span className="inline-flex items-center gap-1 text-xs text-warning">
               <AlertTriangle className="h-3.5 w-3.5" />
               {t(`agentEvaluation.task.changed.${delta}`)}
             </span>

--- a/apps/web/src/pages/agent-detail/overview-trends.tsx
+++ b/apps/web/src/pages/agent-detail/overview-trends.tsx
@@ -1,13 +1,3 @@
-import { Card, CardContent } from '@/components/ui/card'
-import { Skeleton } from '@/components/ui/skeleton'
-import {
-  type AgentTimeseries,
-  type AgentTimeseriesPoint,
-  type TimeseriesRange,
-  useAgentTimeseries,
-} from '@/hooks/use-runs'
-import { formatTokens, sumTokenUsage } from '@/lib/format-tokens'
-import { formatDuration } from '@/lib/utils'
 import dayjs from 'dayjs'
 import { type ReactNode, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -24,6 +14,16 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
+import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  type AgentTimeseries,
+  type AgentTimeseriesPoint,
+  type TimeseriesRange,
+  useAgentTimeseries,
+} from '@/hooks/use-runs'
+import { formatTokens, sumTokenUsage } from '@/lib/format-tokens'
+import { formatDuration } from '@/lib/utils'
 import {
   ACTIVE_DOT_PROPS,
   AXIS_PROPS,
@@ -145,11 +145,15 @@ function TrendCard({
   title,
   total,
   hint,
+  legend,
   children,
 }: {
   title: ReactNode
   total: string
   hint?: string
+  /** `[label, color]` per series. Required for multi-series charts, where the
+      tooltip alone leaves identity carried by color until the user hovers. */
+  legend?: ReadonlyArray<readonly [string, string]>
   children: ReactNode
 }) {
   return (
@@ -160,6 +164,20 @@ function TrendCard({
           {total}
         </div>
         {hint && <p className="mt-1 text-xs text-muted-foreground">{hint}</p>}
+        {legend && (
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1">
+            {legend.map(([label, color]) => (
+              <span key={label} className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <span
+                  className="size-2 shrink-0 rounded-[2px]"
+                  style={{ backgroundColor: color }}
+                  aria-hidden="true"
+                />
+                {label}
+              </span>
+            ))}
+          </div>
+        )}
         {/* ResponsiveContainer measures its parent, so the height must be
             explicit — inside a grid child it would otherwise collapse to 0. */}
         <div className="mt-4 h-[200px] w-full">{children}</div>
@@ -312,6 +330,10 @@ export function OverviewTrends({ agentId }: { agentId: string | undefined }) {
           <TrendCard
             title={t('agentOverview.chartTokensTitle')}
             total={formatTokens(totals.tokens)}
+            legend={[
+              [t('agentOverview.tokenInput'), SERIES_COLORS.tokenInput],
+              [t('agentOverview.tokenOutput'), SERIES_COLORS.tokenOutput],
+            ]}
           >
             {isLoading ? (
               <Skeleton className="h-full w-full" />
@@ -347,6 +369,11 @@ export function OverviewTrends({ agentId }: { agentId: string | undefined }) {
                       />
                     )}
                   />
+                  {/* Stacked: input + output are parts of the total in the card
+                      header, so the upper edge is the whole. The two fills need
+                      distinguishable hues *and* a surface-colored seam — output is
+                      routinely ~1% of input, so without the seam the thin band
+                      collapses into the boundary and the chart reads as one series. */}
                   <Area
                     dataKey="tokenInput"
                     stackId="tokens"
@@ -360,7 +387,7 @@ export function OverviewTrends({ agentId }: { agentId: string | undefined }) {
                     stackId="tokens"
                     stroke={SERIES_COLORS.tokenOutput}
                     fill={SERIES_COLORS.tokenOutput}
-                    fillOpacity={0.18}
+                    fillOpacity={0.28}
                     strokeWidth={2}
                   />
                 </AreaChart>

--- a/apps/web/src/pages/agent-detail/overview-trends.tsx
+++ b/apps/web/src/pages/agent-detail/overview-trends.tsx
@@ -64,7 +64,10 @@ function TrendTooltip({
 }) {
   if (!active) return null
   return (
-    <div className="rounded-md border border-border bg-popover px-3 py-2 shadow-md">
+    // `bg-card`, not `bg-popover`: no `--color-popover` token exists, so that class
+    // was inert and the tooltip had no fill at all — chart marks showed straight
+    // through the text. A tooltip sits over the plot and must be opaque.
+    <div className="rounded-md border border-border bg-card px-3 py-2 shadow-md">
       <div className="mb-1 text-xs font-medium text-foreground">{label}</div>
       <ul className="space-y-0.5">
         {rows.map(([name, value, color]) => (
@@ -369,25 +372,24 @@ export function OverviewTrends({ agentId }: { agentId: string | undefined }) {
                       />
                     )}
                   />
-                  {/* Stacked: input + output are parts of the total in the card
-                      header, so the upper edge is the whole. The two fills need
-                      distinguishable hues *and* a surface-colored seam — output is
-                      routinely ~1% of input, so without the seam the thin band
-                      collapses into the boundary and the chart reads as one series. */}
+                  {/* Deliberately NOT stacked. Output runs a few percent of input, so
+                      stacked it became a band 0.5-3px tall riding on the input line —
+                      unreadable on its own, and its upper edge looked like a second
+                      series shadowing the first. Unstacked, each line is measured from
+                      zero, which is also what the tooltip's two numbers imply. The card
+                      header still carries the combined total. */}
                   <Area
                     dataKey="tokenInput"
-                    stackId="tokens"
                     stroke={SERIES_COLORS.tokenInput}
                     fill={SERIES_COLORS.tokenInput}
-                    fillOpacity={0.18}
+                    fillOpacity={0.16}
                     strokeWidth={2}
                   />
                   <Area
                     dataKey="tokenOutput"
-                    stackId="tokens"
                     stroke={SERIES_COLORS.tokenOutput}
                     fill={SERIES_COLORS.tokenOutput}
-                    fillOpacity={0.28}
+                    fillOpacity={0.16}
                     strokeWidth={2}
                   />
                 </AreaChart>

--- a/apps/web/src/pages/agent-detail/publish/schedule-channel-section.tsx
+++ b/apps/web/src/pages/agent-detail/publish/schedule-channel-section.tsx
@@ -405,12 +405,12 @@ export function ScheduleChannelSection({
           />
         </div>
         {!identityBound && (
-          <p className="text-xs text-amber-600">
+          <p className="text-xs text-warning">
             {t('agentPublish.scheduleRunAsOwnerNeedBind')}{' '}
             {bindMethod && (
               <button
                 type="button"
-                className="underline hover:text-amber-700"
+                className="underline hover:text-warning"
                 onClick={() =>
                   startSsoMethod(
                     bindMethod,

--- a/apps/web/src/pages/agent-detail/runs-tab.tsx
+++ b/apps/web/src/pages/agent-detail/runs-tab.tsx
@@ -1,3 +1,9 @@
+import type { RunStatus, RunTriggerSource } from '@a2wave/shared'
+import { Activity, CheckCircle2, Circle, Loader2, XCircle } from 'lucide-react'
+import type React from 'react'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
 import { RunCallerPrefix } from '@/components/run-caller-prefix'
 import { RunDetailDrawer } from '@/components/run-detail-drawer'
 import { Badge } from '@/components/ui/badge'
@@ -6,12 +12,6 @@ import { Pagination } from '@/components/ui/pagination'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useRuns } from '@/hooks/use-runs'
 import { formatRelativeTime } from '@/lib/utils'
-import type { RunStatus, RunTriggerSource } from '@a2wave/shared'
-import { Activity, CheckCircle2, Circle, Loader2, XCircle } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import type React from 'react'
-import { useTranslation } from 'react-i18next'
-import { useSearchParams } from 'react-router-dom'
 
 const STATUS_BADGE: Record<
   RunStatus,
@@ -28,11 +28,11 @@ const STATUS_BADGE: Record<
 function RunStatusIcon({ status }: { status: RunStatus }) {
   switch (status) {
     case 'running':
-      return <Loader2 className="h-4 w-4 text-amber-500 animate-spin shrink-0" aria-hidden="true" />
+      return <Loader2 className="h-4 w-4 text-warning animate-spin shrink-0" aria-hidden="true" />
     case 'completed':
-      return <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" aria-hidden="true" />
+      return <CheckCircle2 className="h-4 w-4 text-success shrink-0" aria-hidden="true" />
     case 'failed':
-      return <XCircle className="h-4 w-4 text-red-500 shrink-0" aria-hidden="true" />
+      return <XCircle className="h-4 w-4 text-destructive shrink-0" aria-hidden="true" />
     default:
       return <Circle className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
   }

--- a/apps/web/src/pages/agent-detail/test-drawer.tsx
+++ b/apps/web/src/pages/agent-detail/test-drawer.tsx
@@ -1,3 +1,7 @@
+import { Drawer } from 'antd'
+import { AlertCircle, MessageSquare, Plus, ScrollText, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ChatComposer } from '@/components/chat/chat-composer'
 import { ChatMessageList } from '@/components/chat/chat-message-list'
 import { InlineArtifactList } from '@/components/chat/inline-artifact-list'
@@ -5,10 +9,6 @@ import { RunLogContent } from '@/components/run-log-content'
 import { Button } from '@/components/ui/button'
 import { useAgentChat } from '@/hooks/use-agent-chat'
 import { cn } from '@/lib/utils'
-import { Drawer } from 'antd'
-import { AlertCircle, MessageSquare, Plus, ScrollText, X } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { useTranslation } from 'react-i18next'
 
 interface TestDrawerProps {
   open: boolean
@@ -157,13 +157,10 @@ export function TestDrawer({ open, onClose, agentId, agentStatus, agentIcon }: T
           )}
 
           {chatDisabledReason && (
-            <div className="px-4 py-3 border-b border-border bg-amber-50">
+            <div className="px-4 py-3 border-b border-border bg-warning-subtle">
               <div className="flex items-start gap-2">
-                <AlertCircle
-                  className="h-4 w-4 text-amber-600 shrink-0 mt-0.5"
-                  aria-hidden="true"
-                />
-                <p className="text-xs text-amber-700">{chatDisabledReason}</p>
+                <AlertCircle className="h-4 w-4 text-warning shrink-0 mt-0.5" aria-hidden="true" />
+                <p className="text-xs text-warning">{chatDisabledReason}</p>
               </div>
             </div>
           )}

--- a/apps/web/src/pages/chat-app.tsx
+++ b/apps/web/src/pages/chat-app.tsx
@@ -10,6 +10,10 @@
  * Layout: agent profile on the left, conversation on the right; the profile
  * collapses into a header strip on narrow screens.
  */
+
+import { AlertCircle, ArrowLeft, MessageSquare, Plus, Sparkles, UserRound } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Link, useParams } from 'react-router-dom'
 import { ChatComposer } from '@/components/chat/chat-composer'
 import { ChatMessageList } from '@/components/chat/chat-message-list'
 import { InlineArtifactList } from '@/components/chat/inline-artifact-list'
@@ -19,9 +23,6 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { useAgentChat } from '@/hooks/use-agent-chat'
 import { useChatAppProfile } from '@/hooks/use-chat-app'
 import { cn } from '@/lib/utils'
-import { AlertCircle, ArrowLeft, MessageSquare, Plus, Sparkles, UserRound } from 'lucide-react'
-import { useTranslation } from 'react-i18next'
-import { Link, useParams } from 'react-router-dom'
 
 export function ChatAppPage() {
   const { t } = useTranslation()
@@ -138,9 +139,9 @@ export function ChatAppPage() {
       {/* ── Conversation ──────────────────────────────────────────────── */}
       <main className="flex min-h-0 min-w-0 flex-1 flex-col">
         {disabledReason && (
-          <div className="flex items-start gap-2 border-b border-border bg-amber-50 px-4 py-3">
-            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" aria-hidden="true" />
-            <p className="text-xs text-amber-700">{disabledReason}</p>
+          <div className="flex items-start gap-2 border-b border-border bg-warning-subtle px-4 py-3">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-warning" aria-hidden="true" />
+            <p className="text-xs text-warning">{disabledReason}</p>
           </div>
         )}
 
@@ -209,13 +210,13 @@ function StatusBadge({ status, isStopped }: { status: string; isStopped: boolean
     <span
       className={cn(
         'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium',
-        online ? 'bg-emerald-50 text-emerald-700' : 'bg-muted text-muted-foreground',
+        online ? 'bg-success-subtle text-success' : 'bg-muted text-muted-foreground',
       )}
     >
       <span
         className={cn(
           'size-1.5 rounded-full',
-          online ? 'bg-emerald-500 animate-pulse' : 'bg-muted-foreground/50',
+          online ? 'bg-success animate-pulse' : 'bg-muted-foreground/50',
         )}
         aria-hidden="true"
       />

--- a/apps/web/src/pages/invite.tsx
+++ b/apps/web/src/pages/invite.tsx
@@ -116,11 +116,11 @@ export function InvitePage() {
   const PolicyItem = ({ ok, label }: { ok: boolean; label: string }) => (
     <div className="flex items-center gap-1.5 text-xs">
       {ok ? (
-        <Check className="h-3.5 w-3.5 text-emerald-500" />
+        <Check className="h-3.5 w-3.5 text-success" />
       ) : (
         <X className="h-3.5 w-3.5 text-muted-foreground/40" />
       )}
-      <span className={ok ? 'text-emerald-600' : 'text-muted-foreground'}>{label}</span>
+      <span className={ok ? 'text-success' : 'text-muted-foreground'}>{label}</span>
     </div>
   )
 
@@ -291,7 +291,7 @@ export function InvitePage() {
                 )}
 
                 {error && (
-                  <div className="rounded-lg bg-red-50 px-3 py-2.5 text-sm text-red-600 sm:col-span-2">
+                  <div className="rounded-lg bg-destructive-subtle px-3 py-2.5 text-sm text-destructive sm:col-span-2">
                     {error}
                   </div>
                 )}

--- a/apps/web/src/pages/providers.tsx
+++ b/apps/web/src/pages/providers.tsx
@@ -1,18 +1,18 @@
+import { AlertTriangle, Blocks } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
 import {
+  needsInstallAction,
   ProviderCliInstallControl,
   ProviderCliStatusChip,
-  needsInstallAction,
 } from '@/components/provider-cli-install-control'
-import { PROVIDER_ICON_TILE, getProviderIconSpec } from '@/components/provider-icon'
+import { getProviderIconSpec, PROVIDER_ICON_TILE } from '@/components/provider-icon'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useCurrentUser } from '@/hooks/use-auth'
 import { useProviderClis } from '@/hooks/use-provider-clis'
 import { useProviders, useUnsupportedProviders } from '@/hooks/use-providers'
-import { AlertTriangle, Blocks } from 'lucide-react'
-import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
 
 /**
  * Base chip shape — reused from the former "Preset" tag for visual consistency.
@@ -105,10 +105,10 @@ export function ProvidersPage() {
       {unsupportedProviders && unsupportedProviders.length > 0 ? (
         <div
           role="alert"
-          className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm"
+          className="rounded-xl border border-warning/30 bg-warning-subtle p-4 text-sm"
         >
           <div className="flex items-start gap-3">
-            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600" aria-hidden="true" />
+            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-warning" aria-hidden="true" />
             <div className="min-w-0">
               <p className="font-medium text-foreground">{t('providers.unsupportedTitle')}</p>
               <p className="mt-1 text-muted-foreground">{t('providers.unsupportedDescription')}</p>

--- a/apps/web/src/pages/scm-sources.tsx
+++ b/apps/web/src/pages/scm-sources.tsx
@@ -1,3 +1,7 @@
+import type { ScmSource } from '@a2wave/shared'
+import { AlertCircle, Clock, FolderGit2, GitBranch, Loader2, Plus, RefreshCw } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ScmSourceFormModal } from '@/components/scm/scm-source-form-modal'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -11,10 +15,6 @@ import { useUrlRecord } from '@/hooks/use-url-state'
 import { message } from '@/lib/antd-static'
 import { formatApiError } from '@/lib/api-error'
 import { cn } from '@/lib/utils'
-import type { ScmSource } from '@a2wave/shared'
-import { AlertCircle, Clock, FolderGit2, GitBranch, Loader2, Plus, RefreshCw } from 'lucide-react'
-import { useState } from 'react'
-import { useTranslation } from 'react-i18next'
 
 /** 将时间格式化为相对时间（如 "3 分钟前"） */
 function formatRelativeTime(
@@ -160,7 +160,7 @@ export function ScmSourcesPage() {
                           className={cn(
                             'mt-0.5 inline-flex w-fit items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] font-medium',
                             source.type === 'git'
-                              ? 'border-orange-200/80 bg-orange-50 text-orange-700'
+                              ? 'border-warning/30 bg-warning-subtle text-warning'
                               : 'border-blue-200/80 bg-blue-50 text-blue-700',
                           )}
                         >

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -1087,7 +1087,7 @@ export function SettingsPage() {
                       />
                     )}
                     {testWebhook.isSuccess && testWebhook.data.data.ok && (
-                      <Check className="h-3.5 w-3.5 text-green-500" aria-hidden="true" />
+                      <Check className="h-3.5 w-3.5 text-success" aria-hidden="true" />
                     )}
                     {(testWebhook.isError ||
                       (testWebhook.isSuccess && !testWebhook.data.data.ok)) && (
@@ -1096,7 +1096,7 @@ export function SettingsPage() {
                     <span
                       className={
                         testWebhook.isSuccess && testWebhook.data.data.ok
-                          ? 'text-green-500'
+                          ? 'text-success'
                           : testWebhook.isError ||
                               (testWebhook.isSuccess && !testWebhook.data.data.ok)
                             ? 'text-destructive'

--- a/apps/web/src/pages/setup.tsx
+++ b/apps/web/src/pages/setup.tsx
@@ -1,12 +1,12 @@
-import { BrandMarkFallback } from '@/components/brand-mark'
-import { Button } from '@/components/ui/button'
-import { useAuthStatus, useSetup } from '@/hooks/use-auth'
-import { formatApiError } from '@/lib/api-error'
 import { Input } from 'antd'
 import { Check, Loader2, X } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Navigate, useNavigate } from 'react-router-dom'
+import { BrandMarkFallback } from '@/components/brand-mark'
+import { Button } from '@/components/ui/button'
+import { useAuthStatus, useSetup } from '@/hooks/use-auth'
+import { formatApiError } from '@/lib/api-error'
 
 function checkPolicy(password: string) {
   return {
@@ -53,11 +53,11 @@ export function SetupPage() {
   const PolicyItem = ({ ok, label }: { ok: boolean; label: string }) => (
     <div className="flex items-center gap-1.5 text-xs">
       {ok ? (
-        <Check className="h-3.5 w-3.5 text-emerald-500" />
+        <Check className="h-3.5 w-3.5 text-success" />
       ) : (
         <X className="h-3.5 w-3.5 text-muted-foreground/40" />
       )}
-      <span className={ok ? 'text-emerald-600' : 'text-muted-foreground'}>{label}</span>
+      <span className={ok ? 'text-success' : 'text-muted-foreground'}>{label}</span>
     </div>
   )
 
@@ -154,7 +154,9 @@ export function SetupPage() {
             )}
 
             {error && (
-              <div className="rounded-lg bg-red-50 px-3 py-2.5 text-sm text-red-600">{error}</div>
+              <div className="rounded-lg bg-destructive-subtle px-3 py-2.5 text-sm text-destructive">
+                {error}
+              </div>
             )}
 
             <div className="pt-1">

--- a/apps/web/src/pages/users.tsx
+++ b/apps/web/src/pages/users.tsx
@@ -693,7 +693,9 @@ function InviteUserDialog({
             </div>
 
             {error && (
-              <div className="rounded-lg bg-red-50 px-3 py-2.5 text-sm text-red-600">{error}</div>
+              <div className="rounded-lg bg-destructive-subtle px-3 py-2.5 text-sm text-destructive">
+                {error}
+              </div>
             )}
           </div>
         )}
@@ -789,11 +791,11 @@ function ResetPasswordDialog({
   const PolicyItem = ({ ok, label }: { ok: boolean; label: string }) => (
     <div className="flex items-center gap-1.5 text-xs">
       {ok ? (
-        <Check className="h-3.5 w-3.5 text-emerald-500" />
+        <Check className="h-3.5 w-3.5 text-success" />
       ) : (
         <X className="h-3.5 w-3.5 text-muted-foreground/40" />
       )}
-      <span className={ok ? 'text-emerald-600' : 'text-muted-foreground'}>{label}</span>
+      <span className={ok ? 'text-success' : 'text-muted-foreground'}>{label}</span>
     </div>
   )
 
@@ -833,7 +835,9 @@ function ResetPasswordDialog({
           )}
 
           {error && (
-            <div className="rounded-lg bg-red-50 px-3 py-2.5 text-sm text-red-600">{error}</div>
+            <div className="rounded-lg bg-destructive-subtle px-3 py-2.5 text-sm text-destructive">
+              {error}
+            </div>
           )}
         </div>
 

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -67,6 +67,12 @@
   --color-red-700: #b91c1c;
 
   --color-primary: #6264ee; /* AA with white primary foreground */
+  /* Chart series — a validated categorical pair, NOT `primary`/`interactive-foreground`.
+     Those two are a shade apart (normal-vision OKLab dE 12.3, under the 15 floor), and in
+     Neo Yellow `primary` is a lime that disappears against a light plot surface. Slots are
+     assigned in fixed order and never cycled. */
+  --color-chart-series-1: #4f46e5;
+  --color-chart-series-2: #eb6834;
   --color-primary-hover: #4f46e5; /* indigo-600 — hover/press for primary surfaces */
   --color-primary-active: #4338ca; /* indigo-700 — pressed */
   --color-primary-foreground: #ffffff;
@@ -284,6 +290,12 @@ html[data-theme="wave-dark"] {
   --color-input: #3a414d;
   --color-ring: #a5b4fc;
   --color-primary: #818cf8;
+  /* Chart series — a validated categorical pair, NOT `primary`/`interactive-foreground`.
+     Those two are a shade apart (normal-vision OKLab dE 12.3, under the 15 floor), and in
+     Neo Yellow `primary` is a lime that disappears against a light plot surface. Slots are
+     assigned in fixed order and never cycled. */
+  --color-chart-series-1: #7c83e8;
+  --color-chart-series-2: #d9743f;
   --color-primary-hover: #a5b4fc;
   --color-primary-active: #6366f1;
   --color-primary-foreground: #101116;
@@ -348,6 +360,12 @@ html[data-theme="neo-yellow"] {
   --color-input: #171717;
   --color-ring: #171717;
   --color-primary: #ddf52f;
+  /* Chart series — a validated categorical pair, NOT `primary`/`interactive-foreground`.
+     Those two are a shade apart (normal-vision OKLab dE 12.3, under the 15 floor), and in
+     Neo Yellow `primary` is a lime that disappears against a light plot surface. Slots are
+     assigned in fixed order and never cycled. */
+  --color-chart-series-1: #4f46e5;
+  --color-chart-series-2: #eb6834;
   --color-primary-hover: #cde71e;
   --color-primary-active: #bdd70f;
   --color-primary-foreground: #121212;
@@ -411,6 +429,12 @@ html[data-theme="midnight"] {
   --color-input: #334867;
   --color-ring: #67d9ff;
   --color-primary: #55d6ff;
+  /* Chart series — a validated categorical pair, NOT `primary`/`interactive-foreground`.
+     Those two are a shade apart (normal-vision OKLab dE 12.3, under the 15 floor), and in
+     Neo Yellow `primary` is a lime that disappears against a light plot surface. Slots are
+     assigned in fixed order and never cycled. */
+  --color-chart-series-1: #7c83e8;
+  --color-chart-series-2: #d9743f;
   --color-primary-hover: #83e3ff;
   --color-primary-active: #2abce9;
   --color-primary-foreground: #06111a;
@@ -465,6 +489,12 @@ html[data-theme="forest"] {
   --color-input: #405043;
   --color-ring: #bef264;
   --color-primary: #a3e635;
+  /* Chart series — a validated categorical pair, NOT `primary`/`interactive-foreground`.
+     Those two are a shade apart (normal-vision OKLab dE 12.3, under the 15 floor), and in
+     Neo Yellow `primary` is a lime that disappears against a light plot surface. Slots are
+     assigned in fixed order and never cycled. */
+  --color-chart-series-1: #7c83e8;
+  --color-chart-series-2: #d9743f;
   --color-primary-hover: #bef264;
   --color-primary-active: #84cc16;
   --color-primary-foreground: #102006;
@@ -519,6 +549,12 @@ html[data-theme="graphite"] {
   --color-input: #444444;
   --color-ring: #ffda7c;
   --color-primary: #f4c95d;
+  /* Chart series — a validated categorical pair, NOT `primary`/`interactive-foreground`.
+     Those two are a shade apart (normal-vision OKLab dE 12.3, under the 15 floor), and in
+     Neo Yellow `primary` is a lime that disappears against a light plot surface. Slots are
+     assigned in fixed order and never cycled. */
+  --color-chart-series-1: #7c83e8;
+  --color-chart-series-2: #d9743f;
   --color-primary-hover: #ffda7c;
   --color-primary-active: #dcae3d;
   --color-primary-foreground: #1b1304;

--- a/docs/agent/design-tokens.md
+++ b/docs/agent/design-tokens.md
@@ -132,6 +132,35 @@ text.
 
 Reference implementations: `device.tsx` (warning panel), `cli-tokens-card.tsx` (one-time secret
 stated as a plain description), `agent-detail/publish/api-key-list.tsx` (both, side by side).
+## Chart series colors
+
+Charts draw their series from `--color-chart-series-N`, assigned **in fixed order and
+never cycled**. Do not reach for `primary`, `interactive-foreground`, or a status token:
+
+- `primary` is a brand **fill**, not a plottable hue. In Neo Yellow it is a bright lime
+  (OKLCH L 0.92) that disappears against a light plot surface.
+- `primary` and `interactive-foreground` are one shade apart — normal-vision OKLab
+  ΔE 12.3, below the 15 floor. Two series painted with them read as **one** series, which
+  is exactly how a stacked chart hid a 16× difference between its two measures.
+- Status tokens are reserved for good/warning/serious/critical and must not become
+  "series 3". (A *lone* series may use one where the hue carries meaning — the duration
+  chart's amber — since there is no adjacent hue to separate from.)
+
+**Validate a categorical pair; do not eyeball it.** The `dataviz` skill ships
+`scripts/validate_palette.js`, which checks the lightness band (light `0.43–0.77`, dark
+`0.48–0.67`), a chroma floor, colorblind separation, the normal-vision ΔE ≥ 15 floor, and
+contrast against the surface:
+
+```
+node scripts/validate_palette.js "#4f46e5,#eb6834" --mode light
+```
+
+Every theme must define the full slot set. A theme missing one inherits a value and ships
+a chart that is broken **only under that theme** — covered by a test in
+`agent-detail/__tests__/chart-theme.test.ts`.
+
+For **≥ 2 series a legend is always present**, so identity is never carried by color alone
+until the user hovers.
 
 ## Hover and selected states
 

--- a/docs/agent/design-tokens.md
+++ b/docs/agent/design-tokens.md
@@ -162,6 +162,14 @@ a chart that is broken **only under that theme** — covered by a test in
 For **≥ 2 series a legend is always present**, so identity is never carried by color alone
 until the user hovers.
 
+**Stack only for part-to-whole, and only when the parts are comparable in size.** Area
+charts are for a *single* series; two series that must be told apart are lines/areas
+measured from zero. The token chart stacked Input and Output until output — a few percent
+of input — became a 0.5–3px band riding on the input line: unreadable on its own, and its
+upper edge read as a second series shadowing the first. A combined total belongs in the
+card header, not in the geometry. Run status counts stay stacked because they genuinely
+partition one whole into comparable parts.
+
 ## Hover and selected states
 
 Interactive surfaces — list rows, tabs, ghost/outline buttons — use two dedicated tokens:


### PR DESCRIPTION
Three related fixes, all in service of "the color on screen should mean something and be readable in every theme."

---

## 1. Status colors → semantic tokens

Status surfaces were styled with fixed Tailwind palette literals — `bg-red-50`, `text-amber-600`, `bg-emerald-500`. Those are hard-coded hex values that **do not participate in theming**, so a notice styled that way keeps its light-mode colors under all six themes. In the dark themes that means red-600 text on a red-50 fill: present in the DOM, occupying space, unreadable.

All **51 occurrences** swapped to the `destructive` / `success` / `warning` trio, plus the one leftover `bg-gray-400` idle dot.

**Light themes are unchanged by construction** — the token definitions record that `destructive-subtle` *is* red-50, `success-subtle` *is* emerald-50, `warning-subtle` *is* amber-50. Invisible on the default theme; a real fix on every other one.

`provider-icon.tsx` keeps its palette values — brand tiles are the documented exception, preserving official glyph contrast rather than expressing a status.

## 2. The Token chart's two series were indistinguishable

`tokenInput` used `--color-primary`, `tokenOutput` used `--color-interactive-foreground` — two indigos one shade apart. Run through the dataviz validator:

```
[FAIL] Normal-vision floor  #4338ca ↔ #6264ee  ΔE 12.3 — below the 15 floor
```

A hard fail: too close even for full color vision.

Added `--color-chart-series-1/2`, defined per theme and validated in both modes (light ΔE 39.2, dark 25.6). This also fixes a latent bug — `primary` in Neo Yellow is a bright lime (OKLCH L 0.92) that disappears against a light plot surface, so that theme had been shipping an invisible series.

Also added the legend a multi-series chart needs; with only a tooltip, identity was carried by color alone until hover.

## 3. The chart was stacked, which hid the very difference it should show

Even with distinct colors it still read as two overlapping lines. The second line wasn't output at all — it was **input + output**. At 5.2M input / 369K output the lines sat ~12px apart; on a quiet day the band between them was **0.5px**.

Stacking was the wrong form: an area chart is for a *single* series, and two series that must be told apart are measured from zero. Unstacked, the distance between the lines is the real magnitude difference instead of an artifact of the geometry. The combined total stays in the card header, where a whole belongs.

**Deliberately not a second y-axis.** Two scales would let the series be slid until they appear to track each other — the exact false relationship the stacked version was already implying. It's also the top entry in the dataviz anti-patterns.

Run status counts stay stacked: those genuinely partition one whole into comparable parts.

**Bonus:** the tooltip asked for `bg-popover`, but no `--color-popover` token exists — the class was inert, so the tooltip had *no fill* and chart marks showed through the text. Switched to `bg-card`, the surface token Card/Button/Command already use. It was the only use of `bg-popover` in the codebase.

---

## Tests

Four regression tests, each verified to fail when the fix is reverted (not just to pass today):

- the two token series never resolve to the same color
- every theme block defines the full chart-slot set — one missing would ship a chart broken *only* under that theme
- token areas are unstacked
- the tooltip has an opaque surface

## Docs

`design-tokens.md` gains a **Chart series colors** section: series tokens are assigned in fixed order and never cycled; `primary` / `interactive-foreground` / status tokens are not series colors; validate a pair with the script rather than eyeballing; stack only for part-to-whole with comparable parts; ≥2 series always get a legend.

## Gates

`pnpm lint` 0 errors (752 warnings — the `main` baseline, measured by stashing) · `pnpm typecheck` green · `pnpm test` **9008 passed, 0 failed**.

Verified running on a live deployment alongside #74 (combined state: 9070 tests green).

## Note for whoever merges second

This and #74 both add a section to `docs/agent/design-tokens.md` at the same anchor, so the second to merge gets one trivial conflict there. The sections don't overlap (status colors/notices vs. chart series colors) — keep both.
