### PR TITLE
test(api): stop the analyzer evasion suite timing out on CI

### DIFF
--- a/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
+++ b/apps/api/src/lib/__tests__/json-sql-call-sites.test.ts
@@ -719,8 +719,17 @@ describe('JSON helper call sites pass JSON-bearing columns', () => {
  *
  * These are type-checked as real program files, which is what lets the last
  * two — local shadowing and an undeclared helper — be caught at all.
+ *
+ * Each case builds its own `ts.Program`, which costs ~0.5-0.8s locally and
+ * several times that on a loaded CI runner — enough to cross vitest's 5s
+ * default and fail the nightly suite on timing alone (observed on run
+ * 32923301720, "flags: aliased import"). The timeout is raised per describe
+ * rather than globally so the rest of the suite keeps the strict default, and
+ * the programs are deliberately not shared: each fixture must be checked in
+ * isolation, or one fixture's declarations would be visible to the next and
+ * an evasion could pass by borrowing another's imports.
  */
-describe('the analyzer itself, against every known evasion shape', () => {
+describe('the analyzer itself, against every known evasion shape', { timeout: 30_000 }, () => {
   const analyzeFixture = (body: string) => {
     const fileName = resolve(SRC, 'routes/__fixture__.ts')
     const preamble = `import { runs, users, runSteps } from '../db/schema.js'\nvoid runs; void users; void runSteps;\n`


### PR DESCRIPTION
The nightly Post-Merge run has been failing on a single test, not a defect.

## What failed

[Run 32923301720](https://github.com/LilithGames/a2wave/actions/runs/32923301720) died on `json-sql-call-sites.test.ts:932 "flags: aliased import"` with `Test timed out in 5000ms`, taking the whole Full Suite (unit + E2E + recovery) red and skipping the restart-recovery scenarios behind it.

It is a timing flake, not an assertion failure. The same file passes 43/43 locally.

## Why it times out

Every evasion fixture in that describe builds its own `ts.Program` so it can be type-checked as a real program file — which is what makes the local-shadowing and undeclared-helper cases detectable at all. Measured per case locally:

```
flags: aliased import                     780ms
flags: quoted-specifier import alias      750ms
flags: namespace destructure              751ms
...                                       ~440-680ms each
```

~0.5-0.8s locally, several times that on a loaded CI runner — the file took 57s there vs ~32s locally. That is enough for the slowest case to cross vitest's 5s default. Nothing in `apps/api/vitest.config.ts` overrides it, and `fileParallelism: false` means the whole suite is already serial and contended.

## The change

Raise the timeout to 30s on that describe only, so the rest of the suite keeps the strict 5s default.

The programs are deliberately **not** shared across fixtures, which would also have fixed the runtime. Each fixture has to be checked in isolation — sharing one program would make one fixture's declarations visible to the next, and an evasion could then pass by borrowing another's imports. This suite exists to catch exactly that kind of smuggling, so the cost is the point.

No production code changes.

## Verification

- `describe(name, {timeout}, fn)` confirmed to actually apply in vitest 4.1.10 — a scratch 8s test (over the 5s default) passes under it and fails without. The option is in force, not silently ignored.
- `pnpm typecheck` fully green
- The file passes 43/43
- `biome check` on the file: 1 warning, pre-existing on `main` at line 114, unrelated to this edit — no new warnings added