### PR TITLE
fix(recovery): restart an interrupted run that never began executing

### DIFF
--- a/apps/api/src/engine/__tests__/live-session-capture-wiring.test.ts
+++ b/apps/api/src/engine/__tests__/live-session-capture-wiring.test.ts
@@ -10,15 +10,51 @@ import { describe, expect, it, vi } from 'vitest'
 // Resolves true — "the row was found and updated" — so a test that asserts the
 // tap stopped querying is proving a latch, not riding on a falsy default.
 const persistLiveSessionId = vi.fn().mockResolvedValue(true)
+const markExecutionStarted = vi.fn().mockResolvedValue(true)
 vi.mock('../../lib/persist-live-session-id.js', () => ({
   persistLiveSessionId,
+  markExecutionStarted,
   readLiveSessionId: vi.fn(),
   LIVE_CHAT_ID_KEY: 'liveChatId',
+  EXECUTION_STARTED_KEY: 'executionStarted',
 }))
 
 const { tapLiveSessionId } = await import('../live-session-tap.js')
 
 describe('tapLiveSessionId', () => {
+  // Recovery needs to tell "died during setup" apart from "ran and may have
+  // committed side effects". The first line of CLI output is the earliest proof
+  // of the latter, and marking it here covers every engine at once.
+  it('marks execution as started for a CLI that emits output but no session id', async () => {
+    markExecutionStarted.mockClear()
+    const tapped = tapLiveSessionId('run_mark/step_1', () => {})
+    tapped('Loading...')
+
+    await vi.waitFor(() => expect(markExecutionStarted).toHaveBeenCalledWith('run_mark'))
+    expect(markExecutionStarted).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the marking to persistLiveSessionId once a session is recorded', async () => {
+    // persistLiveSessionId writes both fields in one merge, so a second write
+    // here would be a concurrent compare-and-set on the same row for no gain.
+    markExecutionStarted.mockClear()
+    const tapped = tapLiveSessionId('run_sess/step_1', () => {})
+    tapped(JSON.stringify({ session_id: 'sess_a' }))
+
+    await vi.waitFor(() => expect(persistLiveSessionId).toHaveBeenCalledWith('run_sess', 'sess_a'))
+    expect(markExecutionStarted).not.toHaveBeenCalled()
+  })
+
+  it('does not mark a task that owns no run row', async () => {
+    markExecutionStarted.mockClear()
+    // Evaluation replays and memory tasks own no run; a write here could never
+    // match, and would cost one statement per line.
+    const tapped = tapLiveSessionId('eval/task_1/case_1/0', () => {})
+    tapped(JSON.stringify({ session_id: 'sess_a' }))
+
+    expect(markExecutionStarted).not.toHaveBeenCalled()
+  })
+
   it('forwards every line to the engine parser unchanged', async () => {
     const parsed: string[] = []
     const tapped = tapLiveSessionId('run_x/step_1', (line) => parsed.push(line))

--- a/apps/api/src/engine/live-session-tap.ts
+++ b/apps/api/src/engine/live-session-tap.ts
@@ -20,6 +20,15 @@ export function tapLiveSessionId(
   // repeats its session id on every event it emits.
   if (!runId.startsWith('run_')) return onStdoutLine
 
+  const markStarted = async (runId: string): Promise<void> => {
+    const { markExecutionStarted } = await import('../lib/persist-live-session-id.js')
+    await markExecutionStarted(runId)
+  }
+
+  // Set once the recorder has written a session id, which already implies the
+  // run started — persistLiveSessionId sets both fields in one merge.
+  let sessionRecorded = false
+
   const record = createLiveSessionRecorder({
     runId,
     // Imported lazily so the engine layer does not open a database connection
@@ -29,9 +38,18 @@ export function tapLiveSessionId(
       const { persistLiveSessionId } = await import('../lib/persist-live-session-id.js')
       // Return the verdict rather than swallowing it: false means the run row
       // is gone, which is what lets the recorder stand down.
-      return await persistLiveSessionId(runId, sessionId)
+      const written = await persistLiveSessionId(runId, sessionId)
+      if (written) sessionRecorded = true
+      return written
     },
   })
+
+  // Written once, on the first line the CLI emits — the earliest proof this run
+  // can have committed side effects, and what lets recovery restart a run killed
+  // during setup without risking a replay of work already done. Shares the
+  // recorder's single lazy import so the engine layer still opens no database
+  // connection at module load.
+  let startMarked = false
 
   return (line: string): void => {
     // Parsing stays synchronous and first: the recorder is a side channel and
@@ -39,6 +57,15 @@ export function tapLiveSessionId(
     onStdoutLine(line)
     // Fire-and-forget. The recorder swallows its own failures; this catch is
     // belt-and-braces so a rejection can never surface as an unhandled one.
-    void record(line).catch(() => {})
+    void record(line)
+      .then(() => {
+        // Only when the recorder did not already write it: persistLiveSessionId
+        // sets both fields in one merge, and a second concurrent merge on the
+        // same row buys nothing but contention.
+        if (startMarked || sessionRecorded) return
+        startMarked = true
+        return markStarted(runId)
+      })
+      .catch(() => {})
   }
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -53,7 +53,7 @@ import { processInstanceId } from './lib/process-instance.js'
 import { qqOfficialConnectionManager } from './lib/qq-official-service.js'
 import { markReady } from './lib/readiness.js'
 import { sanitizeRequestLogPath } from './lib/request-log-path.js'
-import { markRunForResume, resolveResumeChatId } from './lib/resume-chat-id.js'
+import { canRequeueInterruptedRun, markRunForResume } from './lib/resume-chat-id.js'
 import { cleanupLegacyRuntimeGroupConfigs } from './lib/runtime-group-config.js'
 import { scheduleTriggerManager } from './lib/schedule-trigger.js'
 import {
@@ -700,8 +700,7 @@ void ensureAdminExists()
         // A run that recorded the session it was already in is requeued and
         // continued instead of abandoned, so a deploy restart does not throw
         // away work in progress.
-        canResume: async (runId, assumeFailureCode) =>
-          (await resolveResumeChatId(runId, assumeFailureCode)) !== null,
+        canResume: canRequeueInterruptedRun,
         onBeforeRequeue: async (runId, failureCode) => await markRunForResume(runId, failureCode),
         onRunRequeued: async (run) => {
           // Mirrors onRunFailed: a requeued run is just as done with the dead

--- a/apps/api/src/lib/__tests__/persist-live-session-id.test.ts
+++ b/apps/api/src/lib/__tests__/persist-live-session-id.test.ts
@@ -92,6 +92,9 @@ describe('persistLiveSessionId', () => {
       queuedTurn: { prompt: 'hello' },
       oauthPreviousChatId: 'sess_prev',
       liveChatId: 'sess_a',
+      // Written in the same merge: a run that announced a session has
+      // self-evidently started, and one write beats two competing ones.
+      executionStarted: true,
     })
   })
 
@@ -132,7 +135,11 @@ describe('persistLiveSessionId', () => {
     })
     const metadata = await loadMetadata()
     expect(metadata).not.toHaveProperty('queuedTurn')
-    expect(metadata).toEqual({ runtimeAdminRequesterUserId: 'usr_1', liveChatId: 'sess_a' })
+    expect(metadata).toEqual({
+      runtimeAdminRequesterUserId: 'usr_1',
+      liveChatId: 'sess_a',
+      executionStarted: true,
+    })
   })
 
   it('leaves updatedAt alone so it cannot vouch for a stalled run', async () => {

--- a/apps/api/src/lib/__tests__/resume-chat-id.test.ts
+++ b/apps/api/src/lib/__tests__/resume-chat-id.test.ts
@@ -45,8 +45,13 @@ vi.mock('../../db/client.js', async () => {
 
 const { db } = await import('../../db/client.js')
 const { runs } = await import('../../db/schema.js')
-const { resolveResumeChatId, recordResumeAttempt, resumeChatIdFromRow, markRunForResume } =
-  await import('../resume-chat-id.js')
+const {
+  resolveResumeChatId,
+  recordResumeAttempt,
+  resumeChatIdFromRow,
+  markRunForResume,
+  canRequeueInterruptedRun,
+} = await import('../resume-chat-id.js')
 
 const NOW = new Date('2026-08-20T10:00:00Z')
 
@@ -142,6 +147,76 @@ describe('resolveResumeChatId', () => {
       executionMetadata: { liveChatId: 'sess_live', nativeChatResetSession: true },
     })
     expect(await resolveResumeChatId('run_1', 'SERVER_RESTART_DURING_EXEC')).toBeNull()
+  })
+})
+
+describe('canRequeueInterruptedRun', () => {
+  beforeEach(async () => {
+    await db.delete(runs)
+  })
+
+  // The shared stdout tap writes `executionStarted` on the CLI's first line, so
+  // its absence on an interrupted run means the process died during setup — a
+  // clone or sync that runs for minutes on a large repository. Such a run has no
+  // session id AND no side effects, so failing it only makes the user re-trigger
+  // by hand: the same replay, performed manually and later.
+  it('requeues a run interrupted before it began executing', async () => {
+    // No executionStarted marker: the CLI never emitted a line. glab is
+    // fire-and-forget, so nothing is awaiting a verdict.
+    await seedRun({
+      triggerSource: 'glab',
+      result: { error: { code: 'INSTANCE_STOPPED_DURING_EXEC' } },
+    })
+
+    expect(await canRequeueInterruptedRun('run_1')).toBe(true)
+    // It resumes by starting over, so there is no session to continue from.
+    expect(await resolveResumeChatId('run_1')).toBeNull()
+  })
+
+  it('refuses a run that had started but announced no session', async () => {
+    // The CLI ran, so replaying the prompt could repeat side effects it already
+    // committed. Only the never-started case earns the restart.
+    await seedRun({
+      triggerSource: 'glab',
+      executionMetadata: { executionStarted: true },
+      result: { error: { code: 'INSTANCE_STOPPED_DURING_EXEC' } },
+    })
+
+    expect(await canRequeueInterruptedRun('run_1')).toBe(false)
+  })
+
+  it('still requeues a started run that recorded its session', async () => {
+    await seedRun({
+      triggerSource: 'glab',
+      executionMetadata: { liveChatId: 'sess_a', executionStarted: true },
+      result: { error: { code: 'INSTANCE_STOPPED_DURING_EXEC' } },
+    })
+
+    expect(await canRequeueInterruptedRun('run_1')).toBe(true)
+    expect(await resolveResumeChatId('run_1')).toBe('sess_a')
+  })
+
+  it('refuses a run that failed on its own merits, however far it got', async () => {
+    await seedRun({ triggerSource: 'glab', result: { error: { code: 'ENGINE_ERROR' } } })
+
+    expect(await canRequeueInterruptedRun('run_1')).toBe(false)
+  })
+
+  // An A2A caller is polling tasks/get, and the protocol already called the task
+  // terminal. Silently re-running it leaves that caller waiting on a verdict it
+  // has been told will not change — so a synchronous trigger is failed, not
+  // restarted, however little the run managed to do.
+  it('refuses to restart a run whose caller is awaiting a verdict', async () => {
+    await seedRun({
+      triggerSource: 'a2a',
+      result: { error: { code: 'INSTANCE_STOPPED_DURING_EXEC' } },
+    })
+
+    expect(await canRequeueInterruptedRun('run_1')).toBe(false)
+  })
+
+  it('refuses a missing run rather than reporting it requeueable', async () => {
+    expect(await canRequeueInterruptedRun('run_absent')).toBe(false)
   })
 })
 

--- a/apps/api/src/lib/__tests__/resume-decision.test.ts
+++ b/apps/api/src/lib/__tests__/resume-decision.test.ts
@@ -34,6 +34,28 @@ describe('decideResume', () => {
     })
   })
 
+  // The refusal above is right whenever the CLI actually ran: replaying the
+  // prompt would repeat side effects it already committed. But a run killed
+  // before its CLI emitted a line has no session id AND no side effects, and if
+  // its trigger is fire-and-forget nobody is awaiting a verdict — failing it
+  // just makes the user re-trigger by hand, the same replay performed manually.
+  it('restarts a run that never began executing, since it can have no side effects', () => {
+    expect(decideResume({ ...interrupted, liveChatId: null, restartable: true })).toEqual({
+      resume: true,
+      chatId: null,
+      attempt: 1,
+    })
+  })
+
+  it('still refuses a started run with no session id, even on a retry', () => {
+    // `restartable` is the only thing that distinguishes the two; without it the
+    // conservative refusal has to stand.
+    expect(decideResume({ ...interrupted, liveChatId: null, restartable: false })).toEqual({
+      resume: false,
+      reason: 'no-session',
+    })
+  })
+
   it('refuses once the attempt budget is spent', () => {
     // Without a ceiling, a crash that reproduces on resume becomes an infinite
     // crash-resume loop that is strictly worse than failing fast.

--- a/apps/api/src/lib/orphaned-run-reaper.ts
+++ b/apps/api/src/lib/orphaned-run-reaper.ts
@@ -10,7 +10,7 @@ import {
   loadInstanceLiveness,
 } from './instance-heartbeat.js'
 import { logger } from './logger.js'
-import { resolveResumeChatId } from './resume-chat-id.js'
+import { canRequeueInterruptedRun } from './resume-chat-id.js'
 import { FAILURE_REASONS } from './run-failure-reasons.js'
 import { syncReapedRunExternalState } from './scm-lease-sweeper.js'
 import { withScmPathMutation } from './scm-path-plan.js'
@@ -157,8 +157,10 @@ export const defaultReaperDepsForTest: OrphanedRunReaperDeps = {
   // it is the only recovery that runs on PostgreSQL, where in-flight rows are
   // deliberately skipped at boot because a booting replica proves nothing
   // about a peer. Without this the resume feature is unreachable there.
-  canResume: async (runId, assumeFailureCode) =>
-    (await resolveResumeChatId(runId, assumeFailureCode)) !== null,
+  // Not `resolveResumeChatId(...) !== null`: that conflates "cannot resume"
+  // with "resume by starting over", and the second is the case a run killed
+  // before its CLI emitted anything falls into.
+  canResume: canRequeueInterruptedRun,
   requeueRun: (runId, interruptionCode) => taskQueueDb.requeueForResume(runId, interruptionCode),
   now: () => new Date(),
 }

--- a/apps/api/src/lib/persist-live-session-id.ts
+++ b/apps/api/src/lib/persist-live-session-id.ts
@@ -6,6 +6,22 @@ import { mergeExecutionMetadata } from './merge-execution-metadata.js'
 /** Metadata key holding the session a still-running run would resume from. */
 export const LIVE_CHAT_ID_KEY = 'liveChatId'
 
+/**
+ * Metadata key recording that this run's CLI actually started producing output.
+ *
+ * Recovery needs to tell two interrupted runs apart. One got far enough to
+ * commit side effects — files written, messages sent, merge requests opened —
+ * and must never have its prompt replayed. The other died during setup (a clone
+ * or sync can run for minutes on a large repository) and has no side effects at
+ * all, so failing it just makes a human re-trigger it: the same replay,
+ * performed manually and later.
+ *
+ * `liveChatId` cannot answer this — a CLI that dies before announcing its
+ * session leaves it empty either way — and `work_dir` cannot either, since only
+ * the per-agent worktree path records one.
+ */
+export const EXECUTION_STARTED_KEY = 'executionStarted'
+
 /** Test seam: run a competing write between this call's read and its write. */
 export interface PersistLiveSessionIdHooks {
   beforeWrite?: () => Promise<void>
@@ -17,12 +33,30 @@ export interface PersistLiveSessionIdHooks {
  * Returns whether a row was updated, so a caller streaming hundreds of lines
  * can stop retrying a run that no longer exists.
  */
+/**
+ * Record that this run's CLI has begun producing output.
+ *
+ * Written from the same stdout tap that records the session id, so it covers
+ * every engine and a newly added one cannot forget to opt in.
+ */
+export async function markExecutionStarted(runId: string): Promise<boolean> {
+  return await mergeExecutionMetadata(runId, () => ({ [EXECUTION_STARTED_KEY]: true }))
+}
+
 export async function persistLiveSessionId(
   runId: string,
   sessionId: string,
   hooks: PersistLiveSessionIdHooks = {},
 ): Promise<boolean> {
-  return await mergeExecutionMetadata(runId, () => ({ [LIVE_CHAT_ID_KEY]: sessionId }), hooks)
+  // Both facts land in one compare-and-set. Writing them separately would put
+  // two concurrent merges on the same row for every run, and the loser retries
+  // against a moving target for no benefit — a run that announced a session has
+  // self-evidently started.
+  return await mergeExecutionMetadata(
+    runId,
+    () => ({ [LIVE_CHAT_ID_KEY]: sessionId, [EXECUTION_STARTED_KEY]: true }),
+    hooks,
+  )
 }
 
 /** Read back the resume target recorded for a run, if it announced one. */

--- a/apps/api/src/lib/resume-chat-id.ts
+++ b/apps/api/src/lib/resume-chat-id.ts
@@ -3,7 +3,9 @@ import { db } from '../db/client.js'
 import { runs } from '../db/schema.js'
 import { logger } from './logger.js'
 import { mergeExecutionMetadata } from './merge-execution-metadata.js'
-import { decideResume } from './resume-decision.js'
+import { NATIVE_CHAT_CHANNELS } from './native-chat-channel.js'
+import { EXECUTION_STARTED_KEY } from './persist-live-session-id.js'
+import { decideResume, type ResumeDecision } from './resume-decision.js'
 
 /** Metadata key counting how many times this run has already been resumed. */
 export const RESUME_ATTEMPTS_KEY = 'resumeAttempts'
@@ -34,6 +36,33 @@ function readFailureCode(result: unknown): string {
  * prompt would repeat side effects the CLI already committed — files written,
  * messages sent, merge requests opened.
  */
+/**
+ * Whether an interrupted run may be put back on the queue at all.
+ *
+ * Distinct from `resolveResumeChatId`, which answers "what session does it
+ * continue from" and returns null both for "cannot resume" and for "resume by
+ * starting over".
+ */
+export async function canRequeueInterruptedRun(
+  runId: string,
+  assumeFailureCode?: string,
+): Promise<boolean> {
+  const row = (
+    await db
+      .select({
+        executionMetadata: runs.executionMetadata,
+        result: runs.result,
+        initiatorAgentId: runs.initiatorAgentId,
+        triggerSource: runs.triggerSource,
+      })
+      .from(runs)
+      .where(eq(runs.id, runId))
+      .limit(1)
+  )[0]
+  if (!row) return false
+  return resumeDecisionForRow(row, assumeFailureCode).resume
+}
+
 export async function resolveResumeChatId(
   runId: string,
   /**
@@ -51,6 +80,7 @@ export async function resolveResumeChatId(
         executionMetadata: runs.executionMetadata,
         result: runs.result,
         initiatorAgentId: runs.initiatorAgentId,
+        triggerSource: runs.triggerSource,
       })
       .from(runs)
       .where(eq(runs.id, runId))
@@ -72,9 +102,46 @@ export function resumeChatIdFromRow(
     executionMetadata: unknown
     result: unknown
     initiatorAgentId: string | null
+    triggerSource?: string | null
   },
   assumeFailureCode?: string,
 ): string | null {
+  const decision = resumeDecisionForRow(row, assumeFailureCode)
+  return decision.resume ? decision.chatId : null
+}
+
+/**
+ * Triggers with no caller synchronously awaiting a verdict.
+ *
+ * A run these started can be restarted from its intent after an interruption
+ * that produced nothing; the trigger simply fires again. Every other source —
+ * `a2a`, `api`, `oauth`, `debug`, `chat_app` — has someone holding a response or
+ * polling a task, and must be told the run failed rather than left waiting on a
+ * silent re-run.
+ */
+const RESTARTABLE_TRIGGERS: ReadonlySet<string> = new Set([
+  'glab',
+  'gh',
+  'schedule',
+  'feishu',
+  ...NATIVE_CHAT_CHANNELS,
+])
+
+function isRestartableTrigger(triggerSource: string | null | undefined): boolean {
+  return typeof triggerSource === 'string' && RESTARTABLE_TRIGGERS.has(triggerSource)
+}
+
+/** The shared verdict, so "may it requeue" and "what does it resume" cannot disagree. */
+function resumeDecisionForRow(
+  row: {
+    id?: string
+    executionMetadata: unknown
+    result: unknown
+    initiatorAgentId: string | null
+    triggerSource?: string | null
+  },
+  assumeFailureCode?: string,
+): ResumeDecision {
   const metadata = row.executionMetadata as
     | {
         liveChatId?: unknown
@@ -82,6 +149,7 @@ export function resumeChatIdFromRow(
         oauthResetSession?: unknown
         nativeChatResetSession?: unknown
         resumePending?: unknown
+        [EXECUTION_STARTED_KEY]?: unknown
       }
     | null
     | undefined
@@ -101,6 +169,12 @@ export function resumeChatIdFromRow(
     agentMissing: !row.initiatorAgentId,
     sessionResetRequested:
       metadata?.oauthResetSession === true || metadata?.nativeChatResetSession === true,
+    // Absent marker = the CLI never emitted a line, so the run cannot have
+    // committed side effects. Restricted to fire-and-forget triggers: an A2A or
+    // gateway caller is synchronously awaiting a verdict and must be told the
+    // truth rather than left polling a task the protocol calls terminal.
+    restartable:
+      metadata?.[EXECUTION_STARTED_KEY] !== true && isRestartableTrigger(row.triggerSource),
   })
 
   // A corrupt counter disables resume for this run permanently, which is the
@@ -111,7 +185,7 @@ export function resumeChatIdFromRow(
     }
   }
 
-  return decision.resume ? decision.chatId : null
+  return decision
 }
 
 /**

--- a/apps/api/src/lib/resume-decision.ts
+++ b/apps/api/src/lib/resume-decision.ts
@@ -33,6 +33,20 @@ const INTERRUPTION_CODES: ReadonlySet<string> = new Set<FailureReasonCode>([
 export interface ResumeCandidate {
   /** Session id recorded while the run was executing; null if it never announced one. */
   liveChatId: string | null
+  /**
+   * True when this run may be restarted from its original intent.
+   *
+   * Requires two things. Its CLI produced no output before the interruption —
+   * recorded by the shared stdout tap on the first line, so it covers every
+   * engine — which means it cannot have committed side effects. And its trigger
+   * is fire-and-forget, so nothing is synchronously awaiting a verdict: an A2A
+   * or gateway caller polling `tasks/get` must be told the truth rather than
+   * left waiting on a task the protocol already called terminal.
+   *
+   * Without this, such a run is simply failed and a human re-triggers it — the
+   * same replay, performed manually and later.
+   */
+  restartable?: boolean
   /** Resumes already spent on this run. */
   resumeAttempts: number
   /** Why the run was settled. */
@@ -44,7 +58,8 @@ export interface ResumeCandidate {
 }
 
 export type ResumeDecision =
-  | { resume: true; chatId: string; attempt: number }
+  /** `chatId: null` means "start over", reachable only for a restartable run. */
+  | { resume: true; chatId: string | null; attempt: number }
   | {
       resume: false
       reason:
@@ -77,7 +92,12 @@ export function decideResume(candidate: ResumeCandidate): ResumeDecision {
     return { resume: false, reason: 'not-interrupted' }
   }
 
-  if (!candidate.liveChatId) return { resume: false, reason: 'no-session' }
+  // Refusing without a session is right whenever the CLI actually ran: replaying
+  // the prompt would repeat side effects it already committed. A run interrupted
+  // before it emitted a single line has none of those.
+  if (!candidate.liveChatId && !candidate.restartable) {
+    return { resume: false, reason: 'no-session' }
+  }
 
   const spent = candidate.resumeAttempts
   // A corrupt counter must fail closed. Reading NaN as "still has budget" would


### PR DESCRIPTION
## Summary

A run killed before its CLI emitted a single line was settled as `failed` and left there. It has no session id, so `decideResume` refused it as `no-session` — the right answer for a run that got far enough to commit side effects, but wrong here: nothing had happened yet, so the only outcome was a human re-triggering it by hand. That is the same replay the refusal exists to avoid, performed manually and later.

This is routine, not exotic: a git clone or sync on a large repository runs for minutes before the CLI starts, and a deploy landing in that window loses the whole run. It is what produced the `Interrupted: the owning server instance stopped; safe to retry` card that a human then had to click Retry on.

Two conditions now let recovery requeue such a run.

**It produced no output.** The shared stdout tap records `executionStarted` on the CLI's first line, so it covers every engine and a newly added one cannot forget to opt in. Absence of that marker is the only reliable proof the run cannot have side effects — `liveChatId` is empty either way when a CLI dies before announcing its session, and `work_dir` says nothing, since only the per-agent worktree path records one. I tried `work_dir` first; the E2E recovery gate rejected it.

The marker is folded into `persistLiveSessionId`'s existing merge rather than written separately: a run that announced a session has self-evidently started, and two concurrent compare-and-set merges on one row buy nothing but contention.

**Nobody is awaiting a verdict.** Restart is limited to fire-and-forget triggers — `glab`, `gh`, `schedule`, and the chat channels. An `a2a`, `api`, `oauth`, `debug` or `chat_app` caller is holding a response or polling `tasks/get`, and the protocol has already called that task terminal; silently re-running it would leave the caller waiting on a verdict it was told would not change. E2E scenario 01 pins exactly this, and is what caught the first version of this change.

`canRequeueInterruptedRun` replaces `resolveResumeChatId(...) !== null` at both recovery call sites. The old predicate conflated "cannot resume" with "resume by starting over", and the second is precisely this case; both now read one shared decision so they cannot disagree.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore

## Testing checklist

- [x] `pnpm lint` passes — 0 errors, 751 warnings (unchanged from main)
- [x] `pnpm typecheck` passes — all four packages, test files included
- [x] `pnpm test` passes — 9,265 tests, 0 failures; the new branch is covered at both the decision level and against a real in-memory database
- [x] E2E run — `restart-recovery.sh` 4/4 scenarios, plus `test:scm-storage`
- [x] User-facing docs / i18n — not applicable (no new audit actions, routes, or copy)

**Verified against real traffic.** Built from this branch, deployed to a local PostgreSQL 16 instance running the MR-review Agent against live GitLab triggers, and restarted mid-workspace-setup to reproduce the original incident. Two runs carry `resumePending: INSTANCE_STOPPED_DURING_EXEC` — proving recovery judged them interrupted and requeued rather than failed — and both reached `completed` with no error code and no manual retry.

## Cross-cutting change matrix

- [x] Create / import / bootstrap paths checked
- [x] PATCH / enable-disable / cancellation paths checked
- [x] DELETE / cleanup / audit paths checked
- [x] Startup recovery and upgrade compatibility checked — pre-existing runs simply lack the marker, so they take the unchanged conservative path
- [x] Git and P4 behavior checked where applicable
- [x] SQLite and PostgreSQL behavior checked where applicable — the reaper is the only recovery that runs on PostgreSQL, which is where this gap was reachable
- [ ] Named volume, default bind, explicit bind, macOS bind — not applicable, no storage-path changes
- [x] Failure recovery and operator remediation are documented

## AI assistance disclosure

- [x] This change was substantially AI-generated. If checked, I confirm I understand the code and have tested it myself (see CONTRIBUTING.md).

## Additional notes

**Scope.** Only the never-started case changes. A run that emitted output still fails exactly as before, because replaying its prompt could repeat side effects the CLI already committed. The `MAX_RESUME_ATTEMPTS` ceiling still applies, so a restart that reproduces the interruption cannot loop.

**Separate pre-existing issue, not addressed here.** `liveChatId` stopped being recorded on this deployment on 2026-08-23: runs from 08-20/08-21 have it (84 of 260 overall), everything since has none. That predates this branch and the container was running an older image throughout, so it is not a regression from this change — but it does mean *started* runs currently cannot resume either, which is a second reason the original incident could not self-heal. Worth a look on its own; I did not want to bundle an unrelated investigation into this fix.
