### PR TITLE
fix(artifacts): give each run its own artifacts directory

### DIFF
--- a/apps/api/src/__tests__/e2e/worktree-e2e.test.ts
+++ b/apps/api/src/__tests__/e2e/worktree-e2e.test.ts
@@ -40,6 +40,7 @@ vi.mock('../../lib/webhook-notifier.js', () => ({
 
 vi.mock('../../lib/artifact-storage.js', () => ({
   scanAndRegisterArtifacts: vi.fn().mockResolvedValue([]),
+  discardRunArtifactsDir: vi.fn(),
 }))
 
 // ============================================================

--- a/apps/api/src/engine/__tests__/runtime-context.test.ts
+++ b/apps/api/src/engine/__tests__/runtime-context.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -42,7 +42,7 @@ describe('runtime-context', () => {
       type: 'temp',
       cleanup: 'ttl',
     })
-    expect(ctx.artifacts.dir).toBe(join(resolve('/workspace'), 'artifacts'))
+    expect(ctx.artifacts.dir).toBe(join(resolve('/workspace'), 'artifacts', 'run_123'))
     expect(ctx.env).toMatchObject({
       HOME: ctx.home.dir,
       A2WAVE_AGENT_HOME: ctx.home.dir,
@@ -109,9 +109,53 @@ describe('runtime-context', () => {
     )
 
     expect(ctx.workspace.dir).toBe(resolve('/engine/default-workdir'))
-    expect(ctx.artifacts.dir).toBe(join(resolve('/engine/default-workdir'), 'artifacts'))
+    expect(ctx.artifacts.dir).toBe(join(resolve('/engine/default-workdir'), 'artifacts', 'run_123'))
     expect(ctx.env.A2WAVE_WORKSPACE_DIR).toBe(resolve('/engine/default-workdir'))
-    expect(ctx.env.A2WAVE_ARTIFACTS_DIR).toBe(join(resolve('/engine/default-workdir'), 'artifacts'))
+    expect(ctx.env.A2WAVE_ARTIFACTS_DIR).toBe(
+      join(resolve('/engine/default-workdir'), 'artifacts', 'run_123'),
+    )
+  })
+
+  it('creates the per-run artifacts directory so the Agent can write into it at once', async () => {
+    // The directory is removed when the run settles, so unlike the old flat
+    // artifacts/ on a warm workspace it never pre-exists: `cp x "$A2WAVE_ARTIFACTS_DIR/"`
+    // would fail on every run unless the platform creates it.
+    const workDir = mkdtempSync(join(tmpdir(), 'a2wave-workspace-'))
+    try {
+      const ctx = prepareRuntimeContext({ ...makeReq('agt_mkdir'), workDir })
+
+      expect(ctx.artifacts.dir).toBe(join(workDir, 'artifacts', 'run_123'))
+      expect(existsSync(ctx.artifacts.dir)).toBe(true)
+    } finally {
+      rmSync(workDir, { recursive: true, force: true })
+    }
+  })
+
+  it('still prepares the context when the artifacts directory cannot be created', async () => {
+    // A read-only or otherwise unwritable workspace must not fail the run here;
+    // the engine and the collector cope with a missing directory on their own.
+    // A path through a plain file fails with ENOTDIR as any user on any OS.
+    const parent = mkdtempSync(join(tmpdir(), 'a2wave-workspace-'))
+    const blocker = join(parent, 'not-a-dir')
+    writeFileSync(blocker, '')
+    try {
+      const workDir = join(blocker, 'workspace')
+      const ctx = prepareRuntimeContext({ ...makeReq('agt_ro'), workDir })
+
+      expect(ctx.artifacts.dir).toBe(join(workDir, 'artifacts', 'run_123'))
+      expect(existsSync(ctx.artifacts.dir)).toBe(false)
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps the artifacts directory one flat segment when the taskId carries no run id', async () => {
+    // extractRunId falls back to the whole taskId, which contains separators.
+    // Interpolated raw it would nest the run's artifacts under invented
+    // directories — and `..` would escape the workspace entirely.
+    const ctx = prepareRuntimeContext(makeReq('agt_odd_task', '../evil/task'))
+
+    expect(ctx.artifacts.dir).toBe(join(resolve('/workspace'), 'artifacts', '___evil_task'))
   })
 
   it('fails fast when neither request workDir nor defaultWorkDir is available', async () => {

--- a/apps/api/src/engine/base-engine.ts
+++ b/apps/api/src/engine/base-engine.ts
@@ -30,9 +30,9 @@ import {
 } from './mcp-sync.js'
 import { isModelError, selectFallbackModel } from './model-fallback.js'
 import { assembleSystemPrompt, buildPromptParts } from './prompt-builder.js'
-import { prepareRuntimeContext } from './runtime-context.js'
+import { artifactsDirForTask, prepareRuntimeContext } from './runtime-context.js'
 import { type SkillFile, syncSkillsToWorkspaceAsync } from './skill-sync.js'
-import { type TemplateContext, engineTypeToAgentProviderLabel } from './template-renderer.js'
+import { engineTypeToAgentProviderLabel, type TemplateContext } from './template-renderer.js'
 import type { AgentEngine, ExecuteRequest, ExecuteResult, StreamExecuteRequest } from './types.js'
 import { accumulateUsage, extractUsageFromError } from './usage.js'
 
@@ -246,7 +246,7 @@ export abstract class BaseAgentEngine implements AgentEngine {
     if (request.runtimeContext?.artifacts.dir) {
       parts.artifactsDir = request.runtimeContext.artifacts.dir
     } else if (request.workDir) {
-      parts.artifactsDir = join(request.workDir, 'artifacts')
+      parts.artifactsDir = artifactsDirForTask(request.workDir, taskId)
     }
     const cfg = (agentConfig ?? {}) as Record<string, unknown>
     if (cfg.memoryEnabled && (cfg.memoryContextMode as string) !== 'off') {

--- a/apps/api/src/engine/runtime-context.ts
+++ b/apps/api/src/engine/runtime-context.ts
@@ -1,5 +1,6 @@
 import { mkdirSync } from 'node:fs'
 import { join, resolve } from 'node:path'
+import { logger } from '../lib/logger.js'
 import type {
   AgentRuntimeContext,
   ExecuteRequest,
@@ -178,6 +179,33 @@ export function extractRunId(taskId: string): string {
   return taskId.match(/(?:^|\/)(run_[^/]+)/)?.[1] ?? taskId
 }
 
+/**
+ * Where a single execution drops the files it wants collected.
+ *
+ * Deliberately a per-execution directory *under* the workspace's `artifacts/`,
+ * not `artifacts/` itself: a workspace is shared. Runs of one Agent share their
+ * per-Agent worktree by design (resolvePerAgentWorkspace does not serialise
+ * them), and on a shared SCM checkout every Agent bound to the source shares
+ * it too. One flat drop-box therefore holds files from several live runs at
+ * once with nothing to say whose is whose — the collector used to guess from
+ * mtime, and handed one conversation's report to another conversation's user.
+ * A per-execution directory makes that ownership structural instead of inferred.
+ *
+ * Keyed by the *task id*, not the run id, because the engine is the side that
+ * has to tell the Agent where to write and the engine only ever sees the task
+ * id. For every channel that builds its task id with `buildTaskId` the two are
+ * the same thing; A2A hands the engine the caller's protocol task id as-is, and
+ * the collector must follow the engine there rather than look where the run id
+ * would have put it. Deriving both sides from one function is what makes it
+ * impossible for them to disagree.
+ *
+ * The segment is sanitised because `extractRunId` falls back to the raw task
+ * id when it carries no run id, and a task id contains separators.
+ */
+export function artifactsDirForTask(workspaceDir: string, taskId: string): string {
+  return join(workspaceDir, 'artifacts', sanitizePathSegment(extractRunId(taskId)))
+}
+
 function inferWorkspaceType(request: ExecuteRequest): RuntimeWorkspaceType {
   const workspaceType = request.agentConfig?.workspaceType
   if (workspaceType === 'scm') return 'scm-local'
@@ -254,10 +282,19 @@ export function prepareRuntimeContext(
   const runId = extractRunId(request.taskId)
   const workspaceDir = resolveWorkspaceDir(request, options)
   const workspaceType = inferWorkspaceType(request)
-  const artifactsDir = join(workspaceDir, 'artifacts')
+  const artifactsDir = artifactsDirForTask(workspaceDir, request.taskId)
 
   for (const dir of [agentHomeDir, cacheDir, configDir, tmpDir, claudeDir, codexHomeDir]) {
     mkdirSync(dir, { recursive: true })
+  }
+  // The artifacts directory is removed when the execution settles, so unlike
+  // the old flat `artifacts/` on a warm workspace it never pre-exists; an
+  // Agent doing `cp report.md "$A2WAVE_ARTIFACTS_DIR/"` would fail on every
+  // run. Best effort only: a read-only workspace must not fail the run here.
+  try {
+    mkdirSync(artifactsDir, { recursive: true })
+  } catch (err) {
+    logger.warn({ err, artifactsDir }, 'Could not create the artifacts directory for this run')
   }
 
   return {

--- a/apps/api/src/lib/__tests__/artifact-storage.test.ts
+++ b/apps/api/src/lib/__tests__/artifact-storage.test.ts
@@ -75,18 +75,29 @@ vi.mock('drizzle-orm', () => ({
 
 // ── Import after mocks ─────────────────────────────────────────────────────
 
+import { asyncQuery } from '../../test/async-query.js'
+import { deleteStaleShares } from '../artifact-share.js'
 import {
   deleteExpiredArtifacts,
+  discardRunArtifactsDir,
   getArtifactDir,
   getArtifactRetentionMs,
   getArtifactsStorageRoot,
   scanAndRegisterArtifacts,
 } from '../artifact-storage.js'
-
-import { asyncQuery } from '../../test/async-query.js'
-import { deleteStaleShares } from '../artifact-share.js'
+import { logger } from '../logger.js'
 
 // ── Test fixtures ──────────────────────────────────────────────────────────
+
+/**
+ * Where a run drops its artifacts, spelled out rather than imported: the tests
+ * pin the on-disk layout the Agent is pointed at, so a change to it has to be
+ * a deliberate edit here and not something the implementation can redefine
+ * under them.
+ */
+function runArtifactsDir(workDir: string, runId: string): string {
+  return join(workDir, 'artifacts', runId)
+}
 
 let testRoot: string
 
@@ -188,23 +199,23 @@ describe('scanAndRegisterArtifacts', () => {
     mkdirSync(workDir, { recursive: true })
     // No artifacts/ subdir
 
-    const result = await scanAndRegisterArtifacts('run_1', 'agt_1', 'usr_1', workDir)
+    const result = await scanAndRegisterArtifacts('run_1', 'agt_1', 'usr_1', workDir, 'run_1')
     expect(mockDbInsert).not.toHaveBeenCalled()
     expect(result).toEqual([])
   })
 
   it('does nothing when artifacts dir is empty', async () => {
     const workDir = join(testRoot, 'empty_workdir')
-    mkdirSync(join(workDir, 'artifacts'), { recursive: true })
+    mkdirSync(runArtifactsDir(workDir, 'run_1'), { recursive: true })
 
-    const result = await scanAndRegisterArtifacts('run_1', 'agt_1', 'usr_1', workDir)
+    const result = await scanAndRegisterArtifacts('run_1', 'agt_1', 'usr_1', workDir, 'run_1')
     expect(mockDbInsert).not.toHaveBeenCalled()
     expect(result).toEqual([])
   })
 
   it('copies files and inserts DB records for each artifact', async () => {
     const workDir = join(testRoot, 'workdir1')
-    const artifactsDir = join(workDir, 'artifacts')
+    const artifactsDir = runArtifactsDir(workDir, 'run_1')
     mkdirSync(artifactsDir, { recursive: true })
     writeFileSync(join(artifactsDir, 'report.md'), '# Report\nHello')
     writeFileSync(join(artifactsDir, 'data.json'), '{"key":"value"}')
@@ -212,7 +223,7 @@ describe('scanAndRegisterArtifacts', () => {
     const mockValues = vi.fn().mockReturnValue(asyncQuery({ run: vi.fn() }))
     mockDbInsert.mockReturnValue(asyncQuery({ values: mockValues }))
 
-    const result = await scanAndRegisterArtifacts('run_1', 'agt_1', 'usr_1', workDir)
+    const result = await scanAndRegisterArtifacts('run_1', 'agt_1', 'usr_1', workDir, 'run_1')
 
     expect(mockDbInsert).toHaveBeenCalledTimes(2)
 
@@ -231,14 +242,14 @@ describe('scanAndRegisterArtifacts', () => {
 
   it('copies file content to storage dir correctly', async () => {
     const workDir = join(testRoot, 'workdir_copy')
-    const artifactsDir = join(workDir, 'artifacts')
+    const artifactsDir = runArtifactsDir(workDir, 'run_copy')
     mkdirSync(artifactsDir, { recursive: true })
     writeFileSync(join(artifactsDir, 'output.txt'), 'artifact content')
 
     const mockValues = vi.fn().mockReturnValue(asyncQuery({ run: vi.fn() }))
     mockDbInsert.mockReturnValue(asyncQuery({ values: mockValues }))
 
-    await scanAndRegisterArtifacts('run_copy', 'agt_1', 'usr_1', workDir)
+    await scanAndRegisterArtifacts('run_copy', 'agt_1', 'usr_1', workDir, 'run_copy')
 
     // The stored file should have the same content
     const storedPath = (mockValues.mock.calls[0][0] as { storagePath: string }).storagePath
@@ -248,7 +259,7 @@ describe('scanAndRegisterArtifacts', () => {
 
   it('sets correct MIME type for known extensions', async () => {
     const workDir = join(testRoot, 'workdir_mime')
-    const artifactsDir = join(workDir, 'artifacts')
+    const artifactsDir = runArtifactsDir(workDir, 'run_mime')
     mkdirSync(artifactsDir, { recursive: true })
     writeFileSync(join(artifactsDir, 'image.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]))
     writeFileSync(join(artifactsDir, 'doc.json'), '{}')
@@ -256,7 +267,7 @@ describe('scanAndRegisterArtifacts', () => {
     const mockValues = vi.fn().mockReturnValue(asyncQuery({ run: vi.fn() }))
     mockDbInsert.mockReturnValue(asyncQuery({ values: mockValues }))
 
-    await scanAndRegisterArtifacts('run_mime', 'agt_1', 'usr_1', workDir)
+    await scanAndRegisterArtifacts('run_mime', 'agt_1', 'usr_1', workDir, 'run_mime')
 
     const records = mockValues.mock.calls.map(
       (c: unknown[]) => c[0] as { filename: string; mimeType: string },
@@ -270,7 +281,7 @@ describe('scanAndRegisterArtifacts', () => {
   it('sets expiresAt based on retentionHours', async () => {
     mockRetentionHours = '24'
     const workDir = join(testRoot, 'workdir_expiry')
-    const artifactsDir = join(workDir, 'artifacts')
+    const artifactsDir = runArtifactsDir(workDir, 'run_exp')
     mkdirSync(artifactsDir, { recursive: true })
     writeFileSync(join(artifactsDir, 'file.txt'), 'data')
 
@@ -278,7 +289,7 @@ describe('scanAndRegisterArtifacts', () => {
     mockDbInsert.mockReturnValue(asyncQuery({ values: mockValues }))
 
     const before = Date.now()
-    await scanAndRegisterArtifacts('run_exp', 'agt_1', 'usr_1', workDir)
+    await scanAndRegisterArtifacts('run_exp', 'agt_1', 'usr_1', workDir, 'run_exp')
     const after = Date.now()
 
     const record = mockValues.mock.calls[0][0] as { expiresAt: Date }
@@ -290,14 +301,14 @@ describe('scanAndRegisterArtifacts', () => {
   it('sets null expiresAt when retentionHours is 0', async () => {
     mockRetentionHours = '0'
     const workDir = join(testRoot, 'workdir_noexpiry')
-    const artifactsDir = join(workDir, 'artifacts')
+    const artifactsDir = runArtifactsDir(workDir, 'run_0h')
     mkdirSync(artifactsDir, { recursive: true })
     writeFileSync(join(artifactsDir, 'file.txt'), 'data')
 
     const mockValues = vi.fn().mockReturnValue(asyncQuery({ run: vi.fn() }))
     mockDbInsert.mockReturnValue(asyncQuery({ values: mockValues }))
 
-    await scanAndRegisterArtifacts('run_0h', 'agt_1', 'usr_1', workDir)
+    await scanAndRegisterArtifacts('run_0h', 'agt_1', 'usr_1', workDir, 'run_0h')
 
     const record = mockValues.mock.calls[0][0] as { expiresAt: unknown }
     expect(record.expiresAt).toBeUndefined()
@@ -305,14 +316,14 @@ describe('scanAndRegisterArtifacts', () => {
 
   it('skips empty subdirectories inside artifacts dir', async () => {
     const workDir = join(testRoot, 'workdir_subdir')
-    const artifactsDir = join(workDir, 'artifacts')
+    const artifactsDir = runArtifactsDir(workDir, 'run_sub')
     mkdirSync(join(artifactsDir, 'subdir'), { recursive: true })
     writeFileSync(join(artifactsDir, 'file.txt'), 'ok')
 
     const mockValues = vi.fn().mockReturnValue(asyncQuery({ run: vi.fn() }))
     mockDbInsert.mockReturnValue(asyncQuery({ values: mockValues }))
 
-    await scanAndRegisterArtifacts('run_sub', 'agt_1', 'usr_1', workDir)
+    await scanAndRegisterArtifacts('run_sub', 'agt_1', 'usr_1', workDir, 'run_sub')
 
     // Only the file should be registered, not the empty subdir
     expect(mockDbInsert).toHaveBeenCalledTimes(1)
@@ -322,7 +333,7 @@ describe('scanAndRegisterArtifacts', () => {
 
   it('registers a non-empty subdirectory as a directory artifact with recursive size', async () => {
     const workDir = join(testRoot, 'workdir_dir_artifact')
-    const artifactsDir = join(workDir, 'artifacts')
+    const artifactsDir = runArtifactsDir(workDir, 'run_dir')
     const siteDir = join(artifactsDir, 'site')
     mkdirSync(join(siteDir, 'assets'), { recursive: true })
     writeFileSync(join(siteDir, 'index.html'), '<html>hi</html>')
@@ -331,7 +342,7 @@ describe('scanAndRegisterArtifacts', () => {
     const mockValues = vi.fn().mockReturnValue(asyncQuery({ run: vi.fn() }))
     mockDbInsert.mockReturnValue(asyncQuery({ values: mockValues }))
 
-    const result = await scanAndRegisterArtifacts('run_dir', 'agt_1', 'usr_1', workDir)
+    const result = await scanAndRegisterArtifacts('run_dir', 'agt_1', 'usr_1', workDir, 'run_dir')
 
     expect(result).toHaveLength(1)
     expect(result[0].kind).toBe('directory')
@@ -351,7 +362,7 @@ describe('scanAndRegisterArtifacts', () => {
 
   it('skips symlinks nested inside a directory artifact', async () => {
     const workDir = join(testRoot, 'workdir_dir_symlink')
-    const artifactsDir = join(workDir, 'artifacts')
+    const artifactsDir = runArtifactsDir(workDir, 'run_dir_sym')
     const pkgDir = join(artifactsDir, 'pkg')
     mkdirSync(pkgDir, { recursive: true })
     const sensitiveFile = join(testRoot, 'nested-sensitive.txt')
@@ -362,35 +373,22 @@ describe('scanAndRegisterArtifacts', () => {
     const mockValues = vi.fn().mockReturnValue(asyncQuery({ run: vi.fn() }))
     mockDbInsert.mockReturnValue(asyncQuery({ values: mockValues }))
 
-    const result = await scanAndRegisterArtifacts('run_dir_sym', 'agt_1', 'usr_1', workDir)
+    const result = await scanAndRegisterArtifacts(
+      'run_dir_sym',
+      'agt_1',
+      'usr_1',
+      workDir,
+      'run_dir_sym',
+    )
 
     expect(result).toHaveLength(1)
     expect(existsSync(join(result[0].storagePath, 'real.txt'))).toBe(true)
     expect(existsSync(join(result[0].storagePath, 'leak.txt'))).toBe(false)
   })
 
-  it('skips stale directory artifacts that predate the current run start time', async () => {
-    const workDir = join(testRoot, 'workdir_dir_stale')
-    const artifactsDir = join(workDir, 'artifacts')
-    const oldDir = join(artifactsDir, 'old-report')
-    mkdirSync(oldDir, { recursive: true })
-    writeFileSync(join(oldDir, 'old.txt'), 'stale')
-
-    const mockValues = vi.fn().mockReturnValue(asyncQuery({ run: vi.fn() }))
-    mockDbInsert.mockReturnValue(asyncQuery({ values: mockValues }))
-
-    // registeredAfterMs 在未来：目录内所有文件都视为陈旧
-    const result = await scanAndRegisterArtifacts('run_dir_stale', 'agt_1', 'usr_1', workDir, {
-      registeredAfterMs: Date.now() + 60_000,
-    })
-
-    expect(result).toHaveLength(0)
-    expect(mockDbInsert).not.toHaveBeenCalled()
-  })
-
   it('skips symlinks in artifacts dir', async () => {
     const workDir = join(testRoot, 'workdir_symlink')
-    const artifactsDir = join(workDir, 'artifacts')
+    const artifactsDir = runArtifactsDir(workDir, 'run_sym')
     mkdirSync(artifactsDir, { recursive: true })
     // Create a real file outside artifacts dir (simulating sensitive file)
     const sensitiveFile = join(testRoot, 'sensitive.txt')
@@ -403,7 +401,7 @@ describe('scanAndRegisterArtifacts', () => {
     const mockValues = vi.fn().mockReturnValue(asyncQuery({ run: vi.fn() }))
     mockDbInsert.mockReturnValue(asyncQuery({ values: mockValues }))
 
-    const result = await scanAndRegisterArtifacts('run_sym', 'agt_1', 'usr_1', workDir)
+    const result = await scanAndRegisterArtifacts('run_sym', 'agt_1', 'usr_1', workDir, 'run_sym')
 
     // Only the legit file should be registered
     expect(mockDbInsert).toHaveBeenCalledTimes(1)
@@ -414,7 +412,7 @@ describe('scanAndRegisterArtifacts', () => {
 
   it('records correct size for each file', async () => {
     const workDir = join(testRoot, 'workdir_size')
-    const artifactsDir = join(workDir, 'artifacts')
+    const artifactsDir = runArtifactsDir(workDir, 'run_size')
     mkdirSync(artifactsDir, { recursive: true })
     const content = 'hello world'
     writeFileSync(join(artifactsDir, 'sized.txt'), content)
@@ -422,37 +420,29 @@ describe('scanAndRegisterArtifacts', () => {
     const mockValues = vi.fn().mockReturnValue(asyncQuery({ run: vi.fn() }))
     mockDbInsert.mockReturnValue(asyncQuery({ values: mockValues }))
 
-    await scanAndRegisterArtifacts('run_size', 'agt_1', 'usr_1', workDir)
+    await scanAndRegisterArtifacts('run_size', 'agt_1', 'usr_1', workDir, 'run_size')
 
     const record = mockValues.mock.calls[0][0] as { size: number }
     expect(record.size).toBe(Buffer.byteLength(content))
   })
 
-  it('skips stale artifacts that predate the current run start time', async () => {
-    const workDir = join(testRoot, 'workdir_since')
-    const artifactsDir = join(workDir, 'artifacts')
-    mkdirSync(artifactsDir, { recursive: true })
+  it('leaves a previous run output in place instead of re-registering it', async () => {
+    const workDir = join(testRoot, 'workdir_previous')
+    // The run before this one, in the same workspace. Its directory survives
+    // only when cleanup could not run (a crashed process); either way it is not
+    // this run's to collect, and no timestamp comparison decides that.
+    const previousDir = runArtifactsDir(workDir, 'run_previous')
+    mkdirSync(previousDir, { recursive: true })
+    writeFileSync(join(previousDir, 'old-report.md'), 'previous conversation output')
 
-    const oldFile = join(artifactsDir, 'old-report.md')
-    writeFileSync(oldFile, 'stale artifact')
-    const runStartedAt = Date.now()
-    utimesSync(oldFile, new Date(runStartedAt - 10_000), new Date(runStartedAt - 10_000))
-
-    const newFile = join(artifactsDir, 'new-report.md')
-    writeFileSync(newFile, 'fresh artifact')
-    // Pin the fresh file's mtime the same way the stale one is pinned, instead
-    // of trusting the write to land at or after `runStartedAt`. Filesystem
-    // timestamp granularity is coarser than Date.now() on some Linux setups, so
-    // the mtime could round *below* runStartedAt and the file the test calls
-    // "fresh" would be filtered as stale — green on macOS, red on the CI runner.
-    utimesSync(newFile, new Date(runStartedAt + 1_000), new Date(runStartedAt + 1_000))
+    const mineDir = runArtifactsDir(workDir, 'run_mine')
+    mkdirSync(mineDir, { recursive: true })
+    writeFileSync(join(mineDir, 'new-report.md'), 'fresh artifact')
 
     const mockValues = vi.fn().mockReturnValue(asyncQuery({ run: vi.fn() }))
     mockDbInsert.mockReturnValue(asyncQuery({ values: mockValues }))
 
-    const result = await scanAndRegisterArtifacts('run_since', 'agt_1', 'usr_1', workDir, {
-      registeredAfterMs: runStartedAt,
-    })
+    const result = await scanAndRegisterArtifacts('run_mine', 'agt_1', 'usr_1', workDir, 'run_mine')
 
     expect(mockDbInsert).toHaveBeenCalledTimes(1)
     const record = mockValues.mock.calls[0][0] as { filename: string }
@@ -460,6 +450,192 @@ describe('scanAndRegisterArtifacts', () => {
     expect(result).toHaveLength(1)
     expect(result[0]).toMatchObject({ id: 'art_test123', filename: 'new-report.md' })
     expect(result[0].storagePath).toBeTruthy()
+    expect(existsSync(join(previousDir, 'old-report.md'))).toBe(true)
+  })
+
+  it('ignores what a concurrent run wrote into the shared workspace, however fresh', async () => {
+    const workDir = join(testRoot, 'workdir_concurrent')
+    // A sibling run — another Feishu conversation, or another Agent bound to the
+    // same SCM checkout — producing its report while this run is still open.
+    // Its mtime is deliberately *newer* than this run's start: that is exactly
+    // the case the old mtime heuristic mis-attributed, handing one
+    // conversation's file to another conversation's user.
+    const siblingDir = join(workDir, 'artifacts', 'run_sibling')
+    mkdirSync(siblingDir, { recursive: true })
+    const siblingFile = join(siblingDir, 'price-tiers.csv')
+    writeFileSync(siblingFile, 'a different conversation output')
+    const runStartedAt = Date.now()
+    utimesSync(siblingFile, new Date(runStartedAt + 1_000), new Date(runStartedAt + 1_000))
+
+    const result = await scanAndRegisterArtifacts('run_mine', 'agt_1', 'usr_1', workDir, 'run_mine')
+
+    expect(result).toEqual([])
+    expect(mockDbInsert).not.toHaveBeenCalled()
+  })
+
+  it('registers only its own directory when two runs share one workspace', async () => {
+    const workDir = join(testRoot, 'workdir_two_runs')
+    mkdirSync(join(workDir, 'artifacts', 'run_sibling'), { recursive: true })
+    writeFileSync(join(workDir, 'artifacts', 'run_sibling', 'theirs.md'), 'theirs')
+    mkdirSync(join(workDir, 'artifacts', 'run_mine'), { recursive: true })
+    writeFileSync(join(workDir, 'artifacts', 'run_mine', 'mine.md'), 'mine')
+
+    const result = await scanAndRegisterArtifacts('run_mine', 'agt_1', 'usr_1', workDir, 'run_mine')
+
+    expect(result.map((r) => r.filename)).toEqual(['mine.md'])
+  })
+
+  it('names files written above the run directory, once per workspace', async () => {
+    const workDir = join(testRoot, 'workdir_stray')
+    mkdirSync(join(workDir, 'artifacts'), { recursive: true })
+    // An Agent that hardcoded a relative `artifacts/`: nothing is collected, and
+    // without this warning the author has no way to see why.
+    writeFileSync(join(workDir, 'artifacts', 'misplaced.md'), 'written to the wrong level')
+
+    const result = await scanAndRegisterArtifacts('run_mine', 'agt_1', 'usr_1', workDir, 'run_mine')
+
+    expect(result).toEqual([])
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ entries: ['misplaced.md'] }),
+      expect.stringContaining('workspace artifacts directory'),
+    )
+
+    // A workspace holding pre-existing top-level files would otherwise repeat
+    // this on every artifact-less run for the rest of the process's life.
+    vi.mocked(logger.warn).mockClear()
+    await scanAndRegisterArtifacts('run_later', 'agt_1', 'usr_1', workDir, 'run_later')
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('does not mistake another execution scratch directory for a misplaced file', async () => {
+    const workDir = join(testRoot, 'workdir_eval_neighbour')
+    // Evaluation turns get a taskId of their own (`eval/<task>/<case>/<n>`), so
+    // their directory carries no `run_` prefix. On a P4 source, which shares one
+    // checkout between evaluations and chat, telling the author to "write to
+    // $A2WAVE_ARTIFACTS_DIR" about a directory they wrote there correctly is
+    // worse than saying nothing.
+    mkdirSync(join(workDir, 'artifacts', 'eval_evt_1_evc_1_1'), { recursive: true })
+    writeFileSync(join(workDir, 'artifacts', 'eval_evt_1_evc_1_1', 'replay.md'), 'eval output')
+
+    const result = await scanAndRegisterArtifacts('run_mine', 'agt_1', 'usr_1', workDir, 'run_mine')
+
+    expect(result).toEqual([])
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('reads the directory the engine derived from the task id, not from the run id', async () => {
+    // A2A hands the engine the caller's protocol task id as-is — no `run_`
+    // segment anywhere in it — so the engine's $A2WAVE_ARTIFACTS_DIR is keyed
+    // by that id. The collector must look in the same place, while the
+    // registration itself still belongs to the platform run.
+    const workDir = join(testRoot, 'workdir_a2a')
+    const engineDir = join(workDir, 'artifacts', 'a2a-task-9f1c')
+    mkdirSync(engineDir, { recursive: true })
+    writeFileSync(join(engineDir, 'report.md'), '# via A2A')
+    const mockValues = vi.fn().mockReturnValue(asyncQuery({ run: vi.fn() }))
+    mockDbInsert.mockReturnValue(asyncQuery({ values: mockValues }))
+
+    const result = await scanAndRegisterArtifacts(
+      'run_a2a',
+      'agt_1',
+      'usr_1',
+      workDir,
+      'a2a-task-9f1c',
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0].filename).toBe('report.md')
+    const inserted = (mockValues.mock.calls[0] as unknown[])[0] as Record<string, unknown>
+    expect(inserted.runId).toBe('run_a2a')
+  })
+
+  it('warns once and collects nothing when the workspace artifacts path is a plain file', async () => {
+    // A repo that tracks a top-level file named `artifacts`: neither the run
+    // directory nor the stray scan can exist under it. That is a zero-artifact
+    // run, not a registration failure.
+    const workDir = join(testRoot, 'workdir_file')
+    mkdirSync(workDir, { recursive: true })
+    writeFileSync(join(workDir, 'artifacts'), 'not a directory')
+
+    await expect(
+      scanAndRegisterArtifacts('run_mine', 'agt_1', 'usr_1', workDir, 'run_mine'),
+    ).resolves.toEqual([])
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceLevelDir: join(workDir, 'artifacts') }),
+      expect.stringContaining('not a directory'),
+    )
+  })
+
+  it('warns and collects nothing when the run directory itself is a plain file', async () => {
+    const workDir = join(testRoot, 'workdir_rundir_file')
+    mkdirSync(join(workDir, 'artifacts'), { recursive: true })
+    writeFileSync(runArtifactsDir(workDir, 'run_mine'), 'I should have been a directory')
+
+    await expect(
+      scanAndRegisterArtifacts('run_mine', 'agt_1', 'usr_1', workDir, 'run_mine'),
+    ).resolves.toEqual([])
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceDir: runArtifactsDir(workDir, 'run_mine') }),
+      expect.stringContaining('not a directory'),
+    )
+  })
+
+  it('collects what an earlier attempt of the same run produced', async () => {
+    const workDir = join(testRoot, 'workdir_resumed')
+    // A run interrupted by a restart is requeued under its own runId and
+    // resumes its provider session. Its earlier attempt's output is this run's
+    // own work, for this same user and request — dropping it would throw away
+    // exactly what the resume exists to preserve.
+    const mineDir = runArtifactsDir(workDir, 'run_resumed')
+    mkdirSync(mineDir, { recursive: true })
+    const earlier = join(mineDir, 'from-first-attempt.md')
+    writeFileSync(earlier, 'written before the process died')
+    utimesSync(earlier, new Date(Date.now() - 600_000), new Date(Date.now() - 600_000))
+
+    const result = await scanAndRegisterArtifacts(
+      'run_resumed',
+      'agt_1',
+      'usr_1',
+      workDir,
+      'run_resumed',
+    )
+
+    expect(result.map((r) => r.filename)).toEqual(['from-first-attempt.md'])
+  })
+})
+
+describe('discardRunArtifactsDir', () => {
+  it('removes only the run own directory, leaving a concurrent run untouched', async () => {
+    const workDir = join(testRoot, 'workdir_discard')
+    const mine = runArtifactsDir(workDir, 'run_mine')
+    const sibling = runArtifactsDir(workDir, 'run_sibling')
+    mkdirSync(join(mine, 'nested'), { recursive: true })
+    writeFileSync(join(mine, 'nested', 'deep.md'), 'mine')
+    mkdirSync(sibling, { recursive: true })
+    writeFileSync(join(sibling, 'theirs.md'), 'theirs')
+    writeFileSync(join(workDir, 'artifacts', 'top-level.md'), 'not mine either')
+
+    await discardRunArtifactsDir(workDir, 'run_mine')
+
+    expect(existsSync(mine)).toBe(false)
+    expect(existsSync(join(sibling, 'theirs.md'))).toBe(true)
+    expect(existsSync(join(workDir, 'artifacts', 'top-level.md'))).toBe(true)
+    expect(existsSync(join(workDir, 'artifacts'))).toBe(true)
+  })
+
+  it('removes the directory the engine derived from a task id without a run segment', async () => {
+    const workDir = join(testRoot, 'workdir_discard_a2a')
+    const engineDir = join(workDir, 'artifacts', 'a2a-task-9f1c')
+    mkdirSync(engineDir, { recursive: true })
+    writeFileSync(join(engineDir, 'report.md'), 'via A2A')
+
+    await discardRunArtifactsDir(workDir, 'a2a-task-9f1c')
+
+    expect(existsSync(engineDir)).toBe(false)
+  })
+
+  it('does nothing when the run had no workDir', async () => {
+    await expect(discardRunArtifactsDir(undefined, 'run_mine')).resolves.toBeUndefined()
   })
 })
 

--- a/apps/api/src/lib/__tests__/evaluation-runner.test.ts
+++ b/apps/api/src/lib/__tests__/evaluation-runner.test.ts
@@ -17,6 +17,12 @@ vi.mock('../logger.js', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }))
 
+const discardRunArtifactsDirMock = vi.fn()
+
+vi.mock('../artifact-storage.js', () => ({
+  discardRunArtifactsDir: (...args: unknown[]) => discardRunArtifactsDirMock(...args),
+}))
+
 const { replayCase } = await import('../evaluation-runner.js')
 
 /** Engine reply helper: succeeds, echoing a chatId so resume can be asserted. */
@@ -32,6 +38,7 @@ const AGENT_CONFIG = { engineType: 'claude-code', model: 'm' }
 
 beforeEach(() => {
   executeWithRetryMock.mockReset()
+  discardRunArtifactsDirMock.mockReset()
 })
 
 describe('replayCase', () => {
@@ -309,5 +316,35 @@ describe('summarizeResults', () => {
 
     expect(summary.passRate).toBeNull()
     expect(summary.unreviewed).toBe(2)
+  })
+})
+
+describe('replayCase artifacts scratch', () => {
+  it('discards every turn artifacts directory, including the turn that failed', async () => {
+    // Each turn runs under its own taskId and therefore its own
+    // $A2WAVE_ARTIFACTS_DIR. Evaluation never registers artifacts, so nothing
+    // else would remove them — and on a shared checkout that outlives the task
+    // they would accumulate one directory per turn, forever.
+    executeWithRetryMock
+      .mockResolvedValueOnce(ok('a'))
+      .mockRejectedValueOnce(new Error('engine crashed'))
+
+    await replayCase({
+      taskId: 'evt_1',
+      caseId: 'evc_1',
+      turns: [
+        { request: 'one', expectedResponse: 'a' },
+        { request: 'two', expectedResponse: 'b' },
+      ],
+      agentConfig: AGENT_CONFIG,
+      workDir: '/tmp/eval-workdir',
+    })
+
+    const turnTaskIds = executeWithRetryMock.mock.calls.map((call) => call[0] as string)
+    expect(turnTaskIds).toHaveLength(2)
+    expect(discardRunArtifactsDirMock.mock.calls.map((call) => call[1])).toEqual(turnTaskIds)
+    for (const call of discardRunArtifactsDirMock.mock.calls) {
+      expect(call[0]).toBe('/tmp/eval-workdir')
+    }
   })
 })

--- a/apps/api/src/lib/__tests__/run-lifecycle.test.ts
+++ b/apps/api/src/lib/__tests__/run-lifecycle.test.ts
@@ -155,6 +155,7 @@ const {
   sqliteExec,
   sqliteState,
   mockScanAndRegisterArtifacts,
+  mockDiscardRunArtifactsDir,
   mockDbGet,
   mockDbRun,
   mockDbInsertRun,
@@ -170,6 +171,7 @@ const {
   sqliteExec: vi.fn(),
   sqliteState: { inTransaction: false },
   mockScanAndRegisterArtifacts: vi.fn().mockResolvedValue([]),
+  mockDiscardRunArtifactsDir: vi.fn(),
   mockDbGet: vi.fn().mockReturnValue({ name: 'Test Agent' }),
   mockDbRun: vi.fn().mockReturnValue({ changes: 1 }),
   mockDbInsertRun: vi.fn(),
@@ -292,6 +294,7 @@ vi.mock('../qq-official-service.js', () => ({
 
 vi.mock('../artifact-storage.js', () => ({
   scanAndRegisterArtifacts: mockScanAndRegisterArtifacts,
+  discardRunArtifactsDir: mockDiscardRunArtifactsDir,
 }))
 
 const mockGetArtifactDownloadUrl = vi.hoisted(() =>
@@ -758,19 +761,77 @@ describe('finishRunSuccess', () => {
     expect(stepSetCall?.output?.error).toBeUndefined()
   })
 
-  it('passes startTime to artifact registration to avoid stale files from previous runs', async () => {
+  it('collects only the run own artifacts directory', async () => {
     await finishRunSuccess(
       { ...baseParams, workDir: '/tmp/a2wave-workdir', userId: 'usr_1' },
       { success: true, output: 'ok', chatId: undefined, durationMs: 0 },
     )
 
+    // No timestamp argument: which files belong to this run is decided by the
+    // directory it wrote them to, not by when they were written. The task id
+    // goes along because that directory is keyed by it — the engine only ever
+    // saw the task id, and on A2A that carries no run id at all.
     expect(mockScanAndRegisterArtifacts).toHaveBeenCalledWith(
       runId,
       agentId,
       'usr_1',
       '/tmp/a2wave-workdir',
-      { registeredAfterMs: baseParams.startTime },
+      baseParams.taskId,
     )
+  })
+
+  it('discards the run artifacts directory once the run settles', async () => {
+    await finishRunSuccess(
+      { ...baseParams, workDir: '/tmp/a2wave-workdir', userId: 'usr_1' },
+      { success: true, output: 'ok', chatId: undefined, durationMs: 0 },
+    )
+
+    expect(mockDiscardRunArtifactsDir).toHaveBeenCalledWith(
+      '/tmp/a2wave-workdir',
+      baseParams.taskId,
+    )
+  })
+
+  it('discards the run artifacts directory even when the run fails', async () => {
+    // A failed run never reaches the scan, so nothing else would remove what it
+    // wrote — and a persistent workspace would keep it forever.
+    await finishRunError(
+      { ...baseParams, workDir: '/tmp/a2wave-workdir' },
+      new Error('engine exploded'),
+    )
+
+    expect(mockDiscardRunArtifactsDir).toHaveBeenCalledWith(
+      '/tmp/a2wave-workdir',
+      baseParams.taskId,
+    )
+  })
+
+  it('keeps the run artifacts directory when registration itself failed', async () => {
+    // The workspace copy is the only copy until registration has copied it into
+    // isolated storage. A failed INSERT or a full disk must not turn into a
+    // silent deletion of the run's deliverables.
+    mockScanAndRegisterArtifacts.mockRejectedValueOnce(new Error('SQLITE_BUSY'))
+
+    await finishRunSuccess(
+      { ...baseParams, workDir: '/tmp/a2wave-workdir', userId: 'usr_1' },
+      { success: true, output: 'ok', chatId: undefined, durationMs: 0 },
+    )
+
+    expect(mockDiscardRunArtifactsDir).not.toHaveBeenCalled()
+    expect(mockCompleteExecutionLease).toHaveBeenCalledWith(runId)
+  })
+
+  it('releases the execution lease before removing the artifacts directory', async () => {
+    // The recursive delete can be large; the Agent's next queued run must not
+    // wait behind it.
+    await finishRunSuccess(
+      { ...baseParams, workDir: '/tmp/a2wave-workdir', userId: 'usr_1' },
+      { success: true, output: 'ok', chatId: undefined, durationMs: 0 },
+    )
+
+    const leaseOrder = mockCompleteExecutionLease.mock.invocationCallOrder[0]
+    const discardOrder = mockDiscardRunArtifactsDir.mock.invocationCallOrder[0]
+    expect(leaseOrder).toBeLessThan(discardOrder)
   })
 
   it('awaits scanAndRegisterArtifacts BEFORE cleanupWorktreeIfEphemeral (no race on workDir)', async () => {

--- a/apps/api/src/lib/artifact-storage.ts
+++ b/apps/api/src/lib/artifact-storage.ts
@@ -8,16 +8,18 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   rmSync,
   statSync,
 } from 'node:fs'
+import { rm } from 'node:fs/promises'
 import { join, resolve, sep } from 'node:path'
 import AdmZip from 'adm-zip'
 import { and, eq, gt, inArray, isNull, lt, notExists } from 'drizzle-orm'
 import { db } from '../db/client.js'
 import { artifactShares, artifacts } from '../db/schema.js'
+import { artifactsDirForTask } from '../engine/runtime-context.js'
 import { deleteStaleShares } from './artifact-share.js'
 import { createId } from './id.js'
 import { logger } from './logger.js'
@@ -98,16 +100,15 @@ export interface RegisteredArtifact {
 }
 
 /**
- * 递归复制目录，逐项 lstat 跳过 symlink（含嵌套层级）。
- * 返回复制的文件总大小、文件数和最新文件 mtime（用于陈旧目录判断）。
+ * Recursively copy a directory, lstat-ing each entry so symlinks are skipped at
+ * every depth. Returns the total size and number of files copied.
  */
 function copyDirSkippingSymlinks(
   src: string,
   dest: string,
-): { totalSize: number; fileCount: number; maxMtimeMs: number } {
+): { totalSize: number; fileCount: number } {
   let totalSize = 0
   let fileCount = 0
-  let maxMtimeMs = 0
   ensureDir(dest)
   for (const entry of readdirSync(src)) {
     const srcPath = join(src, entry)
@@ -121,41 +122,130 @@ function copyDirSkippingSymlinks(
       const sub = copyDirSkippingSymlinks(srcPath, destPath)
       totalSize += sub.totalSize
       fileCount += sub.fileCount
-      maxMtimeMs = Math.max(maxMtimeMs, sub.maxMtimeMs)
     } else if (stat.isFile()) {
       copyFileSync(srcPath, destPath)
       totalSize += stat.size
       fileCount += 1
-      maxMtimeMs = Math.max(maxMtimeMs, stat.mtimeMs)
     }
   }
-  return { totalSize, fileCount, maxMtimeMs }
+  return { totalSize, fileCount }
+}
+
+/** Workspaces already reported by warnOnWorkspaceLevelArtifacts, see below. */
+const workspaceLevelArtifactsReported = new Set<string>()
+
+/**
+ * Files directly under the workspace's `artifacts/` sit one level above where
+ * the collector looks and are never collected. Two things put them there: a
+ * workspace that predates per-run directories (every run used to write to the
+ * flat `artifacts/`, and nothing ever removed it), or an Agent that hardcodes
+ * a relative `artifacts/` instead of following the injected absolute path.
+ * Name them, so either cause is diagnosable from the run's own logs rather
+ * than only from an empty artifact list.
+ *
+ * Only plain files count. Every *directory* at that level is some execution's
+ * own drop-box — a run's, or an evaluation turn's, whose taskId carries no
+ * `run_` prefix at all — and on a P4 source, where evaluations share the one
+ * checkout with chat, a name-prefix test would tell the author to write to
+ * $A2WAVE_ARTIFACTS_DIR about a directory they wrote there correctly.
+ *
+ * Reported once per workspace per process, not once per run: a workspace that
+ * predates per-run directories still holds the files those runs left at the top
+ * level, and every artifact-less run afterwards would otherwise repeat the same
+ * list forever. Once is enough to act on; a restart re-reports if it was not.
+ */
+function warnOnWorkspaceLevelArtifacts(workDir: string, runId: string): void {
+  const workspaceLevelDir = join(workDir, 'artifacts')
+  if (workspaceLevelArtifactsReported.has(workspaceLevelDir)) return
+  let strays: string[]
+  try {
+    strays = readdirSync(workspaceLevelDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name)
+  } catch (err) {
+    // Absent is the normal case for a run that wrote nothing. Anything else —
+    // a repo that tracks a plain file named `artifacts`, say — means no run on
+    // this workspace can have a directory to collect, which is worth one line.
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return
+    workspaceLevelArtifactsReported.add(workspaceLevelDir)
+    logger.warn(
+      { err, runId, workspaceLevelDir },
+      'The workspace artifacts path is not a directory; no artifacts can be collected on this workspace',
+    )
+    return
+  }
+  if (strays.length === 0) return
+  workspaceLevelArtifactsReported.add(workspaceLevelDir)
+  logger.warn(
+    { runId, workspaceLevelDir, entries: strays.slice(0, 20) },
+    'Files found directly under the workspace artifacts directory; they belong to no run and ' +
+      'are not collected. They predate per-run artifact directories, or the Agent wrote ' +
+      'outside $A2WAVE_ARTIFACTS_DIR.',
+  )
 }
 
 /**
- * 扫描 workDir/artifacts/ 目录，将产物注册到 DB。
- * 顶层文件注册为 file 产物；顶层目录整体注册为 directory 产物（递归复制）。
- * 文件复制到隔离存储路径后批量 INSERT
+ * Drop the execution's artifacts directory once the run has settled. Keyed by
+ * the task id for the reason artifactsDirForTask gives.
+ *
+ * Registration copies every artifact into isolated storage, so the workspace
+ * copy is scratch from that point on. Removing it is what keeps a persistent
+ * workspace — a per-Agent worktree or a shared SCM checkout — from growing one
+ * directory per run forever.
+ *
+ * Async because this runs on the terminal path of every run and a directory
+ * artifact may be hundreds of megabytes across many files: a synchronous
+ * recursive delete would hold the single API event loop for the whole walk.
+ */
+export async function discardRunArtifactsDir(
+  workDir: string | undefined,
+  taskId: string,
+): Promise<void> {
+  if (!workDir) return
+  try {
+    await rm(artifactsDirForTask(workDir, taskId), { recursive: true, force: true })
+  } catch (err) {
+    logger.warn({ err, taskId, workDir }, 'Failed to remove the run artifacts directory')
+  }
+}
+
+/**
+ * Register everything this run dropped in its own artifacts directory.
+ *
+ * The source is `artifactsDirForTask(workDir, taskId)`, never the workspace-wide
+ * `artifacts/`: the workspace is shared by concurrent runs (see that helper),
+ * so scanning it registered whatever a sibling run happened to be writing.
+ * Ownership is now positional — a run can only ever see its own directory —
+ * which is why no mtime filter is needed to tell the two apart.
+ *
+ * Top-level files register as `file` artifacts; top-level directories register
+ * whole as `directory` artifacts (copied recursively).
  */
 export async function scanAndRegisterArtifacts(
   runId: string,
   agentId: string,
   userId: string | null,
   workDir: string,
-  options?: { registeredAfterMs?: number },
+  taskId: string,
 ): Promise<RegisteredArtifact[]> {
-  const sourceDir = join(workDir, 'artifacts')
+  const sourceDir = artifactsDirForTask(workDir, taskId)
   if (!existsSync(sourceDir)) {
+    warnOnWorkspaceLevelArtifacts(workDir, runId)
     return []
   }
 
   const stat = statSync(sourceDir)
   if (!stat.isDirectory()) {
+    logger.warn(
+      { runId, sourceDir },
+      'The run artifacts path is not a directory; nothing was collected',
+    )
     return []
   }
 
   const entries = readdirSync(sourceDir)
   if (entries.length === 0) {
+    warnOnWorkspaceLevelArtifacts(workDir, runId)
     return []
   }
 
@@ -166,7 +256,6 @@ export async function scanAndRegisterArtifacts(
   const retentionMs = getArtifactRetentionMs()
   const expiresAt = retentionMs > 0 ? new Date(Date.now() + retentionMs) : null
   const registered: RegisteredArtifact[] = []
-  const registeredAfterMs = options?.registeredAfterMs
 
   for (const filename of entries) {
     const srcPath = join(sourceDir, filename)
@@ -191,32 +280,16 @@ export async function scanAndRegisterArtifacts(
     let size: number
 
     if (isDirectory) {
-      const { totalSize, fileCount, maxMtimeMs } = copyDirSkippingSymlinks(srcPath, resolvedDest)
-      // 空目录不注册；目录内没有任何本次运行新产生的文件时视为上次残留
-      if (
-        (await fileCount) === 0 ||
-        (registeredAfterMs != null && maxMtimeMs < registeredAfterMs)
-      ) {
+      const { totalSize, fileCount } = copyDirSkippingSymlinks(srcPath, resolvedDest)
+      // An empty directory is not an artifact — the Agent left a shell behind.
+      if (fileCount === 0) {
         rmSync(resolvedDest, { recursive: true, force: true })
-        if ((await fileCount) > 0) {
-          logger.info(
-            { filename, runId, maxMtimeMs, registeredAfterMs },
-            'Skipping stale directory artifact from previous run',
-          )
-        }
         continue
       }
       kind = 'directory'
       mimeType = null
       size = totalSize
     } else {
-      if (registeredAfterMs != null && srcStat.mtimeMs < registeredAfterMs) {
-        logger.info(
-          { filename, runId, mtimeMs: srcStat.mtimeMs, registeredAfterMs },
-          'Skipping stale artifact from previous run',
-        )
-        continue
-      }
       copyFileSync(srcPath, resolvedDest)
       kind = 'file'
       mimeType = guessMimeType(filename)

--- a/apps/api/src/lib/evaluation-runner.ts
+++ b/apps/api/src/lib/evaluation-runner.ts
@@ -18,6 +18,7 @@
  */
 import type { RunChannelContext } from '@a2wave/shared'
 import type { AgentConfig } from './agent-helpers.js'
+import { discardRunArtifactsDir } from './artifact-storage.js'
 import { executeWithRetry } from './execute-with-retry.js'
 import { logger } from './logger.js'
 
@@ -151,6 +152,12 @@ export async function replayCase(params: ReplayCaseParams): Promise<ReplayCaseRe
         durationMs: Date.now() - turnStartedAt,
       })
       break
+    } finally {
+      // Each turn ran under its own taskId and so its own $A2WAVE_ARTIFACTS_DIR.
+      // Evaluation never registers artifacts, so nothing downstream removes the
+      // directory — and a checkout that outlives the task would accumulate one
+      // per turn.
+      await discardRunArtifactsDir(workDir, turnTaskId)
     }
   }
 

--- a/apps/api/src/lib/run-lifecycle.ts
+++ b/apps/api/src/lib/run-lifecycle.ts
@@ -21,7 +21,11 @@ import { taskQueueDb } from '../engine/task-queue-db.js'
 import type { StreamLogEntry, TokenUsage } from '../engine/types.js'
 import type { ExecuteWorkerResult } from '../worker/types.js'
 import { buildArtifactLinkLines } from './artifact-links.js'
-import { type RegisteredArtifact, scanAndRegisterArtifacts } from './artifact-storage.js'
+import {
+  discardRunArtifactsDir,
+  type RegisteredArtifact,
+  scanAndRegisterArtifacts,
+} from './artifact-storage.js'
 import { executeChatRun } from './execute-chat-run.js'
 import { buildFeishuFallbackText } from './feishu-fallback.js'
 import { isPerAgentWorkspaceName } from './git-workspace.js'
@@ -240,16 +244,31 @@ async function cancelLateStep(stepId: string): Promise<void> {
 }
 
 async function cleanupFinishedExecution(
-  runId: string,
-  agentId: string,
+  params: Pick<FinishRunParams, 'runId' | 'agentId' | 'workDir' | 'taskId'>,
   shouldScheduleNext: boolean,
+  options: { keepArtifactsDir?: boolean } = {},
 ): Promise<void> {
+  const { runId, agentId, workDir, taskId } = params
   await cleanupWorkspaceOrHandOff(() => cleanupWorktreeIfEphemeral(runId, agentId), {
     context: { type: 'run', runId, agentId },
   })
   completeExecutionLease(runId)
   if (shouldScheduleNext) {
     void scheduleNext(taskQueueDb, agentId, (rid, aid) => void executeChatRun(aid, rid))
+  }
+  // On every terminal path: whatever the run dropped has been copied into
+  // isolated storage by now, so leaving the workspace copy behind only grows a
+  // persistent workspace by one directory per run. Failed and aborted runs
+  // never reach the scan, which is exactly why this lives here rather than
+  // beside it. Last, after the lease is released and the next run admitted: a
+  // directory artifact can be large, and its removal must not sit on the
+  // Agent's queue. An ephemeral worktree has already been removed whole by
+  // then, and the force-remove of a path inside it is a no-op.
+  //
+  // The one exception is a registration that threw: until the copy into
+  // isolated storage succeeded, the workspace copy is the only copy.
+  if (!options.keepArtifactsDir) {
+    await discardRunArtifactsDir(workDir, taskId)
   }
 }
 
@@ -531,7 +550,7 @@ export async function finishRunSuccess(
       { taskId, runId, stepId },
       'Run terminal transition recovered as failed; skipping success side effects',
     )
-    await cleanupFinishedExecution(runId, agentId, true)
+    await cleanupFinishedExecution(params, true)
     return []
   }
 
@@ -549,16 +568,18 @@ export async function finishRunSuccess(
       try {
         await cancelLateStep(stepId)
       } finally {
-        await cleanupFinishedExecution(runId, agentId, false)
+        await cleanupFinishedExecution(params, false)
       }
     } else if ((await currentStatus) === undefined) {
-      // No terminal owner remains to finish cleanup for a deleted Run.
+      // No terminal owner remains to finish cleanup for a deleted Run — but its
+      // scratch directory still has to go, or nothing ever removes it.
+      await discardRunArtifactsDir(params.workDir, params.taskId)
       completeExecutionLease(runId)
     } else if ((await currentStatus) === 'running') {
       // Recovery could not persist a terminal state. Release the in-memory
       // lease so cancellation is not left waiting forever; the running DB row
       // still prevents over-admission until recovery or cancellation repairs it.
-      await cleanupFinishedExecution(runId, agentId, true)
+      await cleanupFinishedExecution(params, true)
     }
     return []
   }
@@ -577,6 +598,10 @@ export async function finishRunSuccess(
   let successContext: Record<string, unknown> | undefined
 
   let registered: RegisteredArtifact[] = []
+  // Until registration has copied the run's files into isolated storage the
+  // workspace copy is the only copy. A run with nothing to collect is secure
+  // from the start.
+  let artifactsSecured = !(result.success && workDir)
   try {
     if (result.success) {
       // Load the step context once and reuse it for both the persist decision and
@@ -625,12 +650,22 @@ export async function finishRunSuccess(
       )[0]
       const rawPolicy = agentRow?.artifactPolicy
       const artifactPolicy = rawPolicy ? artifactPolicySchema.parse(rawPolicy) : null
-      registered = await scanAndRegisterArtifacts(runId, agentId, userId ?? null, workDir, {
-        registeredAfterMs: startTime,
-      }).catch((err) => {
-        logger.warn({ err }, 'Artifact registration failed')
-        return [] as RegisteredArtifact[]
-      })
+      try {
+        registered = await scanAndRegisterArtifacts(
+          runId,
+          agentId,
+          userId ?? null,
+          workDir,
+          params.taskId,
+        )
+        artifactsSecured = true
+      } catch (err) {
+        logger.warn(
+          { err, runId, workDir },
+          'Artifact registration failed; the run artifacts directory is left in place',
+        )
+        registered = []
+      }
       if (registered.length > 0) {
         const links = await buildArtifactLinkLines(registered, userId ?? null, artifactPolicy)
         const channelType = (successContext?.channel as { channel_type?: string } | undefined)
@@ -651,7 +686,7 @@ export async function finishRunSuccess(
   } catch (err) {
     logger.error({ err, runId, stepId }, 'Post-success side effect failed')
   } finally {
-    await cleanupFinishedExecution(runId, agentId, true)
+    await cleanupFinishedExecution(params, true, { keepArtifactsDir: !artifactsSecured })
   }
 
   // Async worklog + insight generation — fire-and-forget, does not affect caller
@@ -720,13 +755,15 @@ async function finishRunFailure(
       try {
         await cancelLateStep(stepId)
       } finally {
-        await cleanupFinishedExecution(runId, agentId, false)
+        await cleanupFinishedExecution(params, false)
       }
     } else if ((await currentStatus) === undefined) {
-      // No terminal owner remains to finish cleanup for a deleted Run.
+      // No terminal owner remains to finish cleanup for a deleted Run — but its
+      // scratch directory still has to go, or nothing ever removes it.
+      await discardRunArtifactsDir(params.workDir, params.taskId)
       completeExecutionLease(runId)
     } else if (currentStatus === 'running') {
-      await cleanupFinishedExecution(runId, agentId, true)
+      await cleanupFinishedExecution(params, true)
     }
     return
   }
@@ -781,7 +818,7 @@ async function finishRunFailure(
   } catch (err) {
     logger.error({ err, runId, stepId }, 'Post-failure side effect failed')
   } finally {
-    await cleanupFinishedExecution(runId, agentId, true)
+    await cleanupFinishedExecution(params, true)
   }
 }
 

--- a/apps/api/src/routes/__tests__/oauth-gateway.test.ts
+++ b/apps/api/src/routes/__tests__/oauth-gateway.test.ts
@@ -1,6 +1,6 @@
 import { GatewayErrorCode } from '@a2wave/shared'
 import { Hono } from 'hono'
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { GatewayAuthErrors } from '../../lib/gateway-auth-errors.js'
 
 type Json = Record<string, unknown>
@@ -182,7 +182,7 @@ const validCaller = {
 import { db } from '../../db/client.js'
 import { engineRegistry } from '../../engine/index.js'
 import { scheduleNext, tryAcquireSlot } from '../../engine/task-queue.js'
-import { WorktreeOccupiedError, buildAgentConfig, resolveWorkDir } from '../../lib/agent-helpers.js'
+import { buildAgentConfig, resolveWorkDir, WorktreeOccupiedError } from '../../lib/agent-helpers.js'
 import { ProviderConfigurationError } from '../../lib/errors.js'
 import { registerPendingContext } from '../../lib/pending-job-registry.js'
 import { runWithLifecycle } from '../../lib/run-launcher.js'
@@ -931,6 +931,31 @@ describe('OAuth Gateway routes', () => {
         expect.any(String),
         expect.objectContaining({ chatId: 'chat_previous' }),
         expect.any(Object),
+      )
+    })
+
+    it('hands the resolved workDir and the owner to the lifecycle so artifacts are collected, attributed and cleaned up', async () => {
+      // Without workDir the lifecycle skips the artifact scan entirely AND cannot
+      // remove the run's artifacts directory, so every OAuth invocation leaves
+      // one behind in a workspace that persists across runs. Without userId the
+      // artifacts it does collect are filed under no owner, unlike the same
+      // Agent invoked through the API-key gateway.
+      ;(db.select as Mock).mockImplementation(() =>
+        makeDbChain({ ...oauthAgent, userId: 'usr_owner' }),
+      )
+      ;(runWithLifecycle as Mock).mockResolvedValue({
+        success: true,
+        output: 'ok',
+        durationMs: 10,
+      })
+
+      const res = await invokeRequest({ message: 'hi', async: false })
+
+      expect(res.status).toBe(200)
+      expect(runWithLifecycle).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Object),
+        expect.objectContaining({ workDir: '/tmp/work', userId: 'usr_owner' }),
       )
     })
 

--- a/apps/api/src/routes/oauth-gateway.ts
+++ b/apps/api/src/routes/oauth-gateway.ts
@@ -531,7 +531,20 @@ app.post('/:agentId/invoke', async (c) => {
     agentConfig,
   }
 
-  const lifecycleParams = { taskId, runId, stepId, agentId, startTime: Date.now() }
+  // workDir is what lets the lifecycle collect this run's artifacts and, when it
+  // settles, remove the directory they were written to. Omitting it silently
+  // skipped both — no artifacts on this channel, and one abandoned directory per
+  // invocation in a workspace that outlives the run. userId files what is
+  // collected under the Agent's owner, as the API-key gateway does.
+  const lifecycleParams = {
+    taskId,
+    runId,
+    stepId,
+    agentId,
+    startTime: Date.now(),
+    workDir: resolvedWorkDir,
+    userId: agent.userId ?? undefined,
+  }
 
   // 分支顺序（main 侧语义）：stream 优先于 async——`stream:true` 即使 async 缺省（默认 true）
   // 也必须走 SSE，否则调用方拿到 202 却收不到流。

--- a/apps/web/src/content/manual/en/15-runs.md
+++ b/apps/web/src/content/manual/en/15-runs.md
@@ -110,7 +110,7 @@ To keep accumulated run records from slowing down the database, the platform cle
 
 Files produced during a Run are saved as **artifacts**, viewable and downloadable in the artifact list and traceable after the run finishes (`GET /api/artifacts`, `/:id/download`).
 
-> Whether artifacts are retained on disk depends on that invocation's worktree cleanup policy (`ephemeral` deletes immediately / `ttl` retains for N seconds / `persistent` retains long-term); see the `worktree` parameter in [Trigger Methods](/wiki/triggers).
+> Artifacts are copied into the platform's artifact storage when the run finishes, and the run's scratch directory in the workspace is removed regardless of the worktree cleanup policy (`ephemeral` / `ttl` / `persistent` — see the `worktree` parameter in [Trigger Methods](/wiki/triggers), which governs the rest of the workspace). How long the stored copy is kept is set by the retention period on [Settings → Artifacts](/wiki/artifacts).
 
 Beyond downloading, artifacts can also generate an **online share link** in one click, letting the other party preview the web page or report directly — see [Artifacts & Online Sharing](/wiki/artifacts).
 

--- a/apps/web/src/content/manual/zh/15-runs.md
+++ b/apps/web/src/content/manual/zh/15-runs.md
@@ -110,7 +110,7 @@ Run 是 Agent 的一次执行记录。无论通过哪种方式触发，每次执
 
 Run 中产生的文件作为 **产物** 保存，可在产物列表查看与下载，运行结束后仍可追溯（`GET /api/artifacts`、`/:id/download`）。
 
-> 产物是否随磁盘保留，取决于该次调用的 worktree 清理策略（`ephemeral` 立即删 / `ttl` 保留 N 秒 / `persistent` 长期保留），见 [触发方式](/wiki/triggers) 的 `worktree` 参数。
+> 运行结束时，产物会复制到平台的产物存储中，工作区里该次运行的产物暂存目录随即删除，与 worktree 清理策略无关（`ephemeral` / `ttl` / `persistent` 管的是工作区其余部分，见 [触发方式](/wiki/triggers) 的 `worktree` 参数）。平台存储副本的保留时长由 [设置 → 产物](/wiki/artifacts) 的保留期决定。
 
 除下载外，产物还能一键生成**在线分享链接**，让对方直接预览网页或报告——见 [产物与在线分享](/wiki/artifacts)。
 


### PR DESCRIPTION
A run's artifacts were collected from `<workDir>/artifacts`, a directory every run of an Agent shares — and, on a shared SCM checkout, every Agent bound to that source shares too. Which files belonged to the finishing run was inferred from `mtime >= run.startTime`, so any file a *concurrent* run wrote inside that window was registered as the finishing run's own and delivered to its user.

Observed in production: run_qC5wn9wdK2H5gfr- (10:29:43-10:32:12) issued no Write call at all, yet shipped the xlsx/csv that run_s0zQb74xpl3_fJpX wrote into the same workspace at 10:31:41. Two Feishu conversations, one Agent workspace, one pair of files registered twice.

Ownership is now positional rather than inferred: A2WAVE_ARTIFACTS_DIR is `<workDir>/artifacts/<id>` and the collector reads only that directory. Concurrency, name collisions and clock skew stop mattering, and the mtime filter is gone. The directory is created before the engine starts and discarded on every terminal path, so a persistent workspace no longer grows one directory per run.

The `<id>` is derived from the engine task id on both sides, through one function: for every channel that builds its task id with buildTaskId that is the run id, while A2A hands the engine the caller's protocol task id as-is and the collector has to follow the engine there. Evaluation turns, which run under their own task ids and never register artifacts, discard their directory after each turn.

Agents need no change: `<artifacts_guide>` and A2WAVE_ARTIFACTS_DIR already carry an absolute path, which now points at the per-run directory. Files left at the workspace level — from before this change, or by an Agent that ignores the variable — are reported once per workspace rather than silently dropped.

Two guard rails on the removal: a registration that throws leaves the directory in place (until the copy into isolated storage succeeds it is the only copy), and the removal runs after the execution lease is released so a large directory artifact never delays the Agent's next queued run.

Also passes `workDir` and `userId` on the OAuth channel, which omitted both: without them the lifecycle could neither collect that channel's artifacts nor attribute them to the Agent owner the way the API-key gateway does.

Manual: the Runs page said artifact retention followed the worktree cleanup policy; it now says the stored copy follows Settings → Artifacts and the workspace scratch directory is always removed.

Follow-up, not in this change: runs that recovery or the orphaned-run reaper mark failed after a crash bypass the lifecycle and leave their directory behind, as the old flat directory's files always did.

<!--
Thanks for contributing to a2wave! Please fill in the sections below.
See CONTRIBUTING.md for the full process and quality gates.
-->

## Summary

<!-- What does this PR do and why? Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore

## Testing checklist

<!-- Report gate RESULTS, never pasted terminal output. pnpm prints the absolute
     path of each package before every script it runs, so pasting a run log
     leaks local directory structure (and buries the result in thousands of
     lines). Write "0 errors, 426 warnings (unchanged from main)", not the log.
     A CI check rejects PR bodies containing home-directory paths. -->

- [ ] `pnpm lint` passes (0 errors)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes; new/changed code is covered by tests
- [ ] E2E updated/run if this touches critical user paths, routes, or i18n
- [ ] User-facing docs, i18n copy (`zh.json` **and** `en.json`), and the in-app
      manual updated where relevant (or "not applicable")

## Cross-cutting change matrix

<!-- Delete this section when it is not applicable. For SCM storage changes,
read docs/agent/scm-storage-invariants.md and mark every affected path. -->

- [ ] Create / import / bootstrap paths checked
- [ ] PATCH / enable-disable / cancellation paths checked
- [ ] DELETE / cleanup / audit paths checked
- [ ] Startup recovery and upgrade compatibility checked
- [ ] Git and P4 behavior checked where applicable
- [ ] SQLite and PostgreSQL behavior checked where applicable
- [ ] Named volume, default bind, explicit bind, and macOS bind behavior checked
      where applicable
- [ ] Failure recovery and operator remediation are documented

## AI assistance disclosure

- [ ] This change was substantially AI-generated. If checked, I confirm I
      understand the code and have tested it myself (see CONTRIBUTING.md).

## Additional notes

<!-- Screenshots, migration notes, follow-ups, anything reviewers should know. -->
