### PR TITLE
fix(api): drop revoked CLI tokens from the token list

### DIFF
--- a/apps/api/src/routes/__tests__/cli-tokens.test.ts
+++ b/apps/api/src/routes/__tests__/cli-tokens.test.ts
@@ -191,6 +191,13 @@ describe('GET /cli-tokens', () => {
     expect(body).toContain('CI runner')
     expect(body).not.toContain('tokenHash')
   })
+
+  it('leaves revoked tokens out entirely, so a deleted one disappears', async () => {
+    await makeApp().request('/api/cli-tokens')
+    // The filter is part of the WHERE clause, not a post-filter: a revoked row must
+    // never reach the client, where it would render as a row with a dead delete button.
+    expect(JSON.stringify(callArg(dbSelect, 'where'))).toContain('cli_tokens.revoked_at')
+  })
 })
 
 describe('DELETE /cli-tokens/:id', () => {

--- a/apps/api/src/routes/cli-tokens.ts
+++ b/apps/api/src/routes/cli-tokens.ts
@@ -36,7 +36,13 @@ const createSchema = z.object({
   expiresInDays: z.number().int().min(1).max(MAX_EXPIRES_IN_DAYS).optional(),
 })
 
-/** GET /cli-tokens — the caller's own tokens, newest first. Never returns a credential. */
+/**
+ * GET /cli-tokens — the caller's own live tokens, newest first. Never returns a credential.
+ *
+ * Revoked rows are filtered out rather than shown greyed: deletion is the last thing
+ * anyone does to a token, so a lingering row offers only a delete button that 404s.
+ * The row survives in the database, and the revocation is in the audit log.
+ */
 app.get('/', async (c) => {
   const userId = c.get('userId' as never) as string
   const rows = await db
@@ -46,11 +52,10 @@ app.get('/', async (c) => {
       tokenPrefix: cliTokens.tokenPrefix,
       expiresAt: cliTokens.expiresAt,
       lastUsedAt: cliTokens.lastUsedAt,
-      revokedAt: cliTokens.revokedAt,
       createdAt: cliTokens.createdAt,
     })
     .from(cliTokens)
-    .where(eq(cliTokens.userId, userId))
+    .where(and(eq(cliTokens.userId, userId), isNull(cliTokens.revokedAt)))
     .orderBy(desc(cliTokens.createdAt))
 
   return c.json({ data: rows })

--- a/apps/web/src/components/__tests__/cli-tokens-card.test.tsx
+++ b/apps/web/src/components/__tests__/cli-tokens-card.test.tsx
@@ -150,16 +150,29 @@ describe('CliTokensCard', () => {
     expect(screen.getByText(/AUTH_SESSION_TTL_DAYS/)).toBeInTheDocument()
   })
 
-  it('distinguishes deleted and expired tokens from live ones', async () => {
+  it('distinguishes expired tokens from live ones', async () => {
     mockList([
-      token({ id: 'a', name: 'gone', revokedAt: new Date().toISOString() }),
       token({ id: 'b', name: 'stale', expiresAt: new Date(Date.now() - 1000).toISOString() }),
       token({ id: 'c', name: 'live' }),
     ])
     renderWithProviders(<CliTokensCard />)
-    expect(await screen.findByText('已删除')).toBeInTheDocument()
-    expect(screen.getByText('已过期')).toBeInTheDocument()
+    expect(await screen.findByText('已过期')).toBeInTheDocument()
     expect(screen.getByText('生效中')).toBeInTheDocument()
+  })
+
+  it('drops a deleted token from the list instead of leaving a dead row behind', async () => {
+    // The API omits revoked tokens from the list, so the refetch that follows a
+    // delete must take the row away — not leave one whose only action would 404.
+    let rows: unknown[] = [token()]
+    mockList(rows)
+    apiDeleteMock.mockImplementation(() => {
+      rows = []
+      mockList(rows)
+      return Promise.resolve({ data: {} })
+    })
+    renderWithProviders(<CliTokensCard />)
+    await userEvent.click(await screen.findByRole('button', { name: /删除/ }))
+    await waitFor(() => expect(screen.queryByText('CI runner')).not.toBeInTheDocument())
   })
 
   it('says a token was never used, since that is what makes it safe to delete', async () => {

--- a/apps/web/src/components/cli-tokens-card.tsx
+++ b/apps/web/src/components/cli-tokens-card.tsx
@@ -27,7 +27,6 @@ interface CliToken {
   tokenPrefix: string
   expiresAt: string | null
   lastUsedAt: string | null
-  revokedAt: string | null
   createdAt: string
 }
 
@@ -38,17 +37,15 @@ interface SessionPolicy {
 
 const EXPIRY_CHOICES = [30, 90, 365, 0] as const
 
-type TokenStatus = 'active' | 'revoked' | 'expired'
+type TokenStatus = 'active' | 'expired'
 
 function statusOf(token: CliToken): TokenStatus {
-  if (token.revokedAt) return 'revoked'
   if (token.expiresAt && dayjs(token.expiresAt).isBefore(dayjs())) return 'expired'
   return 'active'
 }
 
 const STATUS_COLOR: Record<TokenStatus, string> = {
   active: 'green',
-  revoked: 'default',
   expired: 'orange',
 }
 
@@ -57,7 +54,8 @@ const STATUS_COLOR: Record<TokenStatus, string> = {
  *
  * The list is the page; creation lives behind a button, because minting a token is
  * occasional and the form would otherwise dominate a surface people mostly visit to
- * audit what already exists.
+ * audit what already exists. Deleting a token removes its row — the API omits revoked
+ * tokens, so there is no such thing here as a row whose only action would 404.
  */
 export function CliTokensCard() {
   const { t } = useTranslation()

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2710,7 +2710,6 @@
     "deleteContent": "\"{{name}}\" will stop working immediately, and anything using it will lose access.",
     "status": {
       "active": "Active",
-      "revoked": "Deleted",
       "expired": "Expired"
     },
     "pageDesc": "Tokens for the a2wave CLI, CI jobs, and scripts. Each one is yours alone and can be deleted on its own.",

--- a/apps/web/src/locales/zh.json
+++ b/apps/web/src/locales/zh.json
@@ -2710,7 +2710,6 @@
     "deleteContent": "「{{name}}」会立即失效，正在使用它的地方将无法访问。",
     "status": {
       "active": "生效中",
-      "revoked": "已删除",
       "expired": "已过期"
     },
     "pageDesc": "供 a2wave CLI、CI 任务和脚本使用的令牌。每个都只属于你，可以单独删除。",

--- a/docs/agent/cli-tokens.md
+++ b/docs/agent/cli-tokens.md
@@ -68,7 +68,7 @@ their own tokens here.
 
 | Endpoint | Purpose |
 |---|---|
-| `GET /api/cli-tokens` | List the caller's tokens. Never returns a credential |
+| `GET /api/cli-tokens` | List the caller's **live** tokens — revoked ones are filtered out. Never returns a credential |
 | `POST /api/cli-tokens` | Mint one. The **only** time the plaintext is returned. Requires a real session — a CLI token gets `403 SESSION_REQUIRED` |
 | `DELETE /api/cli-tokens/:id` | Revoke. Takes effect on the next request |
 | `GET /api/cli-tokens/session-policy` | Read-only session lifetime, for display |
@@ -84,7 +84,10 @@ their own tokens here.
 - **A short display prefix** is kept so the list can distinguish two tokens without
   showing enough to reconstruct either.
 - **Revocation is scoped by `userId` and guarded on "not already revoked"**, so one
-  user cannot revoke another's token and a repeat call cannot re-audit.
+  user cannot revoke another's token and a repeat call cannot re-audit. The row is
+  kept (soft delete) but **excluded from `GET /api/cli-tokens`**: deletion is the last
+  thing anyone does to a token, so a lingering row would offer only a delete button
+  that answers `404`. The revocation itself lives in the audit log.
 - **Disabling an account cuts off its tokens too** — `isActive` is checked on every
   request, not just at creation.
 - **`tokenVersion` deliberately does not apply.** That is what makes a password


### PR DESCRIPTION
## Problem

Deleting a CLI token soft-deletes it (`revokedAt`), but `GET /api/cli-tokens` returned every row — revoked ones included. The UI rendered those as a greyed 「已删除」 row that still carried a live delete button, and clicking it fails: `DELETE /api/cli-tokens/:id` is guarded on `isNull(revokedAt)`, so a second delete answers `404`. The only action left on that row was one that could not succeed.

## Fix

- `GET /api/cli-tokens` filters on `isNull(cliTokens.revokedAt)`, so a deleted token leaves the list. The row still exists in the database and the revocation stays in the audit log, which is where that history belongs. `revokedAt` also drops out of the select — every returned row now has it `null`.
- The web card's `revoked` status branch and its zh/en copy are unreachable once the API omits those rows, so they go with it (`TokenStatus` is now `active | expired`). Expired-but-not-revoked tokens are unaffected: they still list, and deleting one still works.
- `docs/agent/cli-tokens.md`: endpoint table + the revocation bullet under security properties.

## Tests

Written first, red before green:
- API: the list's WHERE clause carries the `revoked_at` filter — a post-filter would still let a revoked row reach the client.
- Web: the row disappears after a confirmed delete.

## Gates

`pnpm lint` 0 errors (no new warnings) · `pnpm typecheck` green · `pnpm test` 258/258.

Also verified by hand against a locally built image on the PostgreSQL stack.