### PR TITLE
fix(cli): offer device login first when SSO is unconfigured

### DIFF
--- a/apps/cli/src/commands/__tests__/oauth.test.ts
+++ b/apps/cli/src/commands/__tests__/oauth.test.ts
@@ -223,4 +223,30 @@ describe('resolveSsoEntryUrl', () => {
     await expect(resolveSsoEntryUrl()).rejects.toThrow(/--idaas-token/)
     expect(mockFetch).not.toHaveBeenCalled()
   })
+
+  // Device login needs nothing configured up front, so it is the one path that
+  // just works here. It must be offered first; before this it was missing from
+  // the list entirely and users were sent to set up an IdP entry instead.
+  it('offers --device first when $A2WAVE_SSO_URL is unset', async () => {
+    mockLoadConfig.mockReturnValue({ url: 'https://a2wave.test', token: '' })
+    const err = await resolveSsoEntryUrl().catch((e: Error) => e)
+    const message = (err as Error).message
+
+    expect(message).toContain('--device')
+    expect(message.indexOf('--device')).toBeLessThan(message.indexOf('--idaas-token'))
+    expect(message.indexOf('--device')).toBeLessThan(
+      message.indexOf('A2WAVE_SSO_URL=<IdP SSO URL>'),
+    )
+  })
+
+  // The old line read "use username/password: a2wave login", which is the exact
+  // command that just failed — it looped the user back into this same error.
+  it('names --password for the password path, not bare `a2wave login`', async () => {
+    mockLoadConfig.mockReturnValue({ url: 'https://a2wave.test', token: '' })
+    const err = await resolveSsoEntryUrl().catch((e: Error) => e)
+    const message = (err as Error).message
+
+    expect(message).toMatch(/a2wave login --password/)
+    expect(message).not.toMatch(/username\/password: a2wave login$/m)
+  })
 })

--- a/apps/cli/src/commands/oauth.ts
+++ b/apps/cli/src/commands/oauth.ts
@@ -38,9 +38,12 @@ const SSO_URL_ENV_VAR = 'A2WAVE_SSO_URL'
  *
  * This flow needs an IdP entry that redirects back to the CLI's loopback listener, which is not
  * the platform's own OIDC login (that one redirects to the server's callback and ends in a browser
- * session, not a token this process can read). So it is resolved purely from `A2WAVE_SSO_URL`;
- * without it, the supported headless path is `--idaas-token` with an IdP-issued id_token, which
- * the server verifies against the enterprise OIDC JWKS.
+ * session, not a token this process can read). So it is resolved purely from `A2WAVE_SSO_URL`.
+ *
+ * Without it, `--device` is the path to reach for first: the device grant needs nothing
+ * configured up front and works against any server new enough to expose
+ * `/api/auth/device/code`. `--idaas-token` stays listed below it because it is still the
+ * only option when the server predates device login (that endpoint 404s).
  */
 export async function resolveSsoEntryUrl(): Promise<string> {
   const fromEnv = process.env[SSO_URL_ENV_VAR]?.trim()
@@ -49,9 +52,10 @@ export async function resolveSsoEntryUrl(): Promise<string> {
   throw new CliError(
     [
       `No SSO login entry configured ($${SSO_URL_ENV_VAR} is not set).`,
-      `  1. Export ${SSO_URL_ENV_VAR}=<IdP SSO URL> (the IdP entry that redirects back to the CLI; may include query params)`,
-      '  2. Or pass an IdP-issued id_token directly: a2wave login --idaas-token <JWT>',
-      '  3. Or use username/password: a2wave login',
+      '  1. Approve a code from a browser on any machine (nothing to configure): a2wave login --device',
+      `  2. Or export ${SSO_URL_ENV_VAR}=<IdP SSO URL> (the IdP entry that redirects back to the CLI; may include query params)`,
+      '  3. Or pass an IdP-issued id_token directly: a2wave login --idaas-token <JWT>',
+      '  4. Or use username/password: a2wave login --password',
     ].join('\n'),
   )
 }


### PR DESCRIPTION
## Problem

Running `a2wave login` on a deployment without `$A2WAVE_SSO_URL` printed:

```
No SSO login entry configured ($A2WAVE_SSO_URL is not set).
  1. Export A2WAVE_SSO_URL=<IdP SSO URL> (the IdP entry that redirects back to the CLI; may include query params)
  2. Or pass an IdP-issued id_token directly: a2wave login --idaas-token <JWT>
  3. Or use username/password: a2wave login
```

Two problems with that:

1. **Device login is missing entirely**, even though it is the one path that needs nothing configured up front. Users were sent to go set up an IdP entry instead of just approving a code.
2. **Line 3 is wrong.** It names bare `a2wave login` — the exact command that had just failed — so it loops the user straight back into the same error. The password flow is `a2wave login --password`.

## Change

Device login is now offered first, and the password hint names the right flag:

```
No SSO login entry configured ($A2WAVE_SSO_URL is not set).
  1. Approve a code from a browser on any machine (nothing to configure): a2wave login --device
  2. Or export A2WAVE_SSO_URL=<IdP SSO URL> (the IdP entry that redirects back to the CLI; may include query params)
  3. Or pass an IdP-issued id_token directly: a2wave login --idaas-token <JWT>
  4. Or use username/password: a2wave login --password
```

`--idaas-token` is **demoted, not dropped**. It remains the only option when the server predates device login — `device-login.ts` explicitly recommends it when `/api/auth/device/code` returns 404 — so removing it would strand that case.

Every other `--password` reference in the repo was already correct; `oauth.ts` was the lone outlier.

## Tests

Two tests added, both written failing first:

- `offers --device first when $A2WAVE_SSO_URL is unset` — asserts `--device` appears, and ahead of both `--idaas-token` and the `A2WAVE_SSO_URL=` line.
- `names --password for the password path, not bare 'a2wave login'` — pins the loop-back regression.

## Gates

- `pnpm lint` — 0 errors; 751 warnings, unchanged from `main` (adds none)
- `pnpm typecheck` — green
- `pnpm test` — 9311 passed (`apps/cli` 1131 → 1133, exactly the two new tests)

## Note for reviewers

`apps/cli/dist/` is **not** rebuilt in this PR, so it still carries the old string. Installed CLIs keep the old message until the next build/release.