### PR TITLE
fix(web): localize run timestamps

### DIFF
--- a/apps/web/src/components/__tests__/stream-log-item.test.tsx
+++ b/apps/web/src/components/__tests__/stream-log-item.test.tsx
@@ -1,12 +1,27 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { StreamLogEntry } from '@/hooks/use-agents'
 import i18n from '@/i18n'
 import { renderWithProviders, screen } from '@/test/render'
-import { StreamLogsTimeline } from '../stream-log-item'
+import { StreamLogItem, StreamLogsTimeline } from '../stream-log-item'
 
 describe('StreamLogsTimeline', () => {
   beforeEach(async () => {
     await i18n.changeLanguage('en')
+  })
+
+  it('formats absolute timestamps using the active UI language', () => {
+    const format = vi.spyOn(Date.prototype, 'toLocaleTimeString').mockReturnValue('localized time')
+    const entry = {
+      type: 'system',
+      subtype: 'init',
+      ts: Date.parse('2026-09-01T13:05:00Z'),
+    } as StreamLogEntry
+
+    renderWithProviders(<StreamLogItem entry={entry} />)
+
+    expect(screen.getByText('localized time')).toBeInTheDocument()
+    expect(format).toHaveBeenCalledWith('en-US')
+    format.mockRestore()
   })
 
   it('shows A2A Task lifecycle metadata in the ordinary Run timeline', () => {

--- a/apps/web/src/components/run-detail-drawer.tsx
+++ b/apps/web/src/components/run-detail-drawer.tsx
@@ -21,6 +21,7 @@ import { Button } from '@/components/ui/button'
 import type { ChatMessageWithAttachments } from '@/hooks/use-chat-history'
 import { useCancelRun, useRerunRun, useRun } from '@/hooks/use-runs'
 import { historyRefToSentAttachment } from '@/lib/attachments'
+import { formatLocaleTime } from '@/lib/date-time'
 import { formatTokens } from '@/lib/format-tokens'
 import { cn } from '@/lib/utils'
 
@@ -51,7 +52,7 @@ export function RunDetailDrawer({
   open: boolean
   onClose: () => void
 }) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [showLogs, setShowLogs] = useState(false)
   const { data: run, isLoading } = useRun(runId ?? '')
   const cancelRun = useCancelRun()
@@ -216,7 +217,7 @@ export function RunDetailDrawer({
                 {t('runDetail.selectRun')}
               </div>
             ) : (
-              <ChatContent run={run} isLoading={isLoading} t={t} />
+              <ChatContent run={run} isLoading={isLoading} t={t} language={i18n.language} />
             )}
           </div>
         </div>
@@ -230,10 +231,12 @@ function ChatContent({
   run,
   isLoading,
   t,
+  language,
 }: {
   run: ReturnType<typeof useRun>['data']
   isLoading: boolean
   t: (key: string) => string
+  language: string
 }) {
   if (isLoading) {
     return (
@@ -328,7 +331,7 @@ function ChatContent({
             <span
               className={`text-2xs text-muted-foreground/50 mt-0.5 ${message.role === 'user' ? 'mr-8' : 'ml-8'}`}
             >
-              {new Date(message.createdAt).toLocaleTimeString('zh-CN')}
+              {formatLocaleTime(message.createdAt, language)}
             </span>
           </div>
         )

--- a/apps/web/src/components/stream-log-item.tsx
+++ b/apps/web/src/components/stream-log-item.tsx
@@ -12,11 +12,12 @@ import {
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { StreamLogEntry } from '@/hooks/use-agents'
+import { formatLocaleTime } from '@/lib/date-time'
 import { formatTokens } from '@/lib/format-tokens'
 
 /** Format a timestamp relative to a base time */
-export function formatRelativeTs(ts: number, baseTs?: number): string {
-  if (!baseTs) return new Date(ts).toLocaleTimeString('zh-CN')
+export function formatRelativeTs(ts: number, baseTs: number | undefined, language: string): string {
+  if (!baseTs) return formatLocaleTime(ts, language)
   const diff = Math.round((ts - baseTs) / 1000)
   if (diff < 0) return '0s'
   const min = Math.floor(diff / 60)
@@ -132,8 +133,8 @@ function ToolCallEntry({
 
 /** Render a single stream log entry */
 export function StreamLogItem({ entry, baseTs }: { entry: StreamLogEntry; baseTs?: number }) {
-  const { t } = useTranslation()
-  const timeLabel = formatRelativeTs(entry.ts, baseTs)
+  const { t, i18n } = useTranslation()
+  const timeLabel = formatRelativeTs(entry.ts, baseTs, i18n.language)
 
   switch (entry.type) {
     case 'system': {

--- a/apps/web/src/components/streaming-status.tsx
+++ b/apps/web/src/components/streaming-status.tsx
@@ -1,8 +1,8 @@
-import { StreamLogItem, formatRelativeTs } from '@/components/stream-log-item'
-import type { StreamLogEntry } from '@/hooks/use-agents'
 import { ChevronDown, ChevronRight, Loader2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { formatRelativeTs, StreamLogItem } from '@/components/stream-log-item'
+import type { StreamLogEntry } from '@/hooks/use-agents'
 
 interface StreamingStatusProps {
   logs: StreamLogEntry[]
@@ -44,7 +44,7 @@ function getLatestActivity(
 }
 
 export function StreamingStatus({ logs, isStreaming }: StreamingStatusProps) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [expanded, setExpanded] = useState(true)
   const logsEndRef = useRef<HTMLDivElement>(null)
   const prevStreamingRef = useRef(isStreaming)
@@ -79,7 +79,8 @@ export function StreamingStatus({ logs, isStreaming }: StreamingStatusProps) {
   const baseTs = logs[0]?.ts
   const stepCount = countSteps(logs)
   const latestActivity = getLatestActivity(logs, t)
-  const elapsed = logs.length > 0 ? formatRelativeTs(logs[logs.length - 1].ts, baseTs) : ''
+  const elapsed =
+    logs.length > 0 ? formatRelativeTs(logs[logs.length - 1].ts, baseTs, i18n.language) : ''
 
   return (
     <div className="space-y-1.5">

--- a/apps/web/src/lib/__tests__/date-time.test.ts
+++ b/apps/web/src/lib/__tests__/date-time.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { formatLocaleTime, localeForLanguage } from '../date-time'
+
+describe('localeForLanguage', () => {
+  it.each([
+    ['zh', 'zh-CN'],
+    ['zh-CN', 'zh-CN'],
+    ['en', 'en-US'],
+    ['en-US', 'en-US'],
+  ])('maps %s to %s', (language, locale) => {
+    expect(localeForLanguage(language)).toBe(locale)
+  })
+})
+
+describe('formatLocaleTime', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('formats timestamps with the locale selected by the UI language', () => {
+    const format = vi.spyOn(Date.prototype, 'toLocaleTimeString').mockReturnValue('localized time')
+
+    expect(formatLocaleTime('2026-09-01T13:05:00Z', 'en')).toBe('localized time')
+    expect(format).toHaveBeenCalledWith('en-US')
+  })
+})

--- a/apps/web/src/lib/date-time.ts
+++ b/apps/web/src/lib/date-time.ts
@@ -1,0 +1,7 @@
+export function localeForLanguage(language: string): 'zh-CN' | 'en-US' {
+  return language.toLowerCase().startsWith('zh') ? 'zh-CN' : 'en-US'
+}
+
+export function formatLocaleTime(value: string | number | Date, language: string): string {
+  return new Date(value).toLocaleTimeString(localeForLanguage(language))
+}


### PR DESCRIPTION
## Summary

- format Run chat timestamps and absolute stream-log timestamps with the active UI language
- share the `zh-CN` / `en-US` locale mapping so both views stay consistent
- preserve the existing locale-independent relative elapsed-time labels
- add regression tests for locale mapping and the English stream-log rendering path

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore

## Testing checklist

- [x] `pnpm lint` passes (0 errors; existing warnings unchanged)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes; new/changed code is covered by tests
- [x] E2E not applicable: no critical path, route, navigation, or translation-copy changes
- [x] User-facing docs and locale resources not applicable: no copy or behavior requiring documentation changed

## AI assistance disclosure

- [x] This change was substantially AI-generated. If checked, I confirm I understand the code and have tested it myself (see CONTRIBUTING.md).

## Additional notes

No API, persistence, or translation-key changes.
